### PR TITLE
feat(entity): store object of a relationship along with the relationship node

### DIFF
--- a/entity-service/src/main/kotlin/com/egm/stellio/entity/authorization/Neo4jAuthorizationService.kt
+++ b/entity-service/src/main/kotlin/com/egm/stellio/entity/authorization/Neo4jAuthorizationService.kt
@@ -135,6 +135,7 @@ class Neo4jAuthorizationService(
     override fun createAdminLinks(entitiesId: List<URI>, userSub: String) {
         val relationships = entitiesId.map {
             Relationship(
+                objectId = it,
                 type = listOf(R_CAN_ADMIN),
                 datasetId = "urn:ngsi-ld:Dataset:rCanAdmin:$it".toUri()
             )

--- a/entity-service/src/main/kotlin/com/egm/stellio/entity/service/SubscriptionHandlerService.kt
+++ b/entity-service/src/main/kotlin/com/egm/stellio/entity/service/SubscriptionHandlerService.kt
@@ -108,6 +108,7 @@ class SubscriptionHandlerService(
             entityService.deleteEntity(lastNotification.id)
         } else {
             val rawRelationship = Relationship(
+                objectId = notification.id,
                 type = listOf(JsonLdUtils.EGM_RAISED_NOTIFICATION)
             )
 

--- a/entity-service/src/main/resources/neo4j/migrations/V08__add_object_id_in_relationships.cypher
+++ b/entity-service/src/main/resources/neo4j/migrations/V08__add_object_id_in_relationships.cypher
@@ -1,0 +1,2 @@
+MATCH (r:Attribute:Relationship)-[]->(e:Entity)
+SET r.objectId = e.id

--- a/entity-service/src/test/kotlin/com/egm/stellio/entity/authorization/Neo4jAuthorizationRepositoryTest.kt
+++ b/entity-service/src/test/kotlin/com/egm/stellio/entity/authorization/Neo4jAuthorizationRepositoryTest.kt
@@ -395,6 +395,7 @@ class Neo4jAuthorizationRepositoryTest : WithNeo4jContainer {
             userUri,
             targetIds.map {
                 Relationship(
+                    objectId = it,
                     type = listOf(R_CAN_ADMIN),
                     datasetId = "urn:ngsi-ld:Dataset:rCanAdmin:$it".toUri()
                 )
@@ -426,6 +427,7 @@ class Neo4jAuthorizationRepositoryTest : WithNeo4jContainer {
             serviceAccountUri,
             targetIds.map {
                 Relationship(
+                    objectId = it,
                     type = listOf(R_CAN_ADMIN),
                     datasetId = "urn:ngsi-ld:Dataset:rCanAdmin:$it".toUri()
                 )
@@ -442,7 +444,7 @@ class Neo4jAuthorizationRepositoryTest : WithNeo4jContainer {
     }
 
     fun createRelationship(subjectNodeInfo: SubjectNodeInfo, relationshipType: String, objectId: URI): Relationship {
-        val relationship = Relationship(type = listOf(relationshipType))
+        val relationship = Relationship(objectId = objectId, type = listOf(relationshipType))
 
         neo4jRepository.createRelationshipOfSubject(subjectNodeInfo, relationship, objectId)
 

--- a/entity-service/src/test/kotlin/com/egm/stellio/entity/repository/Neo4jSearchRepositoryTests.kt
+++ b/entity-service/src/test/kotlin/com/egm/stellio/entity/repository/Neo4jSearchRepositoryTests.kt
@@ -374,7 +374,7 @@ class Neo4jSearchRepositoryTests : WithNeo4jContainer {
         objectId: URI,
         datasetId: URI? = null
     ): Relationship {
-        val relationship = Relationship(type = listOf(relationshipType), datasetId = datasetId)
+        val relationship = Relationship(objectId = objectId, type = listOf(relationshipType), datasetId = datasetId)
         neo4jRepository.createRelationshipOfSubject(subjectNodeInfo, relationship, objectId)
 
         return relationship

--- a/entity-service/src/test/kotlin/com/egm/stellio/entity/repository/StandaloneNeo4jSearchRepositoryTests.kt
+++ b/entity-service/src/test/kotlin/com/egm/stellio/entity/repository/StandaloneNeo4jSearchRepositoryTests.kt
@@ -828,7 +828,7 @@ class StandaloneNeo4jSearchRepositoryTests : WithNeo4jContainer {
         objectId: URI,
         datasetId: URI? = null
     ): Relationship {
-        val relationship = Relationship(type = listOf(relationshipType), datasetId = datasetId)
+        val relationship = Relationship(objectId = objectId, type = listOf(relationshipType), datasetId = datasetId)
         neo4jRepository.createRelationshipOfSubject(subjectNodeInfo, relationship, objectId)
 
         return relationship

--- a/entity-service/src/test/kotlin/com/egm/stellio/entity/service/EntityAttributeServiceTests.kt
+++ b/entity-service/src/test/kotlin/com/egm/stellio/entity/service/EntityAttributeServiceTests.kt
@@ -22,6 +22,8 @@ import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
+import java.net.URI
+import java.util.UUID
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, classes = [EntityAttributeService::class])
 @ActiveProfiles("test")
@@ -174,7 +176,7 @@ class EntityAttributeServiceTests {
 
         val expandedPayload = parseAndExpandAttributeFragment(propertyName, payload, listOf(AQUAC_COMPOUND_CONTEXT))
         val property = Property(name = propertyName, unitCode = "years", value = 0)
-        val relationship = Relationship(type = listOf("measuredBy"))
+        val relationship = Relationship(objectId = generateRandomObjectId(), type = listOf("measuredBy"))
 
         every { neo4jRepository.hasRelationshipInstance(match { it.label == "Entity" }, any(), any()) } returns false
         every { neo4jRepository.hasPropertyInstance(any(), any(), any()) } returns true
@@ -247,7 +249,7 @@ class EntityAttributeServiceTests {
             """.trimIndent()
 
         val expandedPayload = parseAndExpandAttributeFragment(relationshipType, payload, listOf(AQUAC_COMPOUND_CONTEXT))
-        val relationship = Relationship(type = listOf("isContainedIn"))
+        val relationship = Relationship(objectId = generateRandomObjectId(), type = listOf(relationshipType))
 
         every { neo4jRepository.hasRelationshipInstance(any(), any(), any()) } returns true
         every { relationshipRepository.getRelationshipOfSubject(any(), any()) } returns relationship
@@ -281,7 +283,7 @@ class EntityAttributeServiceTests {
             """.trimIndent()
 
         val expandedPayload = parseAndExpandAttributeFragment(relationshipType, payload, listOf(AQUAC_COMPOUND_CONTEXT))
-        val relationship = Relationship(type = listOf("isContainedIn"))
+        val relationship = Relationship(objectId = generateRandomObjectId(), type = listOf(relationshipType))
 
         every { neo4jRepository.hasRelationshipInstance(any(), any(), any()) } returns true
         every { relationshipRepository.getRelationshipOfSubject(any(), any(), any()) } returns relationship
@@ -320,7 +322,7 @@ class EntityAttributeServiceTests {
             """.trimIndent()
 
         val expandedPayload = parseAndExpandAttributeFragment(relationshipType, payload, listOf(AQUAC_COMPOUND_CONTEXT))
-        val relationship = Relationship(type = listOf("isContainedIn"))
+        val relationship = Relationship(objectId = generateRandomObjectId(), type = listOf(relationshipType))
         val property = Property(name = "depth", value = 0)
 
         every { neo4jRepository.hasRelationshipInstance(match { it.label == "Entity" }, any(), any()) } returns true
@@ -366,8 +368,8 @@ class EntityAttributeServiceTests {
             """.trimIndent()
 
         val expandedPayload = parseAndExpandAttributeFragment(relationshipType, payload, listOf(AQUAC_COMPOUND_CONTEXT))
-        val relationship = Relationship(type = listOf("isContainedIn"))
-        val measuredByRelationship = Relationship(type = listOf("measuredBy"))
+        val relationship = Relationship(objectId = generateRandomObjectId(), type = listOf(relationshipType))
+        val measuredByRelationship = Relationship(objectId = generateRandomObjectId(), type = listOf(relationshipType))
 
         every { neo4jRepository.hasRelationshipInstance(any(), any(), any()) } returns true
         every { relationshipRepository.getRelationshipOfSubject(fishUri, any()) } returns relationship
@@ -497,7 +499,7 @@ class EntityAttributeServiceTests {
             """.trimIndent()
 
         val expandedPayload = parseAndExpandAttributeFragment(relationshipType, payload, listOf(AQUAC_COMPOUND_CONTEXT))
-        val relationship = Relationship(type = listOf("isContainedIn"))
+        val relationship = Relationship(objectId = generateRandomObjectId(), type = listOf(relationshipType))
         every { neo4jRepository.hasRelationshipInstance(any(), any(), any()) } returns true
         every { relationshipRepository.getRelationshipOfSubject(any(), any(), any()) } returns relationship
         every { neo4jRepository.updateRelationshipTargetOfSubject(any(), any(), any()) } returns true
@@ -541,4 +543,7 @@ class EntityAttributeServiceTests {
 
         confirmVerified()
     }
+
+    private fun generateRandomObjectId(): URI =
+        "urn:ngsi-ld:Entity:${UUID.randomUUID()}".toUri()
 }


### PR DESCRIPTION
- thus, it avoids doing one more DB request per relationship when retrieving results of a search query
