### PR TITLE
chore: upgrade Jib to 2.7.1 to fix Java 8 time error

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ plugins {
     kotlin("jvm") version "1.5.21" apply false
     kotlin("plugin.spring") version "1.5.21" apply false
     id("org.jlleitschuh.gradle.ktlint") version "10.1.0"
-    id("com.google.cloud.tools.jib") version "2.5.0" apply false
+    id("com.google.cloud.tools.jib") version "2.7.1" apply false
     kotlin("kapt") version "1.5.21" apply false
     id("io.gitlab.arturbosch.detekt") version "1.17.1" apply false
     id("org.sonarqube") version "3.3"


### PR DESCRIPTION
See https://github.com/GoogleContainerTools/jib/issues/2966 for details

