### PR TITLE
feat: add config file for Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    # Files stored in repository root
+    directory: "/"
+    schedule:
+      interval: "daily"
+    assignees:
+      - "bobeal"
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the default location of `.github/workflows`
+    directory: "/"
+    schedule:
+      interval: "daily"
+    assignees:
+      - "bobeal"


### PR DESCRIPTION
Since Dependabot is now available for `build.gradle.kts` files (https://github.blog/changelog/2020-12-18-dependabot-gradle-kotlin-and-composer-v2-support/), adding this action for automatic dependency updates.

See https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#package-ecosystem for the configuration of the Github Action.
