### PR TITLE
fix: allow to use subscription service when authentication is disabled

### DIFF
--- a/shared/src/main/kotlin/com/egm/stellio/shared/web/AuthUtils.kt
+++ b/shared/src/main/kotlin/com/egm/stellio/shared/web/AuthUtils.kt
@@ -1,18 +1,9 @@
 package com.egm.stellio.shared.web
 
-import org.springframework.security.core.Authentication
 import org.springframework.security.core.context.ReactiveSecurityContextHolder
-import org.springframework.security.core.context.SecurityContext
 import org.springframework.security.core.context.SecurityContextImpl
 import org.springframework.security.oauth2.jwt.Jwt
 import reactor.core.publisher.Mono
-
-fun extractJwT(): Mono<Jwt> {
-    return ReactiveSecurityContextHolder.getContext()
-        .map(SecurityContext::getAuthentication)
-        .map(Authentication::getPrincipal)
-        .cast(Jwt::class.java)
-}
 
 fun extractSubjectOrEmpty(): Mono<String> {
     return ReactiveSecurityContextHolder.getContext()


### PR DESCRIPTION
- currently, if no JWT is retrieved, the flow stops and a 200 status code is returned
- use the same method as in entity service to allow no JWT when auth is disabled