### PR TITLE
fix(subscription): fix warning message when a subscription query contains an unknown attribute #144

### DIFF
--- a/subscription-service/src/main/kotlin/com/egm/stellio/subscription/service/SubscriptionService.kt
+++ b/subscription-service/src/main/kotlin/com/egm/stellio/subscription/service/SubscriptionService.kt
@@ -420,7 +420,6 @@ class SubscriptionService(
             try {
                 runQuery(query, entity)
             } catch (e: Exception) {
-                logger.warn(e.message)
                 false
             }
         }

--- a/subscription-service/src/main/kotlin/com/egm/stellio/subscription/utils/QueryUtils.kt
+++ b/subscription-service/src/main/kotlin/com/egm/stellio/subscription/utils/QueryUtils.kt
@@ -140,7 +140,7 @@ object QueryUtils {
             try {
                 node = node.get(it)
             } catch (e: Exception) {
-                throw BadRequestDataException(e.message ?: "Unresolved value $it")
+                throw BadRequestDataException("Unmatched query since it contains an unknown attribute $it")
             }
         }
 


### PR DESCRIPTION
The  `"node.get(it) must not be null"` warning is returned when a matching subscription has an unknown attribute in its query.   