### PR TITLE
feat(common): improve produced Docker images

### DIFF
--- a/api-gateway/build.gradle.kts
+++ b/api-gateway/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
 
 jib.from.image = project.ext["jibFromImage"].toString()
 jib.to.image = "stellio/stellio-api-gateway"
-jib.container.jvmFlags = listOf(project.ext["jibContainerJvmFlag"].toString())
+jib.container.jvmFlags = project.ext["jibContainerJvmFlags"] as List<String>
 jib.container.ports = listOf("8080")
 jib.container.creationTime = project.ext["jibContainerCreationTime"].toString()
 jib.container.labels = project.ext["jibContainerLabels"] as Map<String, String>

--- a/api-gateway/build.gradle.kts
+++ b/api-gateway/build.gradle.kts
@@ -14,3 +14,4 @@ jib.to.image = "stellio/stellio-api-gateway"
 jib.container.jvmFlags = listOf(project.ext["jibContainerJvmFlag"].toString())
 jib.container.ports = listOf("8080")
 jib.container.creationTime = project.ext["jibContainerCreationTime"].toString()
+jib.container.labels = project.ext["jibContainerLabels"] as Map<String, String>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
     kotlin("jvm") version "1.3.72" apply false
     kotlin("plugin.spring") version "1.3.72" apply false
     id("org.jlleitschuh.gradle.ktlint") version "9.3.0"
-    id("com.google.cloud.tools.jib") version "1.6.1" apply false
+    id("com.google.cloud.tools.jib") version "2.5.0" apply false
     kotlin("kapt") version "1.3.61" apply false
     id("io.gitlab.arturbosch.detekt") version "1.11.2" apply false
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -123,7 +123,7 @@ subprojects {
         }
     }
 
-    project.ext.set("jibFromImage", "adoptopenjdk/openjdk11:alpine-jre")
+    project.ext.set("jibFromImage", "gcr.io/distroless/java:11")
     project.ext.set("jibContainerJvmFlag", "-Xms512m")
     project.ext.set("jibContainerCreationTime", "USE_CURRENT_TIMESTAMP")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -124,7 +124,7 @@ subprojects {
     }
 
     project.ext.set("jibFromImage", "gcr.io/distroless/java:11")
-    project.ext.set("jibContainerJvmFlag", "-Xms512m")
+    project.ext.set("jibContainerJvmFlags", listOf("-Xms256m", "-Xmx768m"))
     project.ext.set("jibContainerCreationTime", "USE_CURRENT_TIMESTAMP")
     project.ext.set("jibContainerLabels", mapOf(
         "maintainer" to "EGM",

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -126,6 +126,21 @@ subprojects {
     project.ext.set("jibFromImage", "gcr.io/distroless/java:11")
     project.ext.set("jibContainerJvmFlag", "-Xms512m")
     project.ext.set("jibContainerCreationTime", "USE_CURRENT_TIMESTAMP")
+    project.ext.set("jibContainerLabels", mapOf(
+        "maintainer" to "EGM",
+        "org.opencontainers.image.authors" to "EGM",
+        "org.opencontainers.image.documentation" to "https://stellio.readthedocs.io/",
+        "org.opencontainers.image.vendor" to "EGM",
+        "org.opencontainers.image.licenses" to "Apache-2.0",
+        "org.opencontainers.image.title" to "Stellio context broker",
+        "org.opencontainers.image.description" to
+            """
+                Stellio is an NGSI-LD compliant context broker developed by EGM. 
+                NGSI-LD is an Open API and data model specification for context management published by ETSI.
+            """.trimIndent(),
+        "org.opencontainers.image.source" to "https://github.com/stellio-hub/stellio-context-broker",
+        "com.java.version" to "${JavaVersion.VERSION_11}"
+    ))
 }
 
 allprojects {

--- a/entity-service/build.gradle.kts
+++ b/entity-service/build.gradle.kts
@@ -46,4 +46,5 @@ jib.container.entrypoint = listOf(
 jib.container.environment = mapOf("NEO4J_WAIT_TIMEOUT" to "100")
 jib.container.ports = listOf("8082")
 jib.container.creationTime = project.ext["jibContainerCreationTime"].toString()
+jib.container.labels = project.ext["jibContainerLabels"] as Map<String, String>
 jib.extraDirectories.permissions = mapOf("/database/wait-for-neo4j.sh" to "775")

--- a/entity-service/build.gradle.kts
+++ b/entity-service/build.gradle.kts
@@ -40,7 +40,7 @@ jib.container.entrypoint = listOf(
     "/bin/sh", "-c",
     "/database/wait-for-neo4j.sh neo4j:7687 -t \$NEO4J_WAIT_TIMEOUT -- " +
         "java " +
-        project.ext["jibContainerJvmFlag"].toString() +
+        (project.ext["jibContainerJvmFlags"] as List<String>).joinToString(" ") +
         " -cp /app/resources:/app/classes:/app/libs/* " + mainClass
 )
 jib.container.environment = mapOf("NEO4J_WAIT_TIMEOUT" to "100")

--- a/search-service/build.gradle.kts
+++ b/search-service/build.gradle.kts
@@ -46,7 +46,7 @@ tasks.bootRun {
 
 jib.from.image = project.ext["jibFromImage"].toString()
 jib.to.image = "stellio/stellio-search-service"
-jib.container.jvmFlags = listOf(project.ext["jibContainerJvmFlag"].toString())
+jib.container.jvmFlags = project.ext["jibContainerJvmFlags"] as List<String>
 jib.container.ports = listOf("8083")
 jib.container.creationTime = project.ext["jibContainerCreationTime"].toString()
 jib.container.labels = project.ext["jibContainerLabels"] as Map<String, String>

--- a/search-service/build.gradle.kts
+++ b/search-service/build.gradle.kts
@@ -49,3 +49,4 @@ jib.to.image = "stellio/stellio-search-service"
 jib.container.jvmFlags = listOf(project.ext["jibContainerJvmFlag"].toString())
 jib.container.ports = listOf("8083")
 jib.container.creationTime = project.ext["jibContainerCreationTime"].toString()
+jib.container.labels = project.ext["jibContainerLabels"] as Map<String, String>

--- a/subscription-service/build.gradle.kts
+++ b/subscription-service/build.gradle.kts
@@ -48,7 +48,7 @@ tasks.bootRun {
 
 jib.from.image = project.ext["jibFromImage"].toString()
 jib.to.image = "stellio/stellio-subscription-service"
-jib.container.jvmFlags = listOf(project.ext["jibContainerJvmFlag"].toString())
+jib.container.jvmFlags = project.ext["jibContainerJvmFlags"] as List<String>
 jib.container.ports = listOf("8084")
 jib.container.creationTime = project.ext["jibContainerCreationTime"].toString()
 jib.container.labels = project.ext["jibContainerLabels"] as Map<String, String>

--- a/subscription-service/build.gradle.kts
+++ b/subscription-service/build.gradle.kts
@@ -51,3 +51,4 @@ jib.to.image = "stellio/stellio-subscription-service"
 jib.container.jvmFlags = listOf(project.ext["jibContainerJvmFlag"].toString())
 jib.container.ports = listOf("8084")
 jib.container.creationTime = project.ext["jibContainerCreationTime"].toString()
+jib.container.labels = project.ext["jibContainerLabels"] as Map<String, String>


### PR DESCRIPTION
Following suggestions from #160, this PR switches the base image used in Docker images to a distroless version of Java.

It also add standard Docker and OCI labels in the produced images.