### PR TITLE
feat(common): add support for an activable version endpoint

### DIFF
--- a/api-gateway/build.gradle.kts
+++ b/api-gateway/build.gradle.kts
@@ -8,6 +8,14 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
 }
 
+springBoot {
+    buildInfo {
+        properties {
+            name = "Stellio Context Broker"
+        }
+    }
+}
+
 jib.from.image = project.ext["jibFromImage"].toString()
 jib.to.image = "stellio/stellio-api-gateway"
 jib.container.jvmFlags = project.ext["jibContainerJvmFlags"] as List<String>

--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -52,6 +52,16 @@ spring:
               - DELETE
             allowedHeaders: "*"
 
+management:
+  endpoints:
+    enabled-by-default: false
+    web:
+      exposure:
+        include: info
+  endpoint:
+    info:
+      enabled: false
+
 # Default values for sending log data to a Gelf compatible endpoint
 # Log data is sent only if the 'gelflogs' Spring profile is active
 # application.graylog.host: localhost

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -168,7 +168,7 @@ subprojects {
 
 allprojects {
     group = "com.egm.stellio"
-    version = "0.7.0"
+    version = "1.12.0-dev"
 
     repositories {
         mavenCentral()


### PR DESCRIPTION
- Exposed by API Gateway component only (version is the same for all components)
- Accessible under `/actuator/info` (e.g., `http://localhost:8080/actuator/info` for a local deployment)
- Disabled by default
- Documentation added in https://stellio.readthedocs.io/en/latest/admin/production_deployment.html#version-endpoint-since-1120-dev
- Example of a response received:

```json
{
    "build": {
        "artifact": "api-gateway",
        "group": "com.egm.stellio",
        "name": "Stellio Context Broker",
        "time": "2021-10-10T11:14:51.675Z",
        "version": "1.12.0-dev"
    }
}
```