### PR TITLE
feat: case insensitive search of a sensor / device by vendorId #5

### DIFF
--- a/entity-service/src/main/kotlin/com/egm/stellio/entity/repository/Neo4jRepository.kt
+++ b/entity-service/src/main/kotlin/com/egm/stellio/entity/repository/Neo4jRepository.kt
@@ -245,13 +245,13 @@ class Neo4jRepository(
             MATCH (m:Property)-[:HAS_OBJECT]-()-[:OBSERVED_BY]->(e:Entity)-[:HAS_VALUE]->(p:Property) 
             WHERE m.name ENDS WITH '$measureName' 
             AND p.name = '$propertyName' 
-            AND p.value = '$observerId' 
+            AND toLower(p.value) = toLower('$observerId') 
             RETURN e
             UNION
             MATCH (m:Property)-[:HAS_OBJECT]-()-[:OBSERVED_BY]->(e:Entity)-[:HAS_OBJECT]-()-[:IS_CONTAINED_IN]->(device:Entity)-[:HAS_VALUE]->(deviceProp:Property)
             WHERE m.name ENDS WITH '$measureName' 
             AND deviceProp.name = '$propertyName' 
-            AND deviceProp.value = '$observerId' 
+            AND toLower(deviceProp.value) = toLower('$observerId') 
             RETURN e
         """.trimIndent()
 

--- a/entity-service/src/test/kotlin/com/egm/stellio/entity/repository/Neo4jRepositoryTests.kt
+++ b/entity-service/src/test/kotlin/com/egm/stellio/entity/repository/Neo4jRepositoryTests.kt
@@ -205,6 +205,19 @@ class Neo4jRepositoryTests {
     }
 
     @Test
+    fun `it should find a sensor by vendor id with case not matching and measured property`() {
+        val vendorId = "urn:something:9876"
+        val entity = createEntity("urn:ngsi-ld:Sensor:1233", listOf("Sensor"), mutableListOf(Property(name = EGM_VENDOR_ID, value = vendorId)))
+        val property = createProperty("https://ontology.eglobalmark.com/apic#outgoing")
+        val relationship = createRelationship(property, EGM_OBSERVED_BY, entity.id)
+        val persistedEntity = neo4jRepository.getObservingSensorEntity(vendorId.toUpperCase(), EGM_VENDOR_ID, "outgoing")
+        assertNotNull(persistedEntity)
+        propertyRepository.delete(property)
+        relationshipRepository.delete(relationship)
+        neo4jRepository.deleteEntity(entity.id)
+    }
+
+    @Test
     fun `it should find a sensor by vendor id of a device and measured property`() {
         val vendorId = "urn:something:9876"
         val sensor = createEntity("urn:ngsi-ld:Sensor:1233", listOf("Sensor"), mutableListOf())


### PR DESCRIPTION
- this allows for more flexibility in how vendorId is filled and transformed all along the transmission chain