### PR TITLE
fix(entity): add missing compaction in attribute info endpoint

### DIFF
--- a/entity-service/src/main/kotlin/com/egm/stellio/entity/model/AttributeDetails.kt
+++ b/entity-service/src/main/kotlin/com/egm/stellio/entity/model/AttributeDetails.kt
@@ -6,5 +6,5 @@ data class AttributeDetails(
     val id: URI,
     val type: String = "Attribute",
     val attributeName: String,
-    val typeNames: List<String>
+    val typeNames: Set<String>
 )

--- a/entity-service/src/main/kotlin/com/egm/stellio/entity/model/AttributeTypeInfo.kt
+++ b/entity-service/src/main/kotlin/com/egm/stellio/entity/model/AttributeTypeInfo.kt
@@ -6,7 +6,7 @@ class AttributeTypeInfo(
     val id: URI,
     val type: String = "Attribute",
     val attributeName: String,
-    val attributeTypes: List<String>,
-    val typeNames: List<String>,
+    val attributeTypes: Set<String>,
+    val typeNames: Set<String>,
     val attributeCount: Int
 )

--- a/entity-service/src/main/kotlin/com/egm/stellio/entity/service/AttributeService.kt
+++ b/entity-service/src/main/kotlin/com/egm/stellio/entity/service/AttributeService.kt
@@ -18,24 +18,27 @@ class AttributeService(
 
     fun getAttributeDetails(contexts: List<String>): List<AttributeDetails> =
         neo4jRepository.getAttributesDetails().map {
-            val attribute = (it["attribute"] as String)
+            val attribute = it["attribute"] as String
             AttributeDetails(
                 id = attribute.toUri(),
                 attributeName = compactTerm(attribute, contexts),
-                typeNames = (it["typeNames"] as Set<String>).toList().map { compactTerm(it, contexts) }
+                typeNames = (it["typeNames"] as Set<String>).compactElements(contexts)
             )
         }
 
-    fun getAttributeTypeInfo(expandedType: String): AttributeTypeInfo? {
+    fun getAttributeTypeInfo(expandedType: String, context: String): AttributeTypeInfo? {
         val attributesInformation = neo4jRepository.getAttributeInformation(expandedType)
         if (attributesInformation.isEmpty()) return null
 
         return AttributeTypeInfo(
             id = expandedType.toUri(),
-            attributeName = attributesInformation["attributeName"] as String,
-            attributeTypes = attributesInformation["attributeTypes"] as List<String>,
-            typeNames = attributesInformation["typeNames"] as List<String>,
+            attributeName = compactTerm(attributesInformation["attributeName"] as String, listOf(context)),
+            attributeTypes = attributesInformation["attributeTypes"] as Set<String>,
+            typeNames = (attributesInformation["typeNames"] as Set<String>).compactElements(listOf(context)),
             attributeCount = attributesInformation["attributeCount"] as Int
         )
     }
+
+    private fun Set<String>.compactElements(contexts: List<String>): Set<String> =
+        this.map { compactTerm(it, contexts) }.toSet()
 }

--- a/entity-service/src/main/kotlin/com/egm/stellio/entity/web/AttributeHandler.kt
+++ b/entity-service/src/main/kotlin/com/egm/stellio/entity/web/AttributeHandler.kt
@@ -17,7 +17,6 @@ class AttributeHandler(
     /**
      * Implements 6.27 - Retrieve Available Attributes
      */
-
     @GetMapping(produces = [MediaType.APPLICATION_JSON_VALUE, JSON_LD_CONTENT_TYPE])
     suspend fun getAttributes(
         @RequestHeader httpHeaders: HttpHeaders,
@@ -48,7 +47,7 @@ class AttributeHandler(
         val mediaType = getApplicableMediaType(httpHeaders)
         val expandedType = JsonLdUtils.expandJsonLdTerm(attrId.decode(), contextLink)!!
 
-        val attributeTypeInfo = attributeService.getAttributeTypeInfo(expandedType)
+        val attributeTypeInfo = attributeService.getAttributeTypeInfo(expandedType, contextLink)
             ?: throw ResourceNotFoundException("No information found for attribute $expandedType")
 
         return buildGetSuccessResponse(mediaType, contextLink)

--- a/entity-service/src/test/kotlin/com/egm/stellio/entity/service/AttributeServiceTest.kt
+++ b/entity-service/src/test/kotlin/com/egm/stellio/entity/service/AttributeServiceTest.kt
@@ -2,10 +2,10 @@ package com.egm.stellio.entity.service
 
 import com.egm.stellio.entity.model.AttributeDetails
 import com.egm.stellio.entity.repository.Neo4jRepository
-import com.egm.stellio.shared.util.APIC_COMPOUND_CONTEXT
-import com.egm.stellio.shared.util.toUri
+import com.egm.stellio.shared.util.*
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -21,43 +21,35 @@ class AttributeServiceTest {
     @MockkBean(relaxed = true)
     private lateinit var neo4jRepository: Neo4jRepository
 
-    private val temperature = "https://ontology.eglobalmark.com/apic#temperature"
-    private val deviceParameter = "https://ontology.eglobalmark.com/apic#deviceParameter"
-    private val beeHiveType = "https://ontology.eglobalmark.com/apic#BeeHive"
-
     @Test
     fun `it should return a list of AttributeDetails`() {
         every { neo4jRepository.getAttributesDetails() } returns listOf(
             mapOf(
-                "attribute" to temperature,
-                "typeNames" to setOf("https://ontology.eglobalmark.com/apic#Beehive")
+                "attribute" to TEMPERATURE_PROPERTY,
+                "typeNames" to setOf(BEEHIVE_TYPE)
             ),
             mapOf(
-                "attribute" to deviceParameter,
-                "typeNames" to setOf("https://ontology.eglobalmark.com/apic#deviceParameter")
+                "attribute" to INCOMING_PROPERTY,
+                "typeNames" to setOf(APIARY_TYPE)
             )
         )
 
         val attributeDetails = attributeService.getAttributeDetails(listOf(APIC_COMPOUND_CONTEXT))
-        assert(attributeDetails.size == 2)
+        assertEquals(2, attributeDetails.size)
         assert(
             attributeDetails.containsAll(
                 listOf(
                     AttributeDetails(
-                        temperature.toUri(),
+                        TEMPERATURE_PROPERTY.toUri(),
                         "Attribute",
-                        "temperature",
-                        listOf(
-                            "https://ontology.eglobalmark.com/apic#Beehive"
-                        )
+                        TEMPERATURE_COMPACT_PROPERTY,
+                        setOf(BEEHIVE_COMPACT_TYPE)
                     ),
                     AttributeDetails(
-                        deviceParameter.toUri(),
+                        INCOMING_PROPERTY.toUri(),
                         "Attribute",
-                        "https://ontology.eglobalmark.com/apic#deviceParameter",
-                        listOf(
-                            "https://ontology.eglobalmark.com/apic#deviceParameter"
-                        )
+                        INCOMING_COMPACT_PROPERTY,
+                        setOf(APIARY_COMPACT_TYPE)
                     )
                 )
             )
@@ -70,34 +62,35 @@ class AttributeServiceTest {
 
         val attributeDetail = attributeService.getAttributeDetails(listOf(APIC_COMPOUND_CONTEXT))
 
-        assert(attributeDetail.isEmpty())
+        assertTrue(attributeDetail.isEmpty())
     }
 
     @Test
     fun `it should return an AttributeList`() {
-        every { neo4jRepository.getAttributes() } returns listOf(temperature, beeHiveType)
+        every { neo4jRepository.getAttributes() } returns listOf(TEMPERATURE_PROPERTY, INCOMING_PROPERTY)
 
         val attributeName = attributeService.getAttributeList(listOf(APIC_COMPOUND_CONTEXT))
 
-        assert(attributeName.attributeList == listOf("temperature", "BeeHive"))
+        assert(attributeName.attributeList == listOf(TEMPERATURE_COMPACT_PROPERTY, INCOMING_COMPACT_PROPERTY))
     }
 
     @Test
     fun `it should return an attribute Information`() {
         every { neo4jRepository.getAttributeInformation(any()) } returns mapOf(
-            "attributeName" to "temperature",
-            "attributeTypes" to listOf("Property"),
-            "typeNames" to listOf("Beehive"),
+            "attributeName" to TEMPERATURE_PROPERTY,
+            "attributeTypes" to setOf("Property"),
+            "typeNames" to setOf(BEEHIVE_TYPE),
             "attributeCount" to 2
         )
 
-        val attributeTypeInfo = attributeService.getAttributeTypeInfo(temperature)!!
+        val attributeTypeInfo = attributeService.getAttributeTypeInfo(TEMPERATURE_PROPERTY, APIC_COMPOUND_CONTEXT)
 
-        assert(attributeTypeInfo.id == temperature.toUri())
-        assert(attributeTypeInfo.type == "Attribute")
-        assert(attributeTypeInfo.attributeName == "temperature")
-        assert(attributeTypeInfo.attributeTypes == listOfNotNull("Property"))
-        assert(attributeTypeInfo.typeNames == listOfNotNull("Beehive"))
-        assert(attributeTypeInfo.attributeCount == 2)
+        assertNotNull(attributeTypeInfo)
+        assertEquals(TEMPERATURE_PROPERTY.toUri(), attributeTypeInfo!!.id)
+        assertEquals("Attribute", attributeTypeInfo.type)
+        assertEquals(TEMPERATURE_COMPACT_PROPERTY, attributeTypeInfo.attributeName)
+        assertEquals(setOf("Property"), attributeTypeInfo.attributeTypes)
+        assertEquals(setOf(BEEHIVE_COMPACT_TYPE), attributeTypeInfo.typeNames)
+        assertEquals(2, attributeTypeInfo.attributeCount)
     }
 }

--- a/shared/src/testFixtures/kotlin/com/egm/stellio/shared/util/JsonLdContextUtils.kt
+++ b/shared/src/testFixtures/kotlin/com/egm/stellio/shared/util/JsonLdContextUtils.kt
@@ -9,6 +9,7 @@ val APIC_COMPOUND_CONTEXT = "${JsonLdUtils.EGM_BASE_CONTEXT_URL}/apic/jsonld-con
 
 const val BEEHIVE_COMPACT_TYPE = "BeeHive"
 const val BEEHIVE_TYPE = "https://ontology.eglobalmark.com/apic#$BEEHIVE_COMPACT_TYPE"
+const val APIARY_COMPACT_TYPE = "Apiary"
 const val APIARY_TYPE = "https://ontology.eglobalmark.com/apic#Apiary"
 const val INCOMING_COMPACT_PROPERTY = "incoming"
 const val INCOMING_PROPERTY = "https://ontology.eglobalmark.com/apic#$INCOMING_COMPACT_PROPERTY"


### PR DESCRIPTION
- attribute name and type names must be compacted according to provided context
- fix cast exceptions as neo4j returns sets, not lists
- cleanup unit tests
