### PR TITLE
feat(common): stop loading NGSI-LD core context at startup

### DIFF
--- a/shared/src/main/kotlin/com/egm/stellio/shared/util/JsonLdUtils.kt
+++ b/shared/src/main/kotlin/com/egm/stellio/shared/util/JsonLdUtils.kt
@@ -76,8 +76,7 @@ object JsonLdUtils {
 
     @PostConstruct
     private fun loadCoreContext() {
-        val coreContextPayload = HttpUtils.doGet(NGSILD_CORE_CONTEXT) ?: localCoreContextPayload
-        val coreContext: Map<String, Any> = deserializeObject(coreContextPayload)
+        val coreContext: Map<String, Any> = deserializeObject(localCoreContextPayload)
         BASE_CONTEXT = coreContext[JSONLD_CONTEXT] as Map<String, Any>
         logger.info("Core context loaded")
     }


### PR DESCRIPTION
- NGSI-LD core context is immutable and it is already cached locally
