### PR TITLE
feat: complete support for JSON-LD @context resolution (6.3.5) #146

### DIFF
--- a/entity-service/src/test/kotlin/com/egm/stellio/entity/web/EntityHandlerTests.kt
+++ b/entity-service/src/test/kotlin/com/egm/stellio/entity/web/EntityHandlerTests.kt
@@ -99,7 +99,6 @@ class EntityHandlerTests {
 
         webClient.post()
             .uri("/ngsi-ld/v1/entities")
-            .header("Link", "<$aquacContext>; rel=http://www.w3.org/ns/json-ld#context; type=application/ld+json")
             .bodyValue(jsonLdFile)
             .exchange()
             .expectStatus().isCreated
@@ -114,7 +113,6 @@ class EntityHandlerTests {
 
         webClient.post()
             .uri("/ngsi-ld/v1/entities")
-            .header("Link", "<$aquacContext>; rel=http://www.w3.org/ns/json-ld#context; type=application/ld+json")
             .bodyValue(jsonLdFile)
             .exchange()
             .expectStatus().isEqualTo(409)
@@ -134,7 +132,6 @@ class EntityHandlerTests {
 
         webClient.post()
             .uri("/ngsi-ld/v1/entities")
-            .header("Link", "<$aquacContext>; rel=http://www.w3.org/ns/json-ld#context; type=application/ld+json")
             .bodyValue(jsonLdFile)
             .exchange()
             .expectStatus().isEqualTo(500)
@@ -189,7 +186,6 @@ class EntityHandlerTests {
 
         webClient.post()
             .uri("/ngsi-ld/v1/entities")
-            .header("Link", "<$aquacContext>; rel=http://www.w3.org/ns/json-ld#context; type=application/ld+json")
             .bodyValue(jsonLdFile)
             .exchange()
             .expectStatus().isBadRequest
@@ -554,6 +550,7 @@ class EntityHandlerTests {
         webClient.post()
             .uri("/ngsi-ld/v1/entities/$entityId/attrs")
             .header("Link", "<$aquacContext>; rel=http://www.w3.org/ns/json-ld#context; type=application/ld+json")
+            .contentType(MediaType.APPLICATION_JSON)
             .bodyValue(jsonLdFile)
             .exchange()
             .expectStatus().isNoContent
@@ -581,6 +578,7 @@ class EntityHandlerTests {
         webClient.post()
             .uri("/ngsi-ld/v1/entities/$entityId/attrs")
             .header("Link", "<$aquacContext>; rel=http://www.w3.org/ns/json-ld#context; type=application/ld+json")
+            .contentType(MediaType.APPLICATION_JSON)
             .bodyValue(jsonLdFile)
             .exchange()
             .expectStatus().isEqualTo(HttpStatus.MULTI_STATUS)
@@ -634,6 +632,7 @@ class EntityHandlerTests {
         webClient.post()
             .uri("/ngsi-ld/v1/entities/$entityId/attrs")
             .header("Link", "<$aquacContext>; rel=http://www.w3.org/ns/json-ld#context; type=application/ld+json")
+            .contentType(MediaType.APPLICATION_JSON)
             .bodyValue(invalidPayload)
             .exchange()
             .expectStatus().isBadRequest
@@ -658,11 +657,12 @@ class EntityHandlerTests {
         webClient.patch()
             .uri("/ngsi-ld/v1/entities/$entityId/attrs/$attrId")
             .header("Link", "<$aquacContext>; rel=http://www.w3.org/ns/json-ld#context; type=application/ld+json")
+            .contentType(MediaType.APPLICATION_JSON)
             .bodyValue(jsonLdFile)
             .exchange()
             .expectStatus().isNoContent
 
-        verify { entityService.updateEntityAttribute(eq(entityId), eq(attrId), any(), eq(aquacContext!!)) }
+        verify { entityService.updateEntityAttribute(eq(entityId), eq(attrId), any(), eq(listOf(aquacContext!!))) }
         confirmVerified(entityService)
     }
 
@@ -677,12 +677,16 @@ class EntityHandlerTests {
                 any(),
                 any()
             )
-        } returns UpdateResult(updated = arrayListOf("fishNumber"), notUpdated = arrayListOf())
+        } returns UpdateResult(
+            updated = arrayListOf("https://ontology.eglobalmark.com/aquac#fishNumber"),
+            notUpdated = arrayListOf()
+        )
         every { repositoryEventsListener.handleRepositoryEvent(any()) } just Runs
 
         webClient.patch()
             .uri("/ngsi-ld/v1/entities/$entityId/attrs")
             .header("Link", "<$aquacContext>; rel=http://www.w3.org/ns/json-ld#context; type=application/ld+json")
+            .contentType(MediaType.APPLICATION_JSON)
             .bodyValue(jsonLdFile)
             .exchange()
             .expectStatus().isNoContent
@@ -703,12 +707,16 @@ class EntityHandlerTests {
                 any(),
                 any()
             )
-        } returns UpdateResult(updated = arrayListOf("fishNumber"), notUpdated = arrayListOf())
+        } returns UpdateResult(
+            updated = arrayListOf("https://ontology.eglobalmark.com/aquac#fishNumber"),
+            notUpdated = arrayListOf()
+        )
         every { repositoryEventsListener.handleRepositoryEvent(any()) } just Runs
 
         webClient.patch()
             .uri("/ngsi-ld/v1/entities/$entityId/attrs")
             .header("Link", "<$aquacContext>; rel=http://www.w3.org/ns/json-ld#context; type=application/ld+json")
+            .contentType(MediaType.APPLICATION_JSON)
             .bodyValue(jsonPayload)
             .exchange()
             .expectStatus().isNoContent
@@ -755,7 +763,12 @@ class EntityHandlerTests {
                 any(),
                 any()
             )
-        } returns UpdateResult(updated = arrayListOf("fishName", "fishNumber"), notUpdated = arrayListOf())
+        } returns UpdateResult(
+            updated = arrayListOf(
+                "https://ontology.eglobalmark.com/aquac#fishName",
+                "https://ontology.eglobalmark.com/aquac#fishNumber"),
+            notUpdated = arrayListOf()
+        )
 
         val events = mutableListOf<EntityEvent>()
         every { repositoryEventsListener.handleRepositoryEvent(capture(events)) } just Runs
@@ -763,6 +776,7 @@ class EntityHandlerTests {
         webClient.patch()
             .uri("/ngsi-ld/v1/entities/$entityId/attrs")
             .header("Link", "<$aquacContext>; rel=http://www.w3.org/ns/json-ld#context; type=application/ld+json")
+            .contentType(MediaType.APPLICATION_JSON)
             .bodyValue(jsonPayload)
             .exchange()
             .expectStatus().isNoContent
@@ -799,12 +813,16 @@ class EntityHandlerTests {
                 any(),
                 any()
             )
-        } returns UpdateResult(updated = arrayListOf("fishNumber"), notUpdated = arrayListOf(notUpdatedAttribute))
+        } returns UpdateResult(
+            updated = arrayListOf("https://ontology.eglobalmark.com/aquac#fishNumber"),
+            notUpdated = arrayListOf(notUpdatedAttribute)
+        )
         every { repositoryEventsListener.handleRepositoryEvent(any()) } just Runs
 
         webClient.patch()
             .uri("/ngsi-ld/v1/entities/$entityId/attrs")
             .header("Link", "<$aquacContext>; rel=http://www.w3.org/ns/json-ld#context; type=application/ld+json")
