### PR TITLE
feat(common): add version tag on docker images #156

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -15,12 +15,12 @@ jobs:
         uses: cla-assistant/github-action@v2.0.1-alpha
         env: 
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # the below token should have repo scope and must be manually added by you in the repository's secret
+          PERSONAL_ACCESS_TOKEN : ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         with:
           path-to-signatures: 'docs/cla/cla.json'
-          path-to-document: 'https://fiware.github.io/contribution-requirements/individual-cla.pdf' # e.g. a CLA or a DCO document
+          path-to-cla-document: 'https://fiware.github.io/contribution-requirements/individual-cla.pdf' # e.g. a CLA or a DCO document
           # branch should not be protected
           branch: 'master'
           allowlist: bobeal,franckLG,HoucemKacem,bot*
-          empty-commit-flag: false
-          blockchain-storage-flag: false
-          use-dco-flag: false #'Set this to true if you want to use a dco instead of a cla'
+          signed-commit-message: '$contributorName has signed the CLA in #$pullRequestNo'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -158,6 +158,21 @@ pipeline {
                 sh './gradlew jib -Djib.to.auth.username=$EGM_CI_DH_USR -Djib.to.auth.password=$EGM_CI_DH_PSW -p search-service'
             }
         }
+        stage('Build tagger Docker images') {
+            when {
+                branch 'master'
+                tag 'v*'
+            }
+            environment {
+                GIT_TAG = sh(returnStdout: true, script: "git describe --tags --abbrev=0").trim().substring(1)
+            }
+            steps {
+                sh './gradlew jib -Djib.to.image=stellio/stellio-api-gateway:${GIT_TAG} -Djib.to.auth.username=$EGM_CI_DH_USR -Djib.to.auth.password=$EGM_CI_DH_PSW -p api-gateway'
+                sh './gradlew jib -Djib.to.image=stellio/stellio-entity-service:${GIT_TAG} -Djib.to.auth.username=$EGM_CI_DH_USR -Djib.to.auth.password=$EGM_CI_DH_PSW -p entity-service'
+                sh './gradlew jib -Djib.to.image=stellio/stellio-search-service:${GIT_TAG} -Djib.to.auth.username=$EGM_CI_DH_USR -Djib.to.auth.password=$EGM_CI_DH_PSW -p search-service'
+                sh './gradlew jib -Djib.to.image=stellio/stellio-subscription-service:${GIT_TAG} -Djib.to.auth.username=$EGM_CI_DH_USR -Djib.to.auth.password=$EGM_CI_DH_PSW -p subscription-service'
+            }
+        }
     }
     post {
         always {


### PR DESCRIPTION
Support added in Jenkinsfile:
- when event is a new tag event, extract the tag from Git
- build and publish tagged images in Docker Hub

Still TODO:
- Jenkins receives the push event (`Received Push event for tag v0.0.0.2 in repository stellio-hub/stellio-context-broker CREATED event ...`) ... but does not trigger a build event (`No automatic build triggered for v0.0.0.2`). Some directions to follow: https://notesfromthelifeboat.com/post/building-git-tags-with-jenkins/ (and https://github.com/jenkinsci/basic-branch-build-strategies-plugin) 