### PR TITLE
feat(entity): improve queries in entity creation process #70

### DIFF
--- a/entity-service/src/main/kotlin/com/egm/stellio/entity/model/Attribute.kt
+++ b/entity-service/src/main/kotlin/com/egm/stellio/entity/model/Attribute.kt
@@ -62,4 +62,24 @@ open class Attribute(
 
         return resultEntity
     }
+
+    /**
+     * Return a map of the properties to store with the Property node in neo4j
+     */
+    open fun nodeProperties(): MutableMap<String, Any> {
+        val nodeProperties = mutableMapOf<String, Any>(
+            "id" to id,
+            "createdAt" to createdAt
+        )
+
+        modifiedAt?.run {
+            nodeProperties["modifiedAt"] = this
+        }
+
+        observedAt?.run {
+            nodeProperties["observedAt"] = this
+        }
+
+        return nodeProperties
+    }
 }

--- a/entity-service/src/main/kotlin/com/egm/stellio/entity/model/Property.kt
+++ b/entity-service/src/main/kotlin/com/egm/stellio/entity/model/Property.kt
@@ -9,6 +9,7 @@ import com.egm.stellio.shared.util.NgsiLdParsingUtils.NGSILD_PROPERTY_VALUE
 import com.egm.stellio.shared.util.NgsiLdParsingUtils.NGSILD_TIME_TYPE
 import com.egm.stellio.shared.util.NgsiLdParsingUtils.NGSILD_UNIT_CODE_PROPERTY
 import com.fasterxml.jackson.annotation.JsonRawValue
+import org.neo4j.ogm.annotation.Index
 import org.neo4j.ogm.annotation.NodeEntity
 import java.time.LocalDate
 import java.time.LocalTime
@@ -16,6 +17,7 @@ import java.time.ZonedDateTime
 
 @NodeEntity
 class Property(
+    @Index
     val name: String,
     var unitCode: String? = null,
 
@@ -39,6 +41,18 @@ class Property(
         }
 
         return resultEntity
+    }
+
+    override fun nodeProperties(): MutableMap<String, Any> {
+        val propsMap = super.nodeProperties()
+        propsMap["name"] = name
+        propsMap["value"] = value
+
+        unitCode?.run {
+            propsMap["unitCode"] = this
+        }
+
+        return propsMap
     }
 
     fun updateValues(unitCode: String?, value: Any?, observedAt: ZonedDateTime?) {

--- a/entity-service/src/main/kotlin/com/egm/stellio/entity/repository/AttributeRepository.kt
+++ b/entity-service/src/main/kotlin/com/egm/stellio/entity/repository/AttributeRepository.kt
@@ -1,8 +1,0 @@
-package com.egm.stellio.entity.repository
-
-import com.egm.stellio.entity.model.Attribute
-import org.springframework.data.neo4j.repository.Neo4jRepository
-import org.springframework.stereotype.Repository
-
-@Repository
-interface AttributeRepository : Neo4jRepository<Attribute, String>

--- a/entity-service/src/main/kotlin/com/egm/stellio/entity/repository/EntityRepository.kt
+++ b/entity-service/src/main/kotlin/com/egm/stellio/entity/repository/EntityRepository.kt
@@ -8,10 +8,11 @@ import org.springframework.stereotype.Repository
 @Repository
 interface EntityRepository : Neo4jRepository<Entity, String> {
 
-    @Query("MATCH (entity:Entity { id: \$id })" +
-            "RETURN entity"
+    @Query("MATCH (entity:Entity { id: \$id }) " +
+            "RETURN entity " +
+            "LIMIT 1"
     )
-    fun getEntityCoreById(id: String): List<Map<String, Any>>
+    fun getEntityCoreById(id: String): Entity
 
     @Query("MATCH (entity:Entity { id: \$id })-[:HAS_VALUE]->(property:Property)" +
             "OPTIONAL MATCH (property)-[:HAS_VALUE]->(propValue:Property)" +
@@ -36,4 +37,7 @@ interface EntityRepository : Neo4jRepository<Entity, String> {
             "RETURN rel, type(r) as relType, relObject, relOfRel, type(or) as relOfRelType, relOfRelObject"
     )
     fun getEntityRelationships(id: String): List<Map<String, Any>>
+
+    @Query("MATCH (e:Entity { id: \$id }) RETURN exists(e.id)")
+    fun exists(id: String): Boolean?
 }

--- a/entity-service/src/main/kotlin/com/egm/stellio/entity/service/EntityService.kt
+++ b/entity-service/src/main/kotlin/com/egm/stellio/entity/service/EntityService.kt
@@ -6,7 +6,6 @@ import com.egm.stellio.entity.model.NotUpdatedDetails
 import com.egm.stellio.entity.model.Property
 import com.egm.stellio.entity.model.Relationship
 import com.egm.stellio.entity.model.UpdateResult
-import com.egm.stellio.entity.repository.AttributeRepository
 import com.egm.stellio.entity.repository.EntityRepository
 import com.egm.stellio.entity.repository.Neo4jRepository
 import com.egm.stellio.entity.repository.PropertyRepository
@@ -54,8 +53,6 @@ import com.egm.stellio.shared.util.toNgsiLdRelationshipKey
 import com.egm.stellio.shared.util.toRelationshipTypeName
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.github.jsonldjava.core.JsonLdOptions
-import com.github.jsonldjava.core.JsonLdProcessor
 import org.neo4j.ogm.types.spatial.GeographicPoint2d
 import org.slf4j.LoggerFactory
 import org.springframework.context.ApplicationEventPublisher
@@ -68,7 +65,6 @@ class EntityService(
     private val entityRepository: EntityRepository,
     private val propertyRepository: PropertyRepository,
     private val relationshipRepository: RelationshipRepository,
-    private val attributeRepository: AttributeRepository,
     private val applicationEventPublisher: ApplicationEventPublisher
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
@@ -79,33 +75,21 @@ class EntityService(
             Entity(id = expandedEntity.id, type = listOf(expandedEntity.type), contexts = expandedEntity.contexts)
         val entity = entityRepository.save(rawEntity)
 
-        // filter the unwanted entries and expand all attributes for easier later processing
-        val propertiesAndRelationshipsMap = expandedEntity.attributes.mapValues {
-            expandValueAsMap(it.value)
-        }
-
-        propertiesAndRelationshipsMap.filter { entry ->
-            isAttributeOfType(entry.value, NGSILD_RELATIONSHIP_TYPE)
-        }.forEach { entry ->
+        expandedEntity.relationships.forEach { entry ->
             val relationshipType = entry.key
             val objectId = getRelationshipObjectId(entry.value)
-            val objectEntity = entityRepository.findById(objectId)
 
-            if (!objectEntity.isPresent) {
+            if (!exists(objectId))
                 throw BadRequestDataException("Target entity $objectId in relationship $relationshipType does not exist, create it first")
-            } else
-                createEntityRelationship(entity, relationshipType, entry.value, objectEntity.get().id)
+            else
+                createEntityRelationship(entity, relationshipType, entry.value, objectId)
         }
 
-        propertiesAndRelationshipsMap.filter { entry ->
-            isAttributeOfType(entry.value, NGSILD_PROPERTY_TYPE)
-        }.forEach { entry ->
+        expandedEntity.properties.forEach { entry ->
             createEntityProperty(entity, entry.key, entry.value)
         }
 
-        propertiesAndRelationshipsMap.filter { entry ->
-            isAttributeOfType(entry.value, NGSILD_GEOPROPERTY_TYPE)
-        }.forEach { entry ->
+        expandedEntity.geoProperties.forEach { entry ->
             createLocationProperty(entity, entry.key, entry.value)
         }
 
@@ -126,11 +110,14 @@ class EntityService(
         applicationEventPublisher.publishEvent(entityEvent)
     }
 
+    /**
+     * @return the id of the created property
+     */
     internal fun createEntityProperty(
         entity: Entity,
         propertyKey: String,
         propertyValues: Map<String, List<Any>>
-    ): Property {
+    ): String {
         val propertyValue = getPropertyValueFromMap(propertyValues, NGSILD_PROPERTY_VALUE)
             ?: throw BadRequestDataException("Key $NGSILD_PROPERTY_VALUE not found in $propertyValues")
 
@@ -142,52 +129,45 @@ class EntityService(
             observedAt = getPropertyValueFromMapAsDateTime(propertyValues, NGSILD_OBSERVED_AT_PROPERTY)
         )
 
-        val property = propertyRepository.save(rawProperty)
+        neo4jRepository.createPropertyOfSubject(
+            subjectId = entity.id,
+            property = rawProperty
+        )
 
-        entity.properties.add(property)
-        entityRepository.save(entity)
+        createAttributeProperties(rawProperty.id, propertyValues)
+        createAttributeRelationships(rawProperty.id, propertyValues)
 
-        createAttributeProperties(property, propertyValues)
-        createAttributeRelationships(property, propertyValues)
-
-        return property
+        return rawProperty.id
     }
 
     /**
      * Create the relationship between two entities, as two relationships : a generic one from source entity to a relationship node,
      * and a typed one (with the relationship type) from the relationship node to the target entity.
      *
-     * @return the created Relationship object
+     * @return the id of the created relationship
      */
     private fun createEntityRelationship(
         entity: Entity,
         relationshipType: String,
         relationshipValues: Map<String, List<Any>>,
         targetEntityId: String
-    ): Relationship {
+    ): String {
 
         // TODO : finish integration with relationship properties (https://redmine.eglobalmark.com/issues/847)
         val rawRelationship = Relationship(
             type = listOf(relationshipType),
             observedAt = getPropertyValueFromMapAsDateTime(relationshipValues, NGSILD_OBSERVED_AT_PROPERTY)
         )
-        val relationship = relationshipRepository.save(rawRelationship)
-        entity.relationships.add(relationship)
-        entityRepository.save(entity)
 
-        neo4jRepository.createRelationshipToEntity(
-            relationship.id,
-            relationshipType.toRelationshipTypeName(),
-            targetEntityId
-        )
+        neo4jRepository.createRelationshipOfSubject(entity.id, rawRelationship, targetEntityId)
 
-        createAttributeProperties(relationship, relationshipValues)
-        createAttributeRelationships(relationship, relationshipValues)
+        createAttributeProperties(rawRelationship.id, relationshipValues)
+        createAttributeRelationships(rawRelationship.id, relationshipValues)
 
-        return relationship
+        return rawRelationship.id
     }
 
-    private fun createAttributeProperties(subject: Attribute, values: Map<String, List<Any>>) {
+    private fun createAttributeProperties(subjectId: String, values: Map<String, List<Any>>) {
         values.filterValues {
             it[0] is Map<*, *>
         }.mapValues {
@@ -208,13 +188,14 @@ class EntityService(
                 observedAt = getPropertyValueFromMapAsDateTime(entry.value, NGSILD_OBSERVED_AT_PROPERTY)
             )
 
-            val property = propertyRepository.save(rawProperty)
-            subject.properties.add(property)
-            attributeRepository.save(subject)
+            neo4jRepository.createPropertyOfSubject(
+                subjectId = subjectId,
+                property = rawProperty
+            )
         }
     }
 
-    private fun createAttributeRelationships(subject: Attribute, values: Map<String, List<Any>>) {
+    private fun createAttributeRelationships(subjectId: String, values: Map<String, List<Any>>) {
         values.forEach { propEntry ->
             val propEntryValue = propEntry.value[0]
             logger.debug("Looking at prop entry ${propEntry.key} with value $propEntryValue")
@@ -222,8 +203,7 @@ class EntityService(
                 val propEntryValueMap = propEntryValue as Map<String, List<Any>>
                 if (isAttributeOfType(propEntryValueMap, NGSILD_RELATIONSHIP_TYPE)) {
                     val objectId = getRelationshipObjectId(propEntryValueMap)
-                    val objectEntity = entityRepository.findById(objectId)
-                    if (objectEntity.isPresent) {
+                    if (exists(objectId)) {
                         val rawRelationship = Relationship(
                             type = listOf(propEntry.key),
                             observedAt = getPropertyValueFromMapAsDateTime(
@@ -231,17 +211,10 @@ class EntityService(
                                 NGSILD_OBSERVED_AT_PROPERTY
                             )
                         )
-                        val relationship = relationshipRepository.save(rawRelationship)
-                        subject.relationships.add(relationship)
-                        attributeRepository.save(subject)
 
-                        neo4jRepository.createRelationshipToEntity(
-                            relationship.id,
-                            propEntry.key.toRelationshipTypeName(),
-                            objectEntity.get().id
-                        )
+                        neo4jRepository.createRelationshipOfSubject(subjectId, rawRelationship, objectId)
                     } else {
-                        throw BadRequestDataException("Target entity $objectId in property $subject does not exist, create it first")
+                        throw BadRequestDataException("Target entity $objectId in property $subjectId does not exist, create it first")
                     }
                 } else {
                     logger.debug("Ignoring ${propEntry.key} entry as it can't be a relationship ($propEntryValue)")
@@ -273,14 +246,14 @@ class EntityService(
         }
     }
 
-    fun exists(entityId: String): Boolean = entityRepository.existsById(entityId)
+    fun exists(entityId: String): Boolean = entityRepository.exists(entityId) ?: false
 
     /**
      * @return a pair consisting of a map representing the entity keys and attributes and the list of contexts
      * associated to the entity
      */
     fun getFullEntityById(entityId: String): ExpandedEntity {
-        val entity = entityRepository.getEntityCoreById(entityId)[0]["entity"] as Entity
+        val entity = entityRepository.getEntityCoreById(entityId)
         val resultEntity = entity.serializeCoreProperties()
 
         // TODO test with a property having more than one relationship (https://redmine.eglobalmark.com/issues/848)
@@ -374,13 +347,7 @@ class EntityService(
         val mapper =
             jacksonObjectMapper().findAndRegisterModules().disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
         val entity = getFullEntityById(entityId)
-        return mapper.writeValueAsString(
-            JsonLdProcessor.compact(
-                entity.rawJsonLdProperties,
-                mapOf("@context" to entity.contexts),
-                JsonLdOptions()
-            )
-        )
+        return mapper.writeValueAsString(entity.compact())
     }
 
     fun searchEntities(type: String, query: List<String>, contextLink: String): List<ExpandedEntity> =
@@ -415,6 +382,7 @@ class EntityService(
             .map { getFullEntityById(it) }
     }
 
+    @Transactional
     fun appendEntityAttributes(
         entityId: String,
         attributes: Map<String, Any>,
@@ -488,7 +456,11 @@ class EntityService(
                 Triple(it.key, false, "Unknown attribute type $attributeType")
             }
         }
-            .toList()
+        .toList()
+
+        // update modifiedAt in entity if at least one attribute has been added
+        if (updateStatuses.isNotEmpty())
+            neo4jRepository.updateEntityModifiedDate(entityId)
 
         val updated = updateStatuses.filter { it.second }.map { it.first }
         val notUpdated = updateStatuses.filter { !it.second }.map { NotUpdatedDetails(it.first, it.third!!) }
@@ -496,12 +468,14 @@ class EntityService(
         return UpdateResult(updated, notUpdated)
     }
 
+    @Transactional
     fun updateEntityAttribute(id: String, attribute: String, payload: String, contextLink: String): Int {
         val expandedAttributeName = expandJsonLdKey(attribute, contextLink)!!
         val attributeValue = parseJsonLdFragment(payload)["value"]!!
         return neo4jRepository.updateEntityAttribute(id, expandedAttributeName, attributeValue)
     }
 
+    @Transactional
     fun updateEntityAttributes(id: String, payload: String, contextLink: String): UpdateResult {
         val updatedAttributes = mutableListOf<String>()
         val updatedAttributesPayload = mutableListOf<String>()
@@ -681,10 +655,11 @@ class EntityService(
         }
     }
 
-    fun deleteEntity(entityId: String): Pair<Int, Int> {
-        return neo4jRepository.deleteEntity(entityId)
-    }
+    @Transactional
+    fun deleteEntity(entityId: String): Pair<Int, Int> =
+        neo4jRepository.deleteEntity(entityId)
 
+    @Transactional
     fun deleteEntityAttribute(entityId: String, attributeName: String, contextLink: String): Boolean {
         val expandedAttributeName = expandJsonLdKey(attributeName, contextLink)!!
 
@@ -699,6 +674,7 @@ class EntityService(
         throw ResourceNotFoundException("Attribute $attributeName not found in entity $entityId")
     }
 
+    @Transactional
     fun updateEntityLastMeasure(observation: Observation) {
         val observingEntity =
             neo4jRepository.getObservingSensorEntity(observation.observedBy, EGM_VENDOR_ID, observation.attributeName)
@@ -738,6 +714,7 @@ class EntityService(
         }
     }
 
+    @Transactional
     fun createSubscriptionEntity(id: String, type: String, properties: Map<String, Any>) {
         if (exists(id)) {
             logger.warn("Subscription $id already exists")
@@ -758,6 +735,7 @@ class EntityService(
         entityRepository.save(subscription)
     }
 
+    @Transactional
     fun createNotificationEntity(id: String, type: String, subscriptionId: String, properties: Map<String, Any>) {
         val subscription = entityRepository.findById(subscriptionId)
         if (!subscription.isPresent) {

--- a/entity-service/src/main/kotlin/com/egm/stellio/entity/service/EntityService.kt
+++ b/entity-service/src/main/kotlin/com/egm/stellio/entity/service/EntityService.kt
@@ -89,13 +89,8 @@ class EntityService(
         val entity = entityRepository.save(rawEntity)
 
         expandedEntity.relationships.forEach { entry ->
-            val relationshipType = entry.key
             val objectId = getRelationshipObjectId(entry.value)
-
-            if (!exists(objectId))
-                throw BadRequestDataException("Target entity $objectId in relationship $relationshipType does not exist, create it first")
-            else
-                createEntityRelationship(entity, relationshipType, entry.value, objectId)
+            createEntityRelationship(entity, entry.key, entry.value, objectId)
         }
 
         expandedEntity.properties.forEach { entry ->

--- a/entity-service/src/main/kotlin/com/egm/stellio/entity/web/EntityHandler.kt
+++ b/entity-service/src/main/kotlin/com/egm/stellio/entity/web/EntityHandler.kt
@@ -2,7 +2,6 @@ package com.egm.stellio.entity.web
 
 import com.egm.stellio.entity.service.EntityService
 import com.egm.stellio.entity.util.decode
-import com.egm.stellio.shared.model.AlreadyExistsException
 import com.egm.stellio.shared.model.BadRequestDataResponse
 import com.egm.stellio.shared.model.InternalErrorResponse
 import com.egm.stellio.shared.model.ResourceNotFoundException
@@ -49,14 +48,6 @@ class EntityHandler(
         return body
             .map {
                 NgsiLdParsingUtils.parseEntity(it, NgsiLdParsingUtils.getContextOrThrowError(it))
-            }
-            .map {
-                // TODO validation (https://redmine.eglobalmark.com/issues/853)
-                if (entityService.exists(it.id)) {
-                    throw AlreadyExistsException("Already Exists")
-                }
-
-                it
             }
             .map {
                 entityService.createEntity(it)

--- a/entity-service/src/main/resources/logback-spring.xml
+++ b/entity-service/src/main/resources/logback-spring.xml
@@ -33,6 +33,7 @@
     <logger name="org.apache.kafka" level="WARN"/>
     <logger name="org.springframework.security" level="DEBUG"/>
     <logger name="org.springframework.web" level="TRACE"/>
+    <logger name="org.neo4j.ogm.drivers.bolt.request.BoltRequest" level="DEBUG"/>
 
     <root level="INFO">
         <appender-ref ref="console" />

--- a/entity-service/src/main/resources/neo4j/migrations/V02__create_minimal_indexes.cypher
+++ b/entity-service/src/main/resources/neo4j/migrations/V02__create_minimal_indexes.cypher
@@ -1,0 +1,2 @@
+CREATE INDEX entity_id_index FOR (e:Entity) ON (e.id);
+CREATE INDEX property_name_index FOR (p:Property) ON (p.name);

--- a/entity-service/src/test/kotlin/com/egm/stellio/entity/service/EntityServiceTests.kt
+++ b/entity-service/src/test/kotlin/com/egm/stellio/entity/service/EntityServiceTests.kt
@@ -224,8 +224,9 @@ class EntityServiceTests {
                     )
                 )
 
-        val exception = assertThrows<BadRequestDataException>("Creation should have failed")
-            { entityService.createEntity(sampleDataWithContext) }
+        val exception = assertThrows<BadRequestDataException>("Creation should have failed") {
+            entityService.createEntity(sampleDataWithContext)
+        }
         assertEquals(
             "Entity urn:ngsi-ld:FeedingService:018z59 targets unknown entities: " +
                         "urn:ngsi-ld:Feeder:018z5,urn:ngsi-ld:FishContainment:0012",

--- a/entity-service/src/test/kotlin/com/egm/stellio/entity/service/EntityServiceTests.kt
+++ b/entity-service/src/test/kotlin/com/egm/stellio/entity/service/EntityServiceTests.kt
@@ -1,10 +1,8 @@
 package com.egm.stellio.entity.service
 
-import com.egm.stellio.entity.model.Attribute
 import com.egm.stellio.entity.model.Entity
 import com.egm.stellio.entity.model.Property
 import com.egm.stellio.entity.model.Relationship
-import com.egm.stellio.entity.repository.AttributeRepository
 import com.egm.stellio.entity.repository.EntityRepository
 import com.egm.stellio.entity.repository.Neo4jRepository
 import com.egm.stellio.entity.repository.PropertyRepository
@@ -29,7 +27,6 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockkClass
 import io.mockk.verify
-import io.mockk.verifyAll
 import org.junit.jupiter.api.Test
 import org.neo4j.ogm.types.spatial.GeographicPoint2d
 import org.springframework.beans.factory.annotation.Autowired
@@ -53,7 +50,7 @@ class EntityServiceTests {
     @Autowired
     private lateinit var entityService: EntityService
 
-    @MockkBean
+    @MockkBean(relaxed = true)
     private lateinit var neo4jRepository: Neo4jRepository
 
     @MockkBean
@@ -64,9 +61,6 @@ class EntityServiceTests {
 
     @MockkBean
     private lateinit var relationshipRepository: RelationshipRepository
-
-    @MockkBean
-    private lateinit var attributeRepository: AttributeRepository
 
     /**
      * As Spring's ApplicationEventPublisher is not easily mockable (https://github.com/spring-projects/spring-framework/issues/18907),
@@ -88,7 +82,7 @@ class EntityServiceTests {
         every { repositoryEventsListener.handleRepositoryEvent(any()) } just Runs
         every { mockedBreedingService.properties } returns mutableListOf()
         every { mockedBreedingService.id } returns "urn:ngsi-ld:MortalityRemovalService:014YFA9Z"
-        every { entityRepository.getEntityCoreById(any()) } returns listOf(mapOf("entity" to mockedBreedingService))
+        every { entityRepository.getEntityCoreById(any()) } returns mockedBreedingService
         every { mockedBreedingService.serializeCoreProperties() } returns mutableMapOf(
             "@id" to "urn:ngsi-ld:MortalityRemovalService:014YFA9Z",
             "@type" to listOf("MortalityRemovalService")
@@ -181,16 +175,13 @@ class EntityServiceTests {
         val sampleDataWithContext = loadAndParseSampleData("aquac/BreedingService_propWithProp.json")
 
         val mockedBreedingService = mockkClass(Entity::class)
-        val mockedProperty = mockkClass(Property::class)
+
+        every { mockedBreedingService.id } returns "urn:ngsi-ld:BreedingService:PropWithProp"
 
         every { entityRepository.save<Entity>(any()) } returns mockedBreedingService
-        every { propertyRepository.save<Property>(any()) } returns mockedProperty
-        every { mockedBreedingService.properties } returns mutableListOf()
-        every { mockedProperty.properties } returns mutableListOf()
-        every { attributeRepository.save<Attribute>(any()) } returns mockedProperty
-        every { mockedBreedingService.id } returns "urn:ngsi-ld:BreedingService:PropWithProp"
+        every { neo4jRepository.createPropertyOfSubject(any(), any()) } returns UUID.randomUUID().toString()
         every { repositoryEventsListener.handleRepositoryEvent(any()) } just Runs
-        every { entityRepository.getEntityCoreById(any()) } returns listOf(mapOf("entity" to mockedBreedingService))
+        every { entityRepository.getEntityCoreById(any()) } returns mockedBreedingService
         every { mockedBreedingService.serializeCoreProperties() } returns mutableMapOf(
             "@id" to "urn:ngsi-ld:MortalityRemovalService:014YFA9Z",
             "@type" to listOf("MortalityRemovalService")
@@ -201,20 +192,7 @@ class EntityServiceTests {
 
         entityService.createEntity(sampleDataWithContext)
 
-        verifyAll {
-            propertyRepository.save<Property>(match {
-                it.name == "https://ontology.eglobalmark.com/aquac#fishName"
-            })
-            propertyRepository.save<Property>(match {
-                it.name == "https://ontology.eglobalmark.com/aquac#foodName" &&
-                    it.unitCode == "slice"
-            })
-            propertyRepository.save<Property>(match {
-                it.name == "https://ontology.eglobalmark.com/aquac#fishSize"
-            })
-        }
-
-        verify(exactly = 2) { attributeRepository.save<Attribute>(any()) }
+        confirmVerified()
     }
 
     @Test
@@ -483,24 +461,20 @@ class EntityServiceTests {
         )
 
         val mockkedEntity = mockkClass(Entity::class)
-        val mockkedProperty = mockkClass(Property::class)
 
         every { mockkedEntity.id } returns entityId
         every { mockkedEntity.properties } returns mutableListOf()
-        every { propertyRepository.save<Property>(any()) } returns mockkedProperty
-        every { entityRepository.save<Entity>(any()) } returns mockkedEntity
+        every { neo4jRepository.createPropertyOfSubject(any(), any()) } returns UUID.randomUUID().toString()
 
         entityService.createEntityProperty(mockkedEntity, "temperature", temperatureMap)
 
-        verify {
-            propertyRepository.save(match<Property> {
-                it.name == "temperature" &&
-                    it.value == 250 &&
-                    it.unitCode == "kg" &&
-                    it.observedAt.toString() == "2019-12-18T10:45:44.248755Z"
+        verify { neo4jRepository.createPropertyOfSubject(eq(entityId), match {
+            it.name == "temperature" &&
+                it.value == 250 &&
+                it.unitCode == "kg" &&
+                it.observedAt.toString() == "2019-12-18T10:45:44.248755Z"
             })
         }
-        verify { entityRepository.save(any<Entity>()) }
 
         confirmVerified()
     }
@@ -534,19 +508,13 @@ class EntityServiceTests {
 
         every { neo4jRepository.hasRelationshipOfType(any(), any()) } returns false
         every { entityRepository.findById(any()) } returns Optional.of(mockkedEntity)
-        every {
-            relationshipRepository.save(match<Relationship> {
-                it.type == listOf("https://ontology.eglobalmark.com/egm#connectsTo")
-            })
-        } returns mockkedRelationship
-        every { entityRepository.save(match<Entity> { it.id == entityId }) } returns mockkedEntity
-        every { neo4jRepository.createRelationshipToEntity(any(), any(), any()) } returns 1
+        every { neo4jRepository.createRelationshipOfSubject(any(), any(), any()) } returns relationshipId
 
         entityService.appendEntityAttributes(entityId, expandedNewRelationship, false)
 
         verify { neo4jRepository.hasRelationshipOfType(eq(entityId), "CONNECTS_TO") }
         verify { entityRepository.findById(eq(entityId)) }
-        verify { neo4jRepository.createRelationshipToEntity(eq(relationshipId), "CONNECTS_TO", eq(targetEntityId)) }
+        verify { neo4jRepository.createRelationshipOfSubject(eq(entityId), any(), eq(targetEntityId)) }
 
         confirmVerified()
     }
@@ -608,20 +576,13 @@ class EntityServiceTests {
         every { neo4jRepository.hasRelationshipOfType(any(), any()) } returns true
         every { neo4jRepository.deleteEntityRelationship(any(), any()) } returns 1
         every { entityRepository.findById(any()) } returns Optional.of(mockkedEntity)
-        every {
-            relationshipRepository.save(match<Relationship> {
-                it.type == listOf("https://ontology.eglobalmark.com/egm#connectsTo")
-            })
-        } returns mockkedRelationship
-        every { entityRepository.save(match<Entity> { it.id == entityId }) } returns mockkedEntity
-        every { neo4jRepository.createRelationshipToEntity(any(), any(), any()) } returns 1
+        every { neo4jRepository.createRelationshipOfSubject(any(), any(), any()) } returns relationshipId
 
         entityService.appendEntityAttributes(entityId, expandedNewRelationship, false)
 
         verify { neo4jRepository.hasRelationshipOfType(eq(entityId), "CONNECTS_TO") }
         verify { neo4jRepository.deleteEntityRelationship(eq(entityId), "CONNECTS_TO") }
         verify { entityRepository.findById(eq(entityId)) }
-        verify { neo4jRepository.createRelationshipToEntity(eq(relationshipId), "CONNECTS_TO", eq(targetEntityId)) }
 
         confirmVerified()
     }
@@ -645,20 +606,24 @@ class EntityServiceTests {
             )
 
         val mockkedEntity = mockkClass(Entity::class)
-        val mockkedProperty = mockkClass(Property::class)
 
         every { mockkedEntity.id } returns entityId
         every { mockkedEntity.properties } returns mutableListOf()
 
         every { neo4jRepository.hasPropertyOfName(any(), any()) } returns false
         every { entityRepository.findById(any()) } returns Optional.of(mockkedEntity)
-        every { propertyRepository.save<Property>(any()) } returns mockkedProperty
-        every { entityRepository.save<Entity>(any()) } returns mockkedEntity
+        every { mockkedEntity.id } returns entityId
+        every { neo4jRepository.createPropertyOfSubject(any(), any()) } returns UUID.randomUUID().toString()
 
         entityService.appendEntityAttributes(entityId, expandedNewProperty, false)
 
         verify { neo4jRepository.hasPropertyOfName(eq(entityId), "https://ontology.eglobalmark.com/aquac#fishNumber") }
         verify { entityRepository.findById(eq(entityId)) }
+        verify { neo4jRepository.createPropertyOfSubject(eq(entityId), match {
+            it.value == 500 &&
+                it.name == "https://ontology.eglobalmark.com/aquac#fishNumber"
+        }) }
+        verify { neo4jRepository.updateEntityModifiedDate(eq(entityId)) }
 
         confirmVerified()
     }
@@ -805,16 +770,13 @@ class EntityServiceTests {
         val mockkedSubscription = mockkClass(Entity::class)
         val mockkedNotification = mockkClass(Entity::class)
         val mockkedProperty = mockkClass(Property::class)
-        val mockkedRelationship = mockkClass(Relationship::class)
 
         every { entityRepository.findById(any()) } returns Optional.of(mockkedSubscription)
         every { propertyRepository.save<Property>(any()) } returns mockkedProperty
         every { entityRepository.save<Entity>(any()) } returns mockkedNotification
         every { neo4jRepository.getRelationshipTargetOfSubject(any(), any()) } returns null
-        every { relationshipRepository.save(any<Relationship>()) } returns mockkedRelationship
-        every { mockkedSubscription.relationships } returns mutableListOf()
-        every { mockkedRelationship.id } returns relationshipId
-        every { neo4jRepository.createRelationshipToEntity(any(), any(), any()) } returns 1
+        every { mockkedSubscription.id } returns subscriptionId
+        every { neo4jRepository.createRelationshipOfSubject(any(), any(), any()) } returns relationshipId
 
         entityService.createNotificationEntity(notificationId, notificationType, subscriptionId, properties)
 
@@ -825,14 +787,6 @@ class EntityServiceTests {
             neo4jRepository.getRelationshipTargetOfSubject(
                 subscriptionId,
                 EGM_RAISED_NOTIFICATION.toRelationshipTypeName()
-            )
-        }
-        verify { relationshipRepository.save(any<Relationship>()) }
-        verify {
-            neo4jRepository.createRelationshipToEntity(
-                relationshipId,
-                EGM_RAISED_NOTIFICATION.toRelationshipTypeName(),
-                notificationId
             )
         }
 

--- a/entity-service/src/test/kotlin/com/egm/stellio/entity/web/EntityHandlerTests.kt
+++ b/entity-service/src/test/kotlin/com/egm/stellio/entity/web/EntityHandlerTests.kt
@@ -5,6 +5,7 @@ import com.egm.stellio.entity.model.Entity
 import com.egm.stellio.entity.model.NotUpdatedDetails
 import com.egm.stellio.entity.model.UpdateResult
 import com.egm.stellio.entity.service.EntityService
+import com.egm.stellio.shared.model.AlreadyExistsException
 import com.egm.stellio.shared.model.BadRequestDataException
 import com.egm.stellio.shared.model.ExpandedEntity
 import com.egm.stellio.shared.model.InternalErrorException
@@ -91,7 +92,7 @@ class EntityHandlerTests {
     fun `create entity should return a 409 if the entity already exists`() {
         val jsonLdFile = ClassPathResource("/ngsild/aquac/BreedingService.json")
 
-        every { entityService.exists(any()) } returns true
+        every { entityService.createEntity(any()) } throws AlreadyExistsException("Already Exists")
 
         webClient.post()
             .uri("/ngsi-ld/v1/entities")

--- a/shared/src/main/kotlin/com/egm/stellio/shared/model/ExpandedEntity.kt
+++ b/shared/src/main/kotlin/com/egm/stellio/shared/model/ExpandedEntity.kt
@@ -2,6 +2,7 @@ package com.egm.stellio.shared.model
 
 import com.egm.stellio.shared.util.AttributeType
 import com.egm.stellio.shared.util.NgsiLdParsingUtils
+import com.egm.stellio.shared.util.NgsiLdParsingUtils.NGSILD_GEOPROPERTY_TYPE
 import com.egm.stellio.shared.util.NgsiLdParsingUtils.NGSILD_PROPERTY_TYPE
 import com.egm.stellio.shared.util.NgsiLdParsingUtils.NGSILD_RELATIONSHIP_TYPE
 import com.github.jsonldjava.core.JsonLdOptions
@@ -27,6 +28,7 @@ class ExpandedEntity private constructor(
     val type = (rawJsonLdProperties[NgsiLdParsingUtils.NGSILD_ENTITY_TYPE]!! as List<String>)[0]
     val relationships by lazy { getAttributesOfType(NGSILD_RELATIONSHIP_TYPE) }
     val properties by lazy { getAttributesOfType(NGSILD_PROPERTY_TYPE) }
+    val geoProperties by lazy { getAttributesOfType(NGSILD_GEOPROPERTY_TYPE) }
     val attributes by lazy { initAttributesWithoutTypeAndId() }
 
     fun compact(): Map<String, Any> =

--- a/shared/src/main/kotlin/com/egm/stellio/shared/util/NgsiLdParsingUtils.kt
+++ b/shared/src/main/kotlin/com/egm/stellio/shared/util/NgsiLdParsingUtils.kt
@@ -123,7 +123,6 @@ object NgsiLdParsingUtils {
             throw BadRequestDataException("Could not parse entity due to invalid json-ld payload")
 
         val expandedResult = JsonUtils.toPrettyString(expandedEntity[0])
-        logger.debug("Expanded entity is $expandedResult")
 
         // TODO find a way to avoid this extra parsing
         val parsedInput: Map<String, Any> = mapper.readValue(


### PR DESCRIPTION
- create properties and relationships of an entity in one Cypher query
- add indexes on entities ids and properties names (the most commonly used)
- improve the efficiency of the entity existence query
- remove customs logs in Neo4jRepository as they can be activated at the Bolt driver level instead
- mark the @Transactional method at the service level as they usually group more than 1 query
- other minor code simplifications