### PR TITLE
feat(common): activate reuse flag for testcontainers driven containers

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
 
 extra["springCloudVersion"] = "2020.0.4"
-extra["testcontainersVersion"] = "1.16.0"
+extra["testcontainersVersion"] = "1.16.2"
 
 plugins {
     java // why did I have to add that ?!

--- a/entity-service/src/test/kotlin/com/egm/stellio/entity/config/WithNeo4jContainer.kt
+++ b/entity-service/src/test/kotlin/com/egm/stellio/entity/config/WithNeo4jContainer.kt
@@ -5,20 +5,17 @@ import org.springframework.boot.autoconfigure.ImportAutoConfiguration
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
 import org.testcontainers.containers.Neo4jContainer
-import org.testcontainers.junit.jupiter.Container
-import org.testcontainers.junit.jupiter.Testcontainers
 
-@Testcontainers
 @ImportAutoConfiguration(MigrationsAutoConfiguration::class)
 interface WithNeo4jContainer {
 
     companion object {
 
-        @Container
-        val neo4jContainer = Neo4jContainer<Nothing>("neo4j:4.4").apply {
+        private val neo4jContainer = Neo4jContainer<Nothing>("neo4j:4.4").apply {
             withNeo4jConfig("dbms.default_database", "stellio")
             withEnv("NEO4JLABS_PLUGINS", "[\"apoc\"]")
             withAdminPassword("neo4j_password")
+            withReuse(true)
         }
 
         @JvmStatic

--- a/search-service/src/test/kotlin/com/egm/stellio/search/support/WithTimescaleContainer.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/support/WithTimescaleContainer.kt
@@ -3,11 +3,8 @@ package com.egm.stellio.search.support
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
 import org.testcontainers.containers.PostgreSQLContainer
-import org.testcontainers.junit.jupiter.Container
-import org.testcontainers.junit.jupiter.Testcontainers
 import org.testcontainers.utility.DockerImageName
 
-@Testcontainers
 interface WithTimescaleContainer {
 
     companion object {
@@ -20,10 +17,10 @@ interface WithTimescaleContainer {
             DockerImageName.parse("stellio/stellio-timescale-postgis:2.3.0-pg13")
                 .asCompatibleSubstituteFor("postgres")
 
-        @Container
-        val timescaleContainer = PostgreSQLContainer<Nothing>(timescaleImage).apply {
+        private val timescaleContainer = PostgreSQLContainer<Nothing>(timescaleImage).apply {
             withEnv("POSTGRES_PASSWORD", "password")
             withEnv("POSTGRES_MULTIPLE_DATABASES", "$DB_NAME,$DB_USER,$DB_PASSWORD")
+            withReuse(true)
         }
 
         @JvmStatic

--- a/shared/src/testFixtures/kotlin/com/egm/stellio/shared/support/WithKafkaContainer.kt
+++ b/shared/src/testFixtures/kotlin/com/egm/stellio/shared/support/WithKafkaContainer.kt
@@ -3,18 +3,17 @@ package com.egm.stellio.shared.support
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
 import org.testcontainers.containers.KafkaContainer
-import org.testcontainers.junit.jupiter.Container
-import org.testcontainers.junit.jupiter.Testcontainers
 import org.testcontainers.utility.DockerImageName
 
-@Testcontainers
 interface WithKafkaContainer {
+
     companion object {
 
         private val kafkaImage: DockerImageName = DockerImageName.parse("confluentinc/cp-kafka:5.4.1")
 
-        @Container
-        val kafkaContainer = KafkaContainer(kafkaImage)
+        private val kafkaContainer = KafkaContainer(kafkaImage).apply {
+            withReuse(true)
+        }
 
         @JvmStatic
         @DynamicPropertySource

--- a/subscription-service/src/test/kotlin/com/egm/stellio/subscription/support/WithTimescaleContainer.kt
+++ b/subscription-service/src/test/kotlin/com/egm/stellio/subscription/support/WithTimescaleContainer.kt
@@ -3,11 +3,8 @@ package com.egm.stellio.subscription.support
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
 import org.testcontainers.containers.PostgreSQLContainer
-import org.testcontainers.junit.jupiter.Container
-import org.testcontainers.junit.jupiter.Testcontainers
 import org.testcontainers.utility.DockerImageName
 
-@Testcontainers
 interface WithTimescaleContainer {
 
     companion object {
@@ -20,10 +17,10 @@ interface WithTimescaleContainer {
             DockerImageName.parse("stellio/stellio-timescale-postgis:2.3.0-pg13")
                 .asCompatibleSubstituteFor("postgres")
 
-        @Container
-        val timescaleContainer = PostgreSQLContainer<Nothing>(timescaleImage).apply {
+        private val timescaleContainer = PostgreSQLContainer<Nothing>(timescaleImage).apply {
             withEnv("POSTGRES_PASSWORD", "password")
             withEnv("POSTGRES_MULTIPLE_DATABASES", "$DB_NAME,$DB_USER,$DB_PASSWORD")
+            withReuse(true)
         }
 
         @JvmStatic


### PR DESCRIPTION
- remove use of @Container annotation since it automatically stops containers after test
- must be manually configured locally to take effect: https://github.com/testcontainers/testcontainers-java/pull/1781