+            .contentType(MediaType.APPLICATION_JSON)
             .bodyValue(jsonLdFile)
             .exchange()
             .expectStatus().isEqualTo(HttpStatus.MULTI_STATUS)
@@ -832,6 +850,7 @@ class EntityHandlerTests {
                 "Link",
                 "<http://easyglobalmarket.com/contexts/diat.jsonld>; rel=http://www.w3.org/ns/json-ld#context; type=application/ld+json"
             )
+            .contentType(MediaType.APPLICATION_JSON)
             .bodyValue(payload)
             .exchange()
             .expectStatus().isBadRequest

--- a/search-service/src/test/kotlin/com/egm/stellio/search/web/TemporalEntityHandlerTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/web/TemporalEntityHandlerTests.kt
@@ -19,9 +19,11 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
 import org.springframework.context.annotation.Import
 import org.springframework.core.io.ClassPathResource
+import org.springframework.http.MediaType
 import org.springframework.security.test.context.support.WithAnonymousUser
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.ActiveProfiles
@@ -38,6 +40,9 @@ import java.util.UUID
 @Import(WebSecurityTestConfig::class)
 @WithMockUser
 class TemporalEntityHandlerTests {
+
+    @Value("\${application.jsonld.apic_context}")
+    val apicContext: String? = null
 
     @Autowired
     private lateinit var webClient: WebTestClient
@@ -74,6 +79,8 @@ class TemporalEntityHandlerTests {
 
         webClient.post()
             .uri("/ngsi-ld/v1/temporal/entities/urn:ngsi-ld:BeeHive:TESTC/attrs")
+            .header("Link", "<$apicContext>; rel=http://www.w3.org/ns/json-ld#context; type=application/ld+json")
+            .contentType(MediaType.APPLICATION_JSON)
             .body(BodyInserters.fromValue(jsonLdObservation.inputStream.readAllBytes()))
             .exchange()
             .expectStatus().isNoContent
@@ -102,6 +109,8 @@ class TemporalEntityHandlerTests {
 
         webClient.post()
             .uri("/ngsi-ld/v1/temporal/entities/entityId/attrs")
+            .header("Link", "<$apicContext>; rel=http://www.w3.org/ns/json-ld#context; type=application/ld+json")
+            .contentType(MediaType.APPLICATION_JSON)
             .body(BodyInserters.fromValue("{ \"id\": \"bad\" }"))
             .exchange()
             .expectStatus().isBadRequest

--- a/shared/src/main/kotlin/com/egm/stellio/shared/util/JsonLdUtils.kt
+++ b/shared/src/main/kotlin/com/egm/stellio/shared/util/JsonLdUtils.kt
@@ -256,13 +256,7 @@ object JsonLdUtils {
     fun compactAndStringifyFragment(key: String, value: Any, context: List<String>): String {
         val compactedFragment =
             JsonLdProcessor.compact(mapOf(key to value), mapOf("@context" to context), JsonLdOptions())
-        return mapper.writeValueAsString(compactedFragment)
-    }
-
-    fun compactAndStringifyFragment(key: String, value: Any, context: String): String {
-        val compactedFragment =
-            JsonLdProcessor.compact(mapOf(key to value), mapOf("@context" to context), JsonLdOptions())
-        return mapper.writeValueAsString(compactedFragment)
+        return mapper.writeValueAsString(compactedFragment.minus("@context"))
     }
 
     fun compactAndSerialize(jsonLdEntity: JsonLdEntity): String =

--- a/subscription-service/src/test/kotlin/com/egm/stellio/subscription/web/SubscriptionHandlerTests.kt
+++ b/subscription-service/src/test/kotlin/com/egm/stellio/subscription/web/SubscriptionHandlerTests.kt
@@ -168,11 +168,13 @@ class SubscriptionHandlerTests {
             .bodyValue(jsonLdFile)
             .exchange()
             .expectStatus().isBadRequest
-            .expectBody().json(
-                "{\"type\":\"https://uri.etsi.org/ngsi-ld/errors/BadRequestData\"," +
-                    "\"title\":\"The request includes input data which does not meet the requirements of the operation\"," +
-                    "\"detail\":\"Context not provided\"}"
-            )
+            .expectBody().json("""
+                {
+                    "type":"https://uri.etsi.org/ngsi-ld/errors/BadRequestData",
+                    "title":"The request includes input data which does not meet the requirements of the operation",
+                    "detail":"JSON-LD @context not found in request payload body"
+                } 
+            """.trimIndent())
     }
 
     @Test
@@ -369,11 +371,13 @@ class SubscriptionHandlerTests {
             .bodyValue(jsonLdFile)
             .exchange()
             .expectStatus().isBadRequest
-            .expectBody().json(
-                "{\"type\":\"https://uri.etsi.org/ngsi-ld/errors/BadRequestData\"," +
-                    "\"title\":\"The request includes input data which does not meet the requirements of the operation\"," +
-                    "\"detail\":\"Context not provided\"}"
-            )
+            .expectBody().json("""
+                {
+                    "type":"https://uri.etsi.org/ngsi-ld/errors/BadRequestData",
+                    "title":"The request includes input data which does not meet the requirements of the operation",
+                    "detail":"JSON-LD @context not found in request payload body"
+                } 
+            """.trimIndent())
 
         verify { subscriptionService.exists(eq(subscriptionId)) }
         verify { subscriptionService.isCreatorOf(subscriptionId, "mock-user") }


### PR DESCRIPTION
- GET or DELETE: get context from Link header or fallback to default JSON-LD @context
- POST or PATH: get context according to content type (error if not provided or mixed)