### PR TITLE
Make Docker Build standalone

### DIFF
--- a/api-gateway/Dockerfile
+++ b/api-gateway/Dockerfile
@@ -1,7 +1,85 @@
-FROM adoptopenjdk/openjdk11:alpine-jre
-RUN addgroup -S stellio && adduser -S stellio -G stellio
-USER stellio:stellio
-ARG JAR_FILE=build/libs/*.jar
-COPY ${JAR_FILE} app.jar
-ENTRYPOINT ["java","-jar","/app.jar"]
+ARG GITHUB_ACCOUNT=stellio-hub
+ARG GITHUB_REPOSITORY=stellio-context-broker
+ARG DOWNLOAD=latest
+ARG SOURCE_BRANCH=develop
+ARG JAVA_VERSION=11
 
+########################################################################################
+#
+# This build stage retrieves the source code from GitHub. The default download is the 
+# latest tip of the master of the named repository on GitHub.
+#
+######################################################################################## 
+
+FROM openjdk:${JAVA_VERSION}-jdk-slim AS builder
+ARG GITHUB_ACCOUNT
+ARG GITHUB_REPOSITORY
+ARG DOWNLOAD
+ARG SOURCE_BRANCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# hadolint ignore=DL3008
+RUN \
+	# Ensure that unzip is installed prior to downloading
+	apt-get update && \
+	apt-get install -y --no-install-recommends unzip curl && \
+	if [ "${DOWNLOAD}" = "latest" ] ; \
+	then \
+		RELEASE="${SOURCE_BRANCH}"; \
+		echo "INFO: Building Latest Development from ${SOURCE_BRANCH} branch."; \
+	elif [ "${DOWNLOAD}" = "stable" ]; \
+	then \
+		RELEASE=$(curl -s https://api.github.com/repos/"${GITHUB_ACCOUNT}"/"${GITHUB_REPOSITORY}"/releases/latest | grep 'tag_name' | cut -d\" -f4); \
+		echo "INFO: Building Latest Stable Release: ${RELEASE}"; \
+	else \
+	 	RELEASE="${DOWNLOAD}"; \
+	 	echo "INFO: Building Release: ${RELEASE}"; \
+	fi && \
+	RELEASE_CONCAT=$(echo "${RELEASE}" | tr / -); \
+	curl -s -L https://github.com/"${GITHUB_ACCOUNT}"/"${GITHUB_REPOSITORY}"/archive/"${RELEASE}".zip > source.zip && \
+	unzip source.zip && \
+	rm source.zip && \
+	mv "${GITHUB_REPOSITORY}-${RELEASE_CONCAT}" /source
+
+WORKDIR /source
+RUN ./gradlew build -p api-gateway
+COPY build/libs/*.jar /source/app.jar
+
+########################################################################################
+#
+# This build stage creates an anonymous user to be used with the distroless build
+# as defined below.
+#
+########################################################################################
+FROM openjdk:${JAVA_VERSION}-jdk-slim AS anon-user
+RUN sed -i -r "/^(root|nobody)/!d" /etc/passwd /etc/shadow /etc/group \
+    && sed -i -r 's#^(.*):[^:]*$#\1:/sbin/nologin#' /etc/passwd
+
+########################################################################################
+#
+# This build stage creates a distroless image for production.
+#
+########################################################################################
+
+FROM gcr.io/distroless/java:${JAVA_VERSION}
+ARG GITHUB_ACCOUNT
+ARG GITHUB_REPOSITORY
+ARG JAVA_VERSION
+
+LABEL "maintainer"="EGM"
+LABEL "org.opencontainers.image.authors"="EGM"
+LABEL "org.opencontainers.image.documentation"="https://stellio.readthedocs.io/"
+LABEL "org.opencontainers.image.vendor"="EGM"
+LABEL "org.opencontainers.image.licenses"="Apache-2.0"
+LABEL "org.opencontainers.image.title"="Stellio context broker"
+LABEL "org.opencontainers.image.description"="Stellio is an NGSI-LD compliant context broker developed by EGM. NGSI-LD is an Open API and Datamodel specification for context management published by ETSI."
+LABEL "org.opencontainers.image.source"="https://github.com/${GITHUB_ACCOUNT}/${GITHUB_REPOSITORY}"
+LABEL "com.java.version"="${JAVA_VERSION}"
+
+COPY --from=anon-user /etc/passwd /etc/shadow /etc/group /etc/
+COPY --from=builder /source/app.jar /app/app.jar
+WORKDIR /app
+
+USER nobody
+CMD ["app.jar"]

--- a/api-gateway/Dockerfile
+++ b/api-gateway/Dockerfile
@@ -40,7 +40,12 @@ RUN \
 	curl -s -L https://github.com/"${GITHUB_ACCOUNT}"/"${GITHUB_REPOSITORY}"/archive/"${RELEASE}".zip > source.zip && \
 	unzip source.zip && \
 	rm source.zip && \
-	mv "${GITHUB_REPOSITORY}-${RELEASE_CONCAT}" /source
+	if ! case $DOWNLOAD in v*) false;; esac; \
+	then \
+    	mv "${GITHUB_REPOSITORY}-${RELEASE_CONCAT#?}" /source; \
+    else \
+    	mv "${GITHUB_REPOSITORY}-${RELEASE_CONCAT}" /source; \
+	fi
 
 WORKDIR /source
 RUN ./gradlew build -p api-gateway


### PR DESCRIPTION
This PR makes the docker build reproducible by other users without the need to run Gradle prior to running docker. The code is obtained directly before building and the final build is **Distroless**


- Add standard metadata build `LABEL` (see [opencontainers.org](https://github.com/opencontainers/opencontainers.org))
- Create multi-stage build process  using a **Distroless** build:

     -    Remove [disto](https://medium.com/@dwdraju/distroless-is-for-security-if-not-for-size-6eac789f695f)
     -    Run as anonymous user

There is not much size difference compared with Alpine, but there is a security side-effect. You can no longer run bash within the container

```console
docker exec -it stellio /bin/bash
```
```text
OCI runtime exec failed: exec failed: container_linux.go:349: starting container process caused "exec: \"/bin/bash\": stat /bin/bash: no such file or directory": unknown
```