### PR TITLE
chore: upgrade to Spring Cloud 2021.0.1 to apply last CVE

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ buildscript {
     }
 }
 
-extra["springCloudVersion"] = "2021.0.0"
+extra["springCloudVersion"] = "2021.0.1"
 extra["testcontainersVersion"] = "1.16.2"
 
 plugins {


### PR DESCRIPTION
- https://spring.io/blog/2022/03/01/spring-cloud-gateway-cve-reports-published