### PR TITLE
fix(entity): remove noisy warn message when a group or user role does not exist

### DIFF
--- a/entity-service/src/main/kotlin/com/egm/stellio/entity/authorization/Neo4jAuthorizationRepository.kt
+++ b/entity-service/src/main/kotlin/com/egm/stellio/entity/authorization/Neo4jAuthorizationRepository.kt
@@ -88,13 +88,13 @@ class Neo4jAuthorizationRepository(
     }
 
     private fun propertyToListOfRoles(property: Any?): List<String> {
-        val rolesProperty = property as Property?
+        val rolesProperty = property as Property? ?: return emptyList()
 
-        return when (rolesProperty?.value) {
+        return when (rolesProperty.value) {
             is String -> listOf(rolesProperty.value as String)
             is List<*> -> rolesProperty.value as List<String>
             else -> {
-                logger.warn("Unknown value type for roles property: ${rolesProperty?.value}")
+                logger.warn("Unknown value type for roles property: ${rolesProperty.value}")
                 emptyList()
             }
         }


### PR DESCRIPTION
It is not mandatory that an user has personal and group roles ... so don't warn about it.
