### PR TITLE
feat(entity): improve cypher queries for efficiency #81

### DIFF
--- a/entity-service/src/main/kotlin/com/egm/stellio/entity/repository/EntityRepository.kt
+++ b/entity-service/src/main/kotlin/com/egm/stellio/entity/repository/EntityRepository.kt
@@ -17,7 +17,6 @@ interface EntityRepository : Neo4jRepository<Entity, String> {
     @Query("MATCH (entity:Entity { id: \$id })-[:HAS_VALUE]->(property:Property)" +
             "OPTIONAL MATCH (property)-[:HAS_VALUE]->(propValue:Property)" +
             "OPTIONAL MATCH (property)-[:HAS_OBJECT]->(relOfProp:Relationship)-[rel]->(relOfPropObject:Entity)" +
-            "WHERE type(rel) <> 'HAS_OBJECT'" +
             "RETURN property, propValue, type(rel) as relType, relOfProp, relOfPropObject"
     )
     fun getEntitySpecificProperties(id: String): List<Map<String, Any>>
@@ -25,15 +24,12 @@ interface EntityRepository : Neo4jRepository<Entity, String> {
     @Query("MATCH (entity:Entity { id: \$id })-[:HAS_VALUE]->(property:Property {id: \$propertyId })" +
             "OPTIONAL MATCH (property)-[:HAS_VALUE]->(propValue:Property)" +
             "OPTIONAL MATCH (property)-[:HAS_OBJECT]->(relOfProp:Relationship)-[rel]->(relOfPropObject:Entity)" +
-            "WHERE type(rel) <> 'HAS_OBJECT'" +
             "RETURN property, propValue, type(rel) as relType, relOfProp, relOfPropObject"
     )
     fun getEntitySpecificProperty(id: String, propertyId: String): List<Map<String, Any>>
 
     @Query("MATCH (entity:Entity { id: \$id })-[:HAS_OBJECT]->(rel:Relationship)-[r]->(relObject:Entity)" +
-            "WHERE type(r) <> 'HAS_OBJECT'" +
             "OPTIONAL MATCH (rel)-[:HAS_OBJECT]->(relOfRel:Relationship)-[or]->(relOfRelObject:Entity)" +
-            "WHERE type(or) <> 'HAS_OBJECT'" +
             "RETURN rel, type(r) as relType, relObject, relOfRel, type(or) as relOfRelType, relOfRelObject"
     )
     fun getEntityRelationships(id: String): List<Map<String, Any>>

--- a/entity-service/src/main/kotlin/com/egm/stellio/entity/repository/Neo4jRepository.kt
+++ b/entity-service/src/main/kotlin/com/egm/stellio/entity/repository/Neo4jRepository.kt
@@ -3,7 +3,6 @@ package com.egm.stellio.entity.repository
 import com.egm.stellio.entity.model.Entity
 import com.egm.stellio.entity.model.Property
 import com.egm.stellio.entity.model.Relationship
-import com.egm.stellio.shared.util.extractShortTypeFromExpanded
 import com.egm.stellio.shared.util.isDate
 import com.egm.stellio.shared.util.isDateTime
 import com.egm.stellio.shared.util.isFloat
@@ -18,33 +17,45 @@ import java.time.Instant
 import java.time.ZoneOffset
 import javax.annotation.PostConstruct
 
+sealed class SubjectNodeInfo(val id: String, val label: String)
+class EntitySubjectNode(id: String) : SubjectNodeInfo(id, "Entity")
+class AttributeSubjectNode(id: String) : SubjectNodeInfo(id, "Attribute")
+
 @Component
 class Neo4jRepository(
     private val session: Session,
     private val sessionFactory: SessionFactory
 ) {
 
-    fun createPropertyOfSubject(subjectId: String, property: Property): String {
+    fun createPropertyOfSubject(subjectNodeInfo: SubjectNodeInfo, property: Property): String {
         val query = """
-            MATCH (subject { id: '$subjectId' })
+            MATCH (subject:${subjectNodeInfo.label} { id: ${'$'}subjectId })
             CREATE (subject)-[:HAS_VALUE]->(p:Attribute:Property ${'$'}props)
             RETURN p.id as id
         """
 
-        return session.query(query, mapOf("props" to property.nodeProperties()))
+        val parameters = mapOf(
+            "props" to property.nodeProperties(),
+            "subjectId" to subjectNodeInfo.id
+        )
+        return session.query(query, parameters)
             .first()["id"] as String
     }
 
-    fun createRelationshipOfSubject(subjectId: String, relationship: Relationship, targetId: String): String {
+    fun createRelationshipOfSubject(subjectNodeInfo: SubjectNodeInfo, relationship: Relationship, targetId: String): String {
         val relationshipType = relationship.type[0].toRelationshipTypeName()
         val query = """
-            MATCH (subject { id: '$subjectId' }), (target:Entity { id: '$targetId' })
-            CREATE (subject)-[:HAS_OBJECT]->(r:Attribute:Relationship:`${relationship.type[0]}` ${'$'}props)-[:HAS_OBJECT]->(target)
-            CREATE (r)-[:$relationshipType]->(target)
+            MATCH (subject:${subjectNodeInfo.label} { id: ${'$'}subjectId }), (target:Entity { id: ${'$'}targetId })
+            CREATE (subject)-[:HAS_OBJECT]->(r:Attribute:Relationship:`${relationship.type[0]}` ${'$'}props)-[:$relationshipType]->(target)
             RETURN r.id as id
         """
 
-        return session.query(query, mapOf("props" to relationship.nodeProperties()))
+        val parameters = mapOf(
+            "props" to relationship.nodeProperties(),
+            "subjectId" to subjectNodeInfo.id,
+            "targetId" to targetId
+        )
+        return session.query(query, parameters)
             .first()["id"] as String
     }
 
@@ -53,20 +64,28 @@ class Neo4jRepository(
      */
     fun addLocationPropertyToEntity(subjectId: String, coordinates: Pair<Double, Double>): Int {
         val query = """
-            MERGE (subject:Entity { id: "$subjectId" })
+            MERGE (subject:Entity { id: ${'$'}subjectId })
             ON MATCH SET subject.location = point({x: ${coordinates.first}, y: ${coordinates.second}, crs: 'wgs-84'})
             """
-        return session.query(query, emptyMap<String, String>()).queryStatistics().propertiesSet
+
+        val parameters = mapOf(
+            "subjectId" to subjectId
+        )
+        return session.query(query, parameters).queryStatistics().propertiesSet
     }
 
     fun updateEntityAttribute(entityId: String, propertyName: String, propertyValue: Any): Int {
         val query = """
-            MERGE (entity:Entity { id: "$entityId" })-[:HAS_VALUE]->(property:Property { name: "$propertyName" })
+            MERGE (entity:Entity { id: ${'$'}entityId })-[:HAS_VALUE]->(property:Property { name: ${'$'}propertyName })
             ON MATCH SET property.value = ${escapePropertyValue(propertyValue)},
                          property.modifiedAt = datetime("${Instant.now().atZone(ZoneOffset.UTC)}")
         """.trimIndent()
 
-        return session.query(query, emptyMap<String, String>()).queryStatistics().propertiesSet
+        val parameters = mapOf(
+            "entityId" to entityId,
+            "propertyName" to propertyName
+        )
+        return session.query(query, parameters).queryStatistics().propertiesSet
     }
 
     fun updateEntityModifiedDate(entityId: String): Int {
@@ -78,31 +97,41 @@ class Neo4jRepository(
         return session.query(query, mapOf("entityId" to entityId)).queryStatistics().propertiesSet
     }
 
-    fun hasRelationshipOfType(attributeId: String, relationshipType: String): Boolean {
+    fun hasRelationshipOfType(subjectNodeInfo: SubjectNodeInfo, relationshipType: String): Boolean {
         val query = """
-            MATCH (a { id: '$attributeId' })-[:HAS_OBJECT]->(rel)-[:$relationshipType]->()
+            MATCH (a:${subjectNodeInfo.label} { id: ${'$'}attributeId })-[:HAS_OBJECT]->(rel)-[:$relationshipType]->()
             RETURN a.id
             """.trimIndent()
 
-        return session.query(query, emptyMap<String, String>(), true).toList().isNotEmpty()
+        val parameters = mapOf(
+            "attributeId" to subjectNodeInfo.id
+        )
+        return session.query(query, parameters, true).toList().isNotEmpty()
     }
 
-    fun hasPropertyOfName(attributeId: String, propertyName: String): Boolean {
+    fun hasPropertyOfName(subjectNodeInfo: SubjectNodeInfo, propertyName: String): Boolean {
         val query = """
-            MATCH (a { id: '$attributeId' })-[:HAS_VALUE]->(property:Property { name: "$propertyName" })
+            MATCH (a:${subjectNodeInfo.label} { id: ${'$'}attributeId })-[:HAS_VALUE]->(property:Property { name: ${'$'}propertyName })
             RETURN a.id
             """.trimIndent()
 
-        return session.query(query, emptyMap<String, String>(), true).toList().isNotEmpty()
+        val parameters = mapOf(
+            "attributeId" to subjectNodeInfo.id,
+            "propertyName" to propertyName
+        )
+        return session.query(query, parameters, true).toList().isNotEmpty()
     }
 
-    fun hasGeoPropertyOfName(attributeId: String, geoPropertyName: String): Boolean {
+    fun hasGeoPropertyOfName(subjectNodeInfo: SubjectNodeInfo, geoPropertyName: String): Boolean {
         val query = """
-            MATCH (a { id: '$attributeId' }) WHERE a.$geoPropertyName IS NOT NULL
+            MATCH (a:${subjectNodeInfo.label} { id: ${'$'}attributeId }) WHERE a.$geoPropertyName IS NOT NULL
             RETURN a.id
             """.trimIndent()
 
-        return session.query(query, emptyMap<String, String>(), true).toList().isNotEmpty()
+        val parameters = mapOf(
+            "attributeId" to subjectNodeInfo.id
+        )
+        return session.query(query, parameters, true).toList().isNotEmpty()
     }
 
     fun updateRelationshipTargetOfAttribute(
@@ -110,27 +139,20 @@ class Neo4jRepository(
         relationshipType: String,
         oldRelationshipObjectId: String,
         newRelationshipObjectId: String
-    ): Pair<Int, Int> {
-        val hasObjectQuery = """
-            MATCH (a:Attribute { id: "$attributeId" })-[v:HAS_OBJECT]->(e:Entity { id: '$oldRelationshipObjectId' }),
-                  (target:Entity { id: "$newRelationshipObjectId" })
-            DETACH DELETE v
-            MERGE (a)-[:HAS_OBJECT]->(target)
-            """.trimIndent()
-
+    ): Int {
         val relationshipTypeQuery = """
-            MATCH (a:Attribute { id: "$attributeId" })-[v:$relationshipType]->(e:Entity { id: '$oldRelationshipObjectId' }),
-                  (target:Entity { id: "$newRelationshipObjectId" })
+            MATCH (a:Attribute { id: ${'$'}attributeId })-[v:$relationshipType]->(e:Entity { id: ${'$'}oldRelationshipObjectId }),
+                  (target:Entity { id: ${'$'}newRelationshipObjectId })
             DETACH DELETE v
             MERGE (a)-[:$relationshipType]->(target)
-            """.trimIndent()
+        """.trimIndent()
 
-        val objectQueryStatistics =
-            session.query(hasObjectQuery, emptyMap<String, String>()).queryStatistics().nodesDeleted
-        val relationshipTypeQueryStatistics =
-            session.query(relationshipTypeQuery, emptyMap<String, String>()).queryStatistics().nodesDeleted
-
-        return Pair(objectQueryStatistics, relationshipTypeQueryStatistics)
+        val parameters = mapOf(
+            "attributeId" to attributeId,
+            "oldRelationshipObjectId" to oldRelationshipObjectId,
+            "newRelationshipObjectId" to newRelationshipObjectId
+        )
+        return session.query(relationshipTypeQuery, parameters).queryStatistics().nodesDeleted
     }
 
     fun updateLocationPropertyOfEntity(entityId: String, coordinates: Pair<Double, Double>): Int {
@@ -154,17 +176,25 @@ class Neo4jRepository(
          * 7. the relationships of relationships
          */
         val query = """
-            MATCH (n:Entity { id: '$entityId' }) 
-            OPTIONAL MATCH (n)-[:HAS_VALUE]->(prop)
-            OPTIONAL MATCH (prop)-[:HAS_OBJECT]->(relOfProp)
-            OPTIONAL MATCH (prop)-[:HAS_VALUE]->(propOfProp)
-            OPTIONAL MATCH (n)-[:HAS_OBJECT]->(rel)
-            OPTIONAL MATCH (rel)-[:HAS_VALUE]->(propOfRel)
+            MATCH (n:Entity { id: ${'$'}entityId }) 
+            OPTIONAL MATCH (n)-[:HAS_VALUE]->(prop:Property)
+            WITH n, prop
+            OPTIONAL MATCH (prop)-[:HAS_OBJECT]->(relOfProp:Relationship)
+            WITH n, prop, relOfProp
+            OPTIONAL MATCH (prop)-[:HAS_VALUE]->(propOfProp:Property)
+            WITH n, prop, relOfProp, propOfProp
+            OPTIONAL MATCH (n)-[:HAS_OBJECT]->(rel:Relationship)
+            WITH n, prop, relOfProp, propOfProp, rel
+            OPTIONAL MATCH (rel)-[:HAS_VALUE]->(propOfRel:Property)
+            WITH n, prop, relOfProp, propOfProp, rel, propOfRel
             OPTIONAL MATCH (rel)-[:HAS_OBJECT]->(relOfRel:Relationship)
-            DETACH DELETE n,prop,relOfProp,propOfProp,rel,propOfRel,relOfRel
+            DETACH DELETE n, prop, relOfProp, propOfProp, rel, propOfRel, relOfRel
             """.trimIndent()
 
-        val queryStatistics = session.query(query, emptyMap<String, Any>()).queryStatistics()
+        val parameters = mapOf(
+            "entityId" to entityId
+        )
+        val queryStatistics = session.query(query, parameters).queryStatistics()
         return Pair(queryStatistics.nodesDeleted, queryStatistics.relationshipsDeleted)
     }
 
@@ -180,17 +210,25 @@ class Neo4jRepository(
          * 6. the relationships of relationships
          */
         val query = """
-            MATCH (n:Entity { id: '$entityId' }) 
-            OPTIONAL MATCH (n)-[:HAS_VALUE]->(prop)
-            OPTIONAL MATCH (prop)-[:HAS_OBJECT]->(relOfProp)
-            OPTIONAL MATCH (prop)-[:HAS_VALUE]->(propOfProp)
-            OPTIONAL MATCH (n)-[:HAS_OBJECT]->(rel)
-            OPTIONAL MATCH (rel)-[:HAS_VALUE]->(propOfRel)
+            MATCH (n:Entity { id: ${'$'}entityId }) 
+            OPTIONAL MATCH (n)-[:HAS_VALUE]->(prop:Property)
+            WITH n, prop
+            OPTIONAL MATCH (prop)-[:HAS_OBJECT]->(relOfProp:Relationship)
+            WITH n, prop, relOfProp
+            OPTIONAL MATCH (prop)-[:HAS_VALUE]->(propOfProp:Property)
+            WITH n, prop, relOfProp, propOfProp
+            OPTIONAL MATCH (n)-[:HAS_OBJECT]->(rel:Relationship)
+            WITH n, prop, relOfProp, propOfProp, rel
+            OPTIONAL MATCH (rel)-[:HAS_VALUE]->(propOfRel:Property)
+            WITH n, prop, relOfProp, propOfProp, rel, propOfRel
             OPTIONAL MATCH (rel)-[:HAS_OBJECT]->(relOfRel:Relationship)
-            DETACH DELETE prop,relOfProp,propOfProp,rel,propOfRel,relOfRel
+            DETACH DELETE prop, relOfProp, propOfProp, rel, propOfRel, relOfRel
             """.trimIndent()
 
-        val queryStatistics = session.query(query, emptyMap<String, Any>()).queryStatistics()
+        val parameters = mapOf(
+            "entityId" to entityId
+        )
+        val queryStatistics = session.query(query, parameters).queryStatistics()
         return Pair(queryStatistics.nodesDeleted, queryStatistics.relationshipsDeleted)
     }
 
@@ -203,21 +241,21 @@ class Neo4jRepository(
          * 3. the relationships of the property
          */
         val query = """
-            MATCH (entity:Entity { id: "$entityId" })-[:HAS_VALUE]->(prop:Attribute { name: "$propertyName" })
-            OPTIONAL MATCH (prop)-[:HAS_VALUE]->(propOfProp)
-            OPTIONAL MATCH (prop)-[:HAS_OBJECT]->(relOfProp)
-            DETACH DELETE prop,propOfProp,relOfProp
+            MATCH (entity:Entity { id: ${'$'}entityId })-[:HAS_VALUE]->(prop:Property { name: ${'$'}propertyName })
+            OPTIONAL MATCH (prop)-[:HAS_VALUE]->(propOfProp:Property)
+            WITH prop, propOfProp
+            OPTIONAL MATCH (prop)-[:HAS_OBJECT]->(relOfProp:Relationship)
+            DETACH DELETE prop, propOfProp, relOfProp
             """.trimIndent()
 
-        val queryStatistics = session.query(query, emptyMap<String, Any>()).queryStatistics()
+        val parameters = mapOf(
+            "entityId" to entityId,
+            "propertyName" to propertyName
+        )
+        val queryStatistics = session.query(query, parameters).queryStatistics()
         return queryStatistics.nodesDeleted
     }
 
-    /**
-    Given an entity E1 having a relationship R1 with an entity E2
-    When matching the relationships of R1 (to be deleted with R1), a check on :Relationship is necessary since R1 has a link also called HAS_OBJECT with the target entity E2
-    Otherwise, it will delete not only the relationships of R1 but also the entity E2
-     */
     fun deleteEntityRelationship(entityId: String, relationshipType: String): Int {
         /**
          * Delete :
@@ -227,14 +265,17 @@ class Neo4jRepository(
          * 3. the relationships of the relationship
          */
         val query = """
-            MATCH (entity:Entity { id: "$entityId" })-[:HAS_OBJECT]->(rel)-[:$relationshipType]->()
-            OPTIONAL MATCH (rel)-[:HAS_VALUE]->(propOfRel)
+            MATCH (entity:Entity { id: ${'$'}entityId })-[:HAS_OBJECT]->(rel)-[:$relationshipType]->()
+            OPTIONAL MATCH (rel)-[:HAS_VALUE]->(propOfRel:Property)
+            WITH rel, propOfRel
             OPTIONAL MATCH (rel)-[:HAS_OBJECT]->(relOfRel:Relationship)
-            DETACH DELETE rel,propOfRel,relOfRel
-            """.trimIndent()
+            DETACH DELETE rel, propOfRel, relOfRel
+        """.trimIndent()
 
-        val queryStatistics = session.query(query, emptyMap<String, Any>()).queryStatistics()
-        return queryStatistics.nodesDeleted
+        val parameters = mapOf(
+            "entityId" to entityId
+        )
+        return session.query(query, parameters).queryStatistics().nodesDeleted
     }
 
     fun getEntitiesByTypeAndQuery(
@@ -251,15 +292,13 @@ class Neo4jRepository(
                         it.third.isTime() -> "localtime('${it.third}')"
                         else -> "'${it.third}'"
                     }
-                    "(n)-[:HAS_VALUE]->(${it.first.extractShortTypeFromExpanded()}:Property { name: '${it.first}'}) and ${it.first.extractShortTypeFromExpanded()}.value ${it.second} $comparableValue"
-                }
-            else
-                ""
-
-        val propertiesVariables =
-            if (query.second.isNotEmpty())
-                query.second.joinToString(", ") {
-                    "(${it.first.extractShortTypeFromExpanded()})"
+                    """
+                       EXISTS {
+                           MATCH (n)-[:HAS_VALUE]->(p:Property)
+                           WHERE p.name = '${it.first}' 
+                           AND p.value ${it.second} $comparableValue
+                       }
+                    """.trimIndent()
                 }
             else
                 ""
@@ -274,13 +313,10 @@ class Neo4jRepository(
 
         val matchClause =
             if (type.isEmpty())
-                "MATCH (n)"
-            else {
-                if (propertiesVariables.isEmpty())
-                    "MATCH (n:`$type`)"
-                else
-                    "MATCH (n:`$type`), $propertiesVariables"
-            }
+                "MATCH (n:Entity)"
+            else
+                "MATCH (n:`$type`)"
+
         val whereClause =
             if (propertiesFilter.isNotEmpty() || relationshipsFilter.isNotEmpty()) " WHERE "
             else ""

--- a/entity-service/src/main/kotlin/com/egm/stellio/entity/service/EntityService.kt
+++ b/entity-service/src/main/kotlin/com/egm/stellio/entity/service/EntityService.kt
@@ -6,7 +6,9 @@ import com.egm.stellio.entity.model.NotUpdatedDetails
 import com.egm.stellio.entity.model.Property
 import com.egm.stellio.entity.model.Relationship
 import com.egm.stellio.entity.model.UpdateResult
+import com.egm.stellio.entity.repository.AttributeSubjectNode
 import com.egm.stellio.entity.repository.EntityRepository
+import com.egm.stellio.entity.repository.EntitySubjectNode
 import com.egm.stellio.entity.repository.Neo4jRepository
 import com.egm.stellio.entity.repository.PropertyRepository
 import com.egm.stellio.entity.repository.RelationshipRepository
@@ -138,7 +140,7 @@ class EntityService(
         )
 
         neo4jRepository.createPropertyOfSubject(
-            subjectId = entity.id,
+            subjectNodeInfo = EntitySubjectNode(entity.id),
             property = rawProperty
         )
 
@@ -167,7 +169,7 @@ class EntityService(
             observedAt = getPropertyValueFromMapAsDateTime(relationshipValues, NGSILD_OBSERVED_AT_PROPERTY)
         )
 
-        neo4jRepository.createRelationshipOfSubject(entity.id, rawRelationship, targetEntityId)
+        neo4jRepository.createRelationshipOfSubject(EntitySubjectNode(entity.id), rawRelationship, targetEntityId)
 
         createAttributeProperties(rawRelationship.id, relationshipValues)
         createAttributeRelationships(rawRelationship.id, relationshipValues)
@@ -197,7 +199,7 @@ class EntityService(
             )
 
             neo4jRepository.createPropertyOfSubject(
-                subjectId = subjectId,
+                subjectNodeInfo = AttributeSubjectNode(subjectId),
                 property = rawProperty
             )
         }
@@ -220,7 +222,11 @@ class EntityService(
                             )
                         )
 
-                        neo4jRepository.createRelationshipOfSubject(subjectId, rawRelationship, objectId)
+                        neo4jRepository.createRelationshipOfSubject(
+                            AttributeSubjectNode(subjectId),
+                            rawRelationship,
+                            objectId
+                        )
                     } else {
                         throw BadRequestDataException("Target entity $objectId in property $subjectId does not exist, create it first")
                     }
@@ -404,7 +410,10 @@ class EntityService(
             logger.debug("Fragment is of type $attributeType")
             if (attributeType == NGSILD_RELATIONSHIP_TYPE.uri) {
                 val relationshipTypeName = it.key.extractShortTypeFromExpanded()
-                if (!neo4jRepository.hasRelationshipOfType(entityId, relationshipTypeName.toRelationshipTypeName())) {
+                if (!neo4jRepository.hasRelationshipOfType(
+                    EntitySubjectNode(entityId),
+                    relationshipTypeName.toRelationshipTypeName())
+                ) {
                     createEntityRelationship(
                         entityRepository.findById(entityId).get(),
                         it.key,
@@ -430,7 +439,7 @@ class EntityService(
                     Triple(it.key, true, null)
                 }
             } else if (attributeType == NGSILD_PROPERTY_TYPE.uri) {
-                if (!neo4jRepository.hasPropertyOfName(entityId, it.key)) {
+                if (!neo4jRepository.hasPropertyOfName(EntitySubjectNode(entityId), it.key)) {
                     createEntityProperty(entityRepository.findById(entityId).get(), it.key, attributeValue)
                     Triple(it.key, true, null)
                 } else if (disallowOverwrite) {
@@ -446,7 +455,10 @@ class EntityService(
                     Triple(it.key, true, null)
                 }
             } else if (attributeType == NGSILD_GEOPROPERTY_TYPE.uri) {
-                if (!neo4jRepository.hasGeoPropertyOfName(entityId, it.key.extractShortTypeFromExpanded())) {
+                if (!neo4jRepository.hasGeoPropertyOfName(
+                    EntitySubjectNode(entityId),
+                    it.key.extractShortTypeFromExpanded())
+                ) {
                     createLocationProperty(entityRepository.findById(entityId).get(), it.key, attributeValue)
                     Triple(it.key, true, null)
                 } else if (disallowOverwrite) {
@@ -499,7 +511,7 @@ class EntityService(
                 val attributeType = attributeValue["@type"]!![0]
                 logger.debug("Trying to update attribute $shortAttributeName of type $attributeType")
                 if (attributeType == NGSILD_RELATIONSHIP_TYPE.uri) {
-                    if (neo4jRepository.hasRelationshipOfType(id, it.key.toRelationshipTypeName())) {
+                    if (neo4jRepository.hasRelationshipOfType(EntitySubjectNode(id), it.key.toRelationshipTypeName())) {
                         updateRelationshipOfEntity(
                             entity,
                             it.key,
@@ -511,14 +523,14 @@ class EntityService(
                     } else
                         notUpdatedAttributes.add(NotUpdatedDetails(shortAttributeName, "Relationship does not exist"))
                 } else if (attributeType == NGSILD_PROPERTY_TYPE.uri) {
-                    if (neo4jRepository.hasPropertyOfName(id, it.key)) {
+                    if (neo4jRepository.hasPropertyOfName(EntitySubjectNode(id), it.key)) {
                         updatePropertyOfEntity(entity, it.key, attributeValue)
                         updatedAttributes.add(shortAttributeName)
                         updatedAttributesPayload.add(compactAndStringifyFragment(it.key, it.value, contextLink))
                     } else
                         notUpdatedAttributes.add(NotUpdatedDetails(shortAttributeName, "Property does not exist"))
                 } else if (attributeType == NGSILD_GEOPROPERTY_TYPE.uri) {
-                    if (neo4jRepository.hasGeoPropertyOfName(id, shortAttributeName)) {
+                    if (neo4jRepository.hasGeoPropertyOfName(EntitySubjectNode(id), shortAttributeName)) {
                         updateLocationPropertyOfEntity(entity, it.key, attributeValue)
                         updatedAttributes.add(shortAttributeName)
                         updatedAttributesPayload.add(compactAndStringifyFragment(it.key, it.value, contextLink))
@@ -618,7 +630,7 @@ class EntityService(
             !(NGSILD_PROPERTIES_CORE_MEMBERS.plus(NGSILD_RELATIONSHIPS_CORE_MEMBERS)).contains(it.key) &&
                 isAttributeOfType(it.value, NGSILD_PROPERTY_TYPE)
         }.forEach { entry ->
-            if (!neo4jRepository.hasPropertyOfName(subject.id, entry.key))
+            if (!neo4jRepository.hasPropertyOfName(AttributeSubjectNode(subject.id), entry.key))
                 throw BadRequestDataException("Property ${entry.key.extractShortTypeFromExpanded()} does not exist")
             updatePropertyValues(subject.id, entry.key, entry.value)
         }
@@ -631,7 +643,10 @@ class EntityService(
             if (propEntryValue is Map<*, *>) {
                 val propEntryValueMap = propEntryValue as Map<String, List<Any>>
                 if (isAttributeOfType(propEntryValueMap, NGSILD_RELATIONSHIP_TYPE)) {
-                    if (!neo4jRepository.hasRelationshipOfType(subject.id, propEntry.key.toRelationshipTypeName()))
+                    if (!neo4jRepository.hasRelationshipOfType(
+                        AttributeSubjectNode(subject.id),
+                        propEntry.key.toRelationshipTypeName())
+                    )
                         throw BadRequestDataException("Relationship ${propEntry.key.toRelationshipTypeName()} does not exist")
                     val objectId = getRelationshipObjectId(propEntryValueMap)
                     updateRelationshipValues(subject.id, propEntry.key, propEntryValueMap, objectId)
@@ -671,9 +686,12 @@ class EntityService(
     fun deleteEntityAttribute(entityId: String, attributeName: String, contextLink: String): Boolean {
         val expandedAttributeName = expandJsonLdKey(attributeName, contextLink)!!
 
-        if (neo4jRepository.hasPropertyOfName(entityId, expandedAttributeName))
+        if (neo4jRepository.hasPropertyOfName(EntitySubjectNode(entityId), expandedAttributeName))
             return neo4jRepository.deleteEntityProperty(entityId, expandedAttributeName) >= 1
-        else if (neo4jRepository.hasRelationshipOfType(entityId, expandedAttributeName.toRelationshipTypeName()))
+        else if (neo4jRepository.hasRelationshipOfType(
+            EntitySubjectNode(entityId),
+            expandedAttributeName.toRelationshipTypeName())
+        )
             return neo4jRepository.deleteEntityRelationship(
                 entityId,
                 expandedAttributeName.toRelationshipTypeName()

--- a/entity-service/src/main/kotlin/com/egm/stellio/entity/web/EntityHandler.kt
+++ b/entity-service/src/main/kotlin/com/egm/stellio/entity/web/EntityHandler.kt
@@ -80,10 +80,7 @@ class EntityHandler(
                 .toMono()
 
         /* Decoding query parameters is not supported by default so a call to a decode function was added query with the right parameters values */
-        return "".toMono()
-            .map {
-                entityService.searchEntities(type, q.decode(), contextLink)
-            }
+        return Mono.just(entityService.searchEntities(type, q.decode(), contextLink))
             .map {
                 compactEntities(it)
             }

--- a/entity-service/src/main/resources/neo4j/migrations/V02__create_minimal_indexes.cypher
+++ b/entity-service/src/main/resources/neo4j/migrations/V02__create_minimal_indexes.cypher
@@ -1,2 +1,3 @@
 CREATE INDEX entity_id_index FOR (e:Entity) ON (e.id);
+CREATE INDEX attribute_id_index FOR (a:Attribute) ON (a.id);
 CREATE INDEX property_name_index FOR (p:Property) ON (p.name);

--- a/entity-service/src/main/resources/neo4j/migrations/V03__remove_has_object_relationship_on_entity.cypher
+++ b/entity-service/src/main/resources/neo4j/migrations/V03__remove_has_object_relationship_on_entity.cypher
@@ -1,0 +1,2 @@
+MATCH (r:Relationship)-[rel:HAS_OBJECT]->(e:Entity)
+DELETE rel;

--- a/entity-service/src/test/kotlin/com/egm/stellio/entity/repository/Neo4jRepositoryTests.kt
+++ b/entity-service/src/test/kotlin/com/egm/stellio/entity/repository/Neo4jRepositoryTests.kt
@@ -316,7 +316,7 @@ class Neo4jRepositoryTests {
             mutableListOf(Property(name = EGM_VENDOR_ID, value = vendorId))
         )
         val property = createProperty("https://ontology.eglobalmark.com/apic#outgoing", 1.0)
-        val relationship = createRelationship(property.id, EGM_OBSERVED_BY, entity.id)
+        val relationship = createRelationship(AttributeSubjectNode(property.id), EGM_OBSERVED_BY, entity.id)
         val persistedEntity = neo4jRepository.getObservingSensorEntity(vendorId, EGM_VENDOR_ID, "outgoing")
         assertNotNull(persistedEntity)
         propertyRepository.delete(property)
@@ -333,7 +333,7 @@ class Neo4jRepositoryTests {
             mutableListOf(Property(name = EGM_VENDOR_ID, value = vendorId))
         )
         val property = createProperty("https://ontology.eglobalmark.com/apic#outgoing", 1.0)
-        val relationship = createRelationship(property.id, EGM_OBSERVED_BY, entity.id)
+        val relationship = createRelationship(AttributeSubjectNode(property.id), EGM_OBSERVED_BY, entity.id)
         val persistedEntity =
             neo4jRepository.getObservingSensorEntity(vendorId.toUpperCase(), EGM_VENDOR_ID, "outgoing")
         assertNotNull(persistedEntity)
@@ -351,9 +351,11 @@ class Neo4jRepositoryTests {
             listOf("Device"),
             mutableListOf(Property(name = EGM_VENDOR_ID, value = vendorId))
         )
-        val sensorToDeviceRelationship = createRelationship(sensor.id, EGM_IS_CONTAINED_IN, device.id)
+        val sensorToDeviceRelationship =
+            createRelationship(EntitySubjectNode(sensor.id), EGM_IS_CONTAINED_IN, device.id)
         val property = createProperty("https://ontology.eglobalmark.com/apic#outgoing", 1.0)
-        val propertyToDeviceRelationship = createRelationship(property.id, EGM_OBSERVED_BY, sensor.id)
+        val propertyToDeviceRelationship =
+            createRelationship(AttributeSubjectNode(property.id), EGM_OBSERVED_BY, sensor.id)
         val persistedEntity = neo4jRepository.getObservingSensorEntity(vendorId, EGM_VENDOR_ID, "outgoing")
         assertNotNull(persistedEntity)
         propertyRepository.delete(property)
@@ -372,7 +374,7 @@ class Neo4jRepositoryTests {
             mutableListOf(Property(name = EGM_VENDOR_ID, value = vendorId))
         )
         val property = createProperty("https://ontology.eglobalmark.com/apic#outgoing", 1.0)
-        val relationship = createRelationship(property.id, EGM_OBSERVED_BY, entity.id)
+        val relationship = createRelationship(AttributeSubjectNode(property.id), EGM_OBSERVED_BY, entity.id)
         val persistedEntity = neo4jRepository.getObservingSensorEntity(vendorId, EGM_VENDOR_ID, "incoming")
         assertNull(persistedEntity)
         propertyRepository.delete(property)
@@ -389,7 +391,7 @@ class Neo4jRepositoryTests {
             mutableListOf(Property(name = EGM_VENDOR_ID, value = vendorId))
         )
         val property = createProperty("https://ontology.eglobalmark.com/apic#outgoing", 1.0)
-        val relationship = createRelationship(property.id, EGM_OBSERVED_BY, entity.id)
+        val relationship = createRelationship(AttributeSubjectNode(property.id), EGM_OBSERVED_BY, entity.id)
         val persistedEntity =
             neo4jRepository.getObservingSensorEntity("urn:ngsi-ld:Sensor:Unknown", EGM_VENDOR_ID, "outgoing")
         assertNull(persistedEntity)
@@ -480,7 +482,7 @@ class Neo4jRepositoryTests {
     fun `it should delete an entity relationship`() {
         val sensor = createEntity("urn:ngsi-ld:Sensor:1233", listOf("Sensor"), mutableListOf())
         val device = createEntity("urn:ngsi-ld:Device:1233", listOf("Device"), mutableListOf())
-        createRelationship(sensor.id, EGM_OBSERVED_BY, device.id)
+        createRelationship(EntitySubjectNode(sensor.id), EGM_OBSERVED_BY, device.id)
 
         neo4jRepository.deleteEntityRelationship(sensor.id, "OBSERVED_BY")
 
@@ -519,7 +521,7 @@ class Neo4jRepositoryTests {
             mutableListOf(Property(name = "name", value = "Scalpa"))
         )
         val device = createEntity("urn:ngsi-ld:Device:1233", listOf("Device"), mutableListOf())
-        createRelationship(sensor.id, EGM_OBSERVED_BY, device.id)
+        createRelationship(EntitySubjectNode(sensor.id), EGM_OBSERVED_BY, device.id)
 
         neo4jRepository.deleteEntityAttributes(sensor.id)
 
@@ -541,9 +543,13 @@ class Neo4jRepositoryTests {
         return propertyRepository.save(property)
     }
 
-    fun createRelationship(subjectId: String, relationshipType: String, objectId: String): Relationship {
+    fun createRelationship(
+        subjectNodeInfo: SubjectNodeInfo,
+        relationshipType: String,
+        objectId: String
+    ): Relationship {
         val relationship = Relationship(type = listOf(relationshipType))
-        neo4jRepository.createRelationshipOfSubject(subjectId, relationship, objectId)
+        neo4jRepository.createRelationshipOfSubject(subjectNodeInfo, relationship, objectId)
 
         return relationship
     }

--- a/entity-service/src/test/kotlin/com/egm/stellio/entity/service/EntityServiceTests.kt
+++ b/entity-service/src/test/kotlin/com/egm/stellio/entity/service/EntityServiceTests.kt
@@ -352,7 +352,7 @@ class EntityServiceTests {
         every { neo4jRepository.hasRelationshipOfType(any(), any()) } returns true
         every { neo4jRepository.getRelationshipOfSubject(any(), any()) } returns mockkedRelationship
         every { neo4jRepository.getRelationshipTargetOfSubject(any(), any()) } returns mockkedRelationshipTarget
-        every { neo4jRepository.updateRelationshipTargetOfAttribute(any(), any(), any(), any()) } returns Pair(1, 1)
+        every { neo4jRepository.updateRelationshipTargetOfAttribute(any(), any(), any(), any()) } returns 1
         every { entityRepository.findById(any()) } returns Optional.of(mockkedSensor)
         every { relationshipRepository.save(any<Relationship>()) } returns mockkedRelationship
         every { repositoryEventsListener.handleRepositoryEvent(any()) } just Runs
@@ -506,7 +506,10 @@ class EntityServiceTests {
 
         entityService.createEntityProperty(mockkedEntity, "temperature", temperatureMap)
 
-        verify { neo4jRepository.createPropertyOfSubject(eq(entityId), match {
+        verify { neo4jRepository.createPropertyOfSubject(match {
+            it.id == entityId &&
+                it.label == "Entity"
+        }, match {
             it.name == "temperature" &&
                 it.value == 250 &&
                 it.unitCode == "kg" &&
@@ -550,9 +553,20 @@ class EntityServiceTests {
 
         entityService.appendEntityAttributes(entityId, expandedNewRelationship, false)
 
-        verify { neo4jRepository.hasRelationshipOfType(eq(entityId), "CONNECTS_TO") }
+        verify { neo4jRepository.hasRelationshipOfType(
+            match {
+                it.id == entityId &&
+                    it.label == "Entity"
+            }, "CONNECTS_TO")
+        }
         verify { entityRepository.findById(eq(entityId)) }
-        verify { neo4jRepository.createRelationshipOfSubject(eq(entityId), any(), eq(targetEntityId)) }
+        verify {
+            neo4jRepository.createRelationshipOfSubject(
+                match {
+                    it.id == entityId &&
+                        it.label == "Entity"
+                }, any(), eq(targetEntityId))
+        }
 
         confirmVerified()
     }
@@ -579,7 +593,12 @@ class EntityServiceTests {
 
         entityService.appendEntityAttributes(entityId, expandedNewRelationship, true)
 
-        verify { neo4jRepository.hasRelationshipOfType(eq(entityId), "CONNECTS_TO") }
+        verify { neo4jRepository.hasRelationshipOfType(
+            match {
+                it.id == entityId &&
+                    it.label == "Entity"
+            }, "CONNECTS_TO")
+        }
 
         confirmVerified()
     }
@@ -618,7 +637,12 @@ class EntityServiceTests {
 
         entityService.appendEntityAttributes(entityId, expandedNewRelationship, false)
 
-        verify { neo4jRepository.hasRelationshipOfType(eq(entityId), "CONNECTS_TO") }
+        verify { neo4jRepository.hasRelationshipOfType(
+            match {
+                it.id == entityId &&
+                    it.label == "Entity"
+            }, "CONNECTS_TO")
+        }
         verify { neo4jRepository.deleteEntityRelationship(eq(entityId), "CONNECTS_TO") }
         verify { entityRepository.findById(eq(entityId)) }
 
@@ -655,12 +679,26 @@ class EntityServiceTests {
 
         entityService.appendEntityAttributes(entityId, expandedNewProperty, false)
 
-        verify { neo4jRepository.hasPropertyOfName(eq(entityId), "https://ontology.eglobalmark.com/aquac#fishNumber") }
+        verify {
+            neo4jRepository.hasPropertyOfName(
+                match {
+                    it.id == entityId &&
+                        it.label == "Entity"
+                },
+                "https://ontology.eglobalmark.com/aquac#fishNumber"
+            )
+        }
         verify { entityRepository.findById(eq(entityId)) }
-        verify { neo4jRepository.createPropertyOfSubject(eq(entityId), match {
-            it.value == 500 &&
-                it.name == "https://ontology.eglobalmark.com/aquac#fishNumber"
-        }) }
+        verify { neo4jRepository.createPropertyOfSubject(
+            match {
+                it.id == entityId &&
+                    it.label == "Entity"
+            },
+            match {
+                it.value == 500 &&
+                    it.name == "https://ontology.eglobalmark.com/aquac#fishNumber"
+            })
+        }
         verify { neo4jRepository.updateEntityModifiedDate(eq(entityId)) }
 
         confirmVerified()
@@ -856,7 +894,7 @@ class EntityServiceTests {
         every { mockkedRelationship.id } returns relationshipId
         every { mockkedNotification.id } returns notificationId
         every { mockkedLastNotification.id } returns lastNotificationId
-        every { neo4jRepository.updateRelationshipTargetOfAttribute(any(), any(), any(), any()) } returns Pair(1, 1)
+        every { neo4jRepository.updateRelationshipTargetOfAttribute(any(), any(), any(), any()) } returns 1
         every { relationshipRepository.save<Relationship>(any()) } returns mockkedRelationship
         every { neo4jRepository.deleteEntity(any()) } returns Pair(1, 1)
 


### PR DESCRIPTION
- use a node label in every MATCH clause
- use params instead of literals in queries (allows caching of query planning by neo4j)
- use existential subqueries to avoid cartesian products in entities search query
- remove HAS_OBJECT relationship between a relationship node and its target entity
- reduce intermediate results when deleting an entity or attribute