### PR TITLE
feat: set default conf for actuator endpoints

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,6 +65,7 @@ subprojects {
         annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 
         runtimeOnly("de.siegmar:logback-gelf:3.0.0")
+        runtimeOnly("io.micrometer:micrometer-registry-prometheus")
 
         testImplementation("org.springframework.boot:spring-boot-starter-test") {
             exclude(group = "org.junit.vintage", module = "junit-vintage-engine")

--- a/entity-service/src/main/kotlin/com/egm/stellio/entity/config/WebSecurityConfig.kt
+++ b/entity-service/src/main/kotlin/com/egm/stellio/entity/config/WebSecurityConfig.kt
@@ -15,8 +15,9 @@ class WebSecurityConfig {
         http
             // disable CSRF as it does not fit with an HTTP REST API
             .csrf().disable()
-            // tweak Actuator health endpoint security rules to grant access to anonymous users
-            .authorizeExchange().pathMatchers("/actuator/health").permitAll().and()
+            // WARNING: this will allow access to everyone to enabled actuator endpoints
+            // by default, only health endpoint is activated, be careful when activating other ones
+            .authorizeExchange().pathMatchers("/actuator/**").permitAll().and()
             .authorizeExchange().pathMatchers("/**").authenticated().and()
             .oauth2ResourceServer().jwt()
 

--- a/entity-service/src/main/resources/application.properties
+++ b/entity-service/src/main/resources/application.properties
@@ -11,8 +11,8 @@ spring.security.oauth2.resourceserver.jwt.jwk-set-uri = https://data-hub.eglobal
 
 server.port = 8082
 
-management.endpoints.web.exposure.include = health,info,metrics,bindings
-management.health.db.enabled = false
+management.endpoints.enabled-by-default = false
+management.endpoint.health.enabled = true
 
 application.authentication.enabled = false
 

--- a/search-service/src/main/kotlin/com/egm/stellio/search/config/WebSecurityConfig.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/config/WebSecurityConfig.kt
@@ -15,8 +15,9 @@ class WebSecurityConfig {
         http
             // disable CSRF as it does not fit with an HTTP REST API
             .csrf().disable()
-            // tweak Actuator health endpoint security rules to grant access to anonymous users
-            .authorizeExchange().pathMatchers("/actuator/health").permitAll().and()
+            // WARNING: this will allow access to everyone to enabled actuator endpoints
+            // by default, only health endpoint is activated, be careful when activating other ones
+            .authorizeExchange().pathMatchers("/actuator/**").permitAll().and()
             .authorizeExchange().pathMatchers("/**").authenticated().and()
             .oauth2ResourceServer().jwt()
 

--- a/search-service/src/main/resources/application.properties
+++ b/search-service/src/main/resources/application.properties
@@ -22,7 +22,8 @@ spring.kafka.bootstrap-servers = localhost:29092
 
 server.port = 8083
 
-management.endpoints.web.exposure.include = health,info,metrics,bindings
+management.endpoints.enabled-by-default = false
+management.endpoint.health.enabled = true
 
 spring.http.log-request-details = true
 

--- a/subscription-service/src/main/kotlin/com/egm/stellio/subscription/config/WebSecurityConfig.kt
+++ b/subscription-service/src/main/kotlin/com/egm/stellio/subscription/config/WebSecurityConfig.kt
@@ -15,8 +15,9 @@ class WebSecurityConfig {
         http
             // disable CSRF as it does not fit with an HTTP REST API
             .csrf().disable()
-            // tweak Actuator health endpoint security rules to grant access to anonymous users
-            .authorizeExchange().pathMatchers("/actuator/health").permitAll().and()
+            // WARNING: this will allow access to everyone to enabled actuator endpoints
+            // by default, only health endpoint is activated, be careful when activating other ones
+            .authorizeExchange().pathMatchers("/actuator/**").permitAll().and()
             .authorizeExchange().pathMatchers("/**").authenticated().and()
             .oauth2ResourceServer().jwt()
 

--- a/subscription-service/src/main/resources/application.properties
+++ b/subscription-service/src/main/resources/application.properties
@@ -19,7 +19,8 @@ spring.security.oauth2.resourceserver.jwt.jwk-set-uri = https://data-hub.eglobal
 
 server.port = 8084
 
-management.endpoints.web.exposure.include = health,info,metrics,bindings
+management.endpoints.enabled-by-default = false
+management.endpoint.health.enabled = true
 
 application.authentication.enabled = false
 


### PR DESCRIPTION
- only activate health endpoint by default
- allow unauthenticated access to enabled endpoints (in production, use a security layer above)
- add exporter for Prometheus metrics