### PR TITLE
feat: upgrade TimescaleDB to 2.3.0 with PostgreSQL 13

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - 7474:7474
       - 7687:7687
   postgres:
-    image: stellio/stellio-timescale-postgis:1.7.2-pg11
+    image: stellio/stellio-timescale-postgis:2.3.0-pg13
     container_name: stellio-postgres
     environment:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}

--- a/search-service/docker-compose.yml
+++ b/search-service/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     depends_on:
       - zookeeper
   postgres:
-    image: stellio/stellio-timescale-postgis:1.7.2-pg11
+    image: stellio/stellio-timescale-postgis:2.3.0-pg13
     environment:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
       - "POSTGRES_MULTIPLE_DATABASES=${STELLIO_SEARCH_DB_DATABASE},${STELLIO_SEARCH_DB_USER},${STELLIO_SEARCH_DB_PASSWORD}"

--- a/search-service/src/test/kotlin/com/egm/stellio/search/support/WithTimescaleContainer.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/support/WithTimescaleContainer.kt
@@ -17,7 +17,7 @@ interface WithTimescaleContainer {
         private const val DB_PASSWORD = "stellio_search_db_password"
 
         private val timescaleImage: DockerImageName =
-            DockerImageName.parse("stellio/stellio-timescale-postgis:1.7.2-pg11")
+            DockerImageName.parse("stellio/stellio-timescale-postgis:2.3.0-pg13")
                 .asCompatibleSubstituteFor("postgres")
 
         @Container

--- a/subscription-service/docker-compose.yml
+++ b/subscription-service/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     depends_on:
       - zookeeper
   postgres:
-    image: stellio/stellio-timescale-postgis:1.7.2-pg11
+    image: stellio/stellio-timescale-postgis:2.3.0-pg13
     environment:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
       - "POSTGRES_MULTIPLE_DATABASES=${STELLIO_SUBSCRIPTION_DB_DATABASE},${STELLIO_SUBSCRIPTION_DB_USER},${STELLIO_SUBSCRIPTION_DB_PASSWORD}"

--- a/subscription-service/src/test/kotlin/com/egm/stellio/subscription/support/WithTimescaleContainer.kt
+++ b/subscription-service/src/test/kotlin/com/egm/stellio/subscription/support/WithTimescaleContainer.kt
@@ -17,7 +17,7 @@ interface WithTimescaleContainer {
         private const val DB_PASSWORD = "stellio_subscription_db_password"
 
         private val timescaleImage: DockerImageName =
-            DockerImageName.parse("stellio/stellio-timescale-postgis:1.7.2-pg11")
+            DockerImageName.parse("stellio/stellio-timescale-postgis:2.3.0-pg13")
                 .asCompatibleSubstituteFor("postgres")
 
         @Container


### PR DESCRIPTION
For running instances, procedure is documented on https://stellio.readthedocs.io/en/latest/admin/upgrading_to_1.0.0.html#upgrade-to-timescale-23-postgresql-13
