### PR TITLE
feat: add cors configuration in api gateway #295

### DIFF
--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -41,6 +41,16 @@ spring:
           filters:
             - TokenRelay=
             - RewritePath=/subscription-service/actuator, /actuator
+      globalcors:
+        corsConfigurations:
+          '[/ngsi-ld/v1/**]':
+            allowedOrigins: ${APPLICATION_CORS_ALLOWED_ORIGINS:http://localhost:3000}
+            allowedMethods:
+              - GET
+              - POST
+              - PATCH
+              - DELETE
+            allowedHeaders: "*"
 
 # Default values for sending log data to a Gelf compatible endpoint
 # Log data is sent only if the 'gelflogs' Spring profile is active

--- a/entity-service/src/main/kotlin/com/egm/stellio/entity/config/WebConfig.kt
+++ b/entity-service/src/main/kotlin/com/egm/stellio/entity/config/WebConfig.kt
@@ -8,7 +8,7 @@ import org.springframework.web.reactive.config.WebFluxConfigurer
 @Configuration
 @EnableWebFlux
 class WebConfig : WebFluxConfigurer {
-    // relaunch tests
+
     override fun configureHttpMessageCodecs(configurer: ServerCodecConfigurer) {
         configurer.defaultCodecs().enableLoggingRequestDetails(true)
     }

--- a/entity-service/src/main/kotlin/com/egm/stellio/entity/config/WebConfig.kt
+++ b/entity-service/src/main/kotlin/com/egm/stellio/entity/config/WebConfig.kt
@@ -8,7 +8,7 @@ import org.springframework.web.reactive.config.WebFluxConfigurer
 @Configuration
 @EnableWebFlux
 class WebConfig : WebFluxConfigurer {
-
+    // re-launch tests
     override fun configureHttpMessageCodecs(configurer: ServerCodecConfigurer) {
         configurer.defaultCodecs().enableLoggingRequestDetails(true)
     }

--- a/entity-service/src/main/kotlin/com/egm/stellio/entity/config/WebConfig.kt
+++ b/entity-service/src/main/kotlin/com/egm/stellio/entity/config/WebConfig.kt
@@ -8,7 +8,7 @@ import org.springframework.web.reactive.config.WebFluxConfigurer
 @Configuration
 @EnableWebFlux
 class WebConfig : WebFluxConfigurer {
-    // re-launch tests
+
     override fun configureHttpMessageCodecs(configurer: ServerCodecConfigurer) {
         configurer.defaultCodecs().enableLoggingRequestDetails(true)
     }

--- a/entity-service/src/main/kotlin/com/egm/stellio/entity/config/WebConfig.kt
+++ b/entity-service/src/main/kotlin/com/egm/stellio/entity/config/WebConfig.kt
@@ -8,7 +8,7 @@ import org.springframework.web.reactive.config.WebFluxConfigurer
 @Configuration
 @EnableWebFlux
 class WebConfig : WebFluxConfigurer {
-
+    // relaunch tests
     override fun configureHttpMessageCodecs(configurer: ServerCodecConfigurer) {
         configurer.defaultCodecs().enableLoggingRequestDetails(true)
     }

--- a/entity-service/src/main/kotlin/com/egm/stellio/entity/config/WebSecurityConfig.kt
+++ b/entity-service/src/main/kotlin/com/egm/stellio/entity/config/WebSecurityConfig.kt
@@ -1,22 +1,13 @@
 package com.egm.stellio.entity.config
 
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.web.server.ServerHttpSecurity
 import org.springframework.security.web.server.SecurityWebFilterChain
-import org.springframework.web.cors.CorsConfiguration
-import org.springframework.web.cors.reactive.CorsConfigurationSource
-import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource
 
 @Configuration
 class WebSecurityConfig {
-
-    @Value("\${application.cors.allowed_origins}")
-    val allowedOrigins: List<String>? = null
-    val allowedMethods = listOf("GET", "POST", "PATCH", "DELETE")
-
     @Bean
     @ConditionalOnProperty("application.authentication.enabled")
     fun springSecurityFilterChain(http: ServerHttpSecurity): SecurityWebFilterChain {
@@ -42,16 +33,5 @@ class WebSecurityConfig {
             .authorizeExchange().pathMatchers("/**").permitAll()
 
         return http.build()
-    }
-
-    @Bean
-    fun corsConfigurationSource(): CorsConfigurationSource {
-        val corsConfig = CorsConfiguration()
-        corsConfig.allowedOrigins = allowedOrigins
-        corsConfig.allowedMethods = allowedMethods
-        corsConfig.addAllowedHeader("*")
-        val source = UrlBasedCorsConfigurationSource()
-        source.registerCorsConfiguration("/ngsi-ld/v1/**", corsConfig)
-        return source
     }
 }

--- a/entity-service/src/main/resources/application.properties
+++ b/entity-service/src/main/resources/application.properties
@@ -31,6 +31,3 @@ org.neo4j.driver.authentication.password=neo4j_password
 org.neo4j.driver.uri=bolt://localhost:7687
 # Disable the check if the location exists
 org.neo4j.migrations.check-location=false
-
-# CORS configuration
-application.cors.allowed_origins=http://localhost:3000

--- a/search-service/src/main/kotlin/com/egm/stellio/search/config/WebSecurityConfig.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/config/WebSecurityConfig.kt
@@ -1,21 +1,13 @@
 package com.egm.stellio.search.config
 
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.web.server.ServerHttpSecurity
 import org.springframework.security.web.server.SecurityWebFilterChain
-import org.springframework.web.cors.CorsConfiguration
-import org.springframework.web.cors.reactive.CorsConfigurationSource
-import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource
 
 @Configuration
 class WebSecurityConfig {
-
-    @Value("\${application.cors.allowed_origins}")
-    val allowedOrigins: List<String>? = null
-    val allowedMethods = listOf("GET", "POST", "PATCH", "DELETE")
 
     @Bean
     @ConditionalOnProperty("application.authentication.enabled")
@@ -42,16 +34,5 @@ class WebSecurityConfig {
             .authorizeExchange().pathMatchers("/**").permitAll()
 
         return http.build()
-    }
-
-    @Bean
-    fun corsConfigurationSource(): CorsConfigurationSource {
-        val corsConfig = CorsConfiguration()
-        corsConfig.allowedOrigins = allowedOrigins
-        corsConfig.allowedMethods = allowedMethods
-        corsConfig.addAllowedHeader("*")
-        val source = UrlBasedCorsConfigurationSource()
-        source.registerCorsConfiguration("/ngsi-ld/v1/**", corsConfig)
-        return source
     }
 }

--- a/search-service/src/main/resources/application.properties
+++ b/search-service/src/main/resources/application.properties
@@ -37,6 +37,3 @@ spring.mvc.log-request-details = true
 # application.graylog.host = localhost
 # application.graylog.port = 12201
 # application.graylog.source = stellio-int
-
-# CORS configuration
-application.cors.allowed_origins=http://localhost:3000

--- a/subscription-service/src/main/kotlin/com/egm/stellio/subscription/config/WebSecurityConfig.kt
+++ b/subscription-service/src/main/kotlin/com/egm/stellio/subscription/config/WebSecurityConfig.kt
@@ -1,21 +1,13 @@
 package com.egm.stellio.subscription.config
 
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.web.server.ServerHttpSecurity
 import org.springframework.security.web.server.SecurityWebFilterChain
-import org.springframework.web.cors.CorsConfiguration
-import org.springframework.web.cors.reactive.CorsConfigurationSource
-import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource
 
 @Configuration
 class WebSecurityConfig {
-
-    @Value("\${application.cors.allowed_origins}")
-    val allowedOrigins: List<String>? = null
-    val allowedMethods = listOf("GET", "POST", "PATCH", "DELETE")
 
     @Bean
     @ConditionalOnProperty("application.authentication.enabled")
@@ -42,16 +34,5 @@ class WebSecurityConfig {
             .authorizeExchange().pathMatchers("/**").permitAll()
 
         return http.build()
-    }
-
-    @Bean
-    fun corsConfigurationSource(): CorsConfigurationSource {
-        val corsConfig = CorsConfiguration()
-        corsConfig.allowedOrigins = allowedOrigins
-        corsConfig.allowedMethods = allowedMethods
-        corsConfig.addAllowedHeader("*")
-        val source = UrlBasedCorsConfigurationSource()
-        source.registerCorsConfiguration("/ngsi-ld/v1/**", corsConfig)
-        return source
     }
 }

--- a/subscription-service/src/main/resources/application.properties
+++ b/subscription-service/src/main/resources/application.properties
@@ -31,6 +31,3 @@ application.authentication.enabled = false
 # application.graylog.host = localhost
 # application.graylog.port = 12201
 # application.graylog.source = stellio-int
-
-# CORS configuration
-application.cors.allowed_origins=http://localhost:3000


### PR DESCRIPTION
The configuration in the api gateway is sufficient to enable CORS in downstream services.
I noticed that a double configuration (in the api gateway and in each downstream service) is not appropriate since the request has been blocked by CORS policy:` The 'Access-Control-Allow-Origin' header contains multiple values 'http://localhost:3000, http://localhost:3000', but only one is allowed` 	 		