### PR TITLE
Add common NGSI-LD test suite.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: node_js
+node_js:
+  - 12.14
+
+services:
+  - docker
+
+install : >
+  curl -LO https://github.com/FIWARE/NGSI-LD_TestSuite/archive/master.zip;
+  shasum -a 256 master.zip;
+  unzip -q master.zip;
+  rm master.zip;
+  cd NGSI-LD_TestSuite-master;  
+  export EXCLUDED_TESTS="003|004|";
+  npm install;
+  docker-compose --log-level ERROR -f docker-compose/stellio.yml pull --ignore-pull-failures 
+
+script:  >
+   echo -e " \033[1;33mRunning NGSI-LD Integration Test Suite";
+   ./services stellio;
+   export TEST_ENDPOINT=http://localhost:8080;
+   npm test;


### PR DESCRIPTION
I have added Stellio Broker to the [FIWARE NGSI-LD_TestSuite](https://travis-ci.org/github/FIWARE/NGSI-LD_TestSuite/builds/721288348) - you can compare the results with Scorpio and Orion-LD.

This PR adds a set of common NGSI-LD compliance tests for your own use.

- Loads common compliance tests
- retrieves latest docker images
- runs tests  - current result [here](https://travis-ci.org/github/jason-fox/stellio-context-broker/builds/721294686)

You'll need to sign up for travis to get it to run obviously.

