### PR TITLE
fix(entity): check provided ids are URIs when retrieving entities

### DIFF
--- a/entity-service/src/main/kotlin/com/egm/stellio/entity/repository/QueryUtils.kt
+++ b/entity-service/src/main/kotlin/com/egm/stellio/entity/repository/QueryUtils.kt
@@ -13,6 +13,7 @@ import com.egm.stellio.shared.util.AuthContextModel.AUTH_TERM_CAN_ADMIN
 import com.egm.stellio.shared.util.AuthContextModel.AUTH_TERM_CAN_READ
 import com.egm.stellio.shared.util.AuthContextModel.AUTH_TERM_CAN_WRITE
 import com.egm.stellio.shared.util.JsonLdUtils.expandJsonLdTerm
+import java.net.URI
 import java.util.regex.Pattern
 
 object QueryUtils {
@@ -124,7 +125,7 @@ object QueryUtils {
         else
             "$prefix (entity:`$expandedType`)"
 
-    private fun buildIdClause(id: List<String>?): String {
+    private fun buildIdClause(id: List<URI>?): String {
         return if (id != null) {
             val formattedIds = id.map { "'$it'" }
             " entity.id in $formattedIds "

--- a/entity-service/src/main/kotlin/com/egm/stellio/entity/web/EntityHandler.kt
+++ b/entity-service/src/main/kotlin/com/egm/stellio/entity/web/EntityHandler.kt
@@ -80,7 +80,7 @@ class EntityHandler(
             applicationProperties.pagination.limitMax,
             count
         )
-        val ids = params.getFirst(QUERY_PARAM_ID)?.split(",")
+        val ids = params.getFirst(QUERY_PARAM_ID)?.split(",")?.toListOfUri()
         val type = params.getFirst(QUERY_PARAM_TYPE)
         val idPattern = params.getFirst(QUERY_PARAM_ID_PATTERN)
         val attrs = params.getFirst(QUERY_PARAM_ATTRS)

--- a/entity-service/src/test/kotlin/com/egm/stellio/entity/repository/StandaloneNeo4jSearchRepositoryTests.kt
+++ b/entity-service/src/test/kotlin/com/egm/stellio/entity/repository/StandaloneNeo4jSearchRepositoryTests.kt
@@ -8,6 +8,7 @@ import com.egm.stellio.entity.model.Relationship
 import com.egm.stellio.shared.model.QueryParams
 import com.egm.stellio.shared.util.DEFAULT_CONTEXTS
 import com.egm.stellio.shared.util.JsonLdUtils.expandJsonLdTerm
+import com.egm.stellio.shared.util.toListOfUri
 import com.egm.stellio.shared.util.toUri
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -491,7 +492,7 @@ class StandaloneNeo4jSearchRepositoryTests : WithNeo4jContainer {
             mutableListOf(Property(name = expandedNameProperty, value = "Scalpa2"))
         )
         val entities = searchRepository.getEntities(
-            QueryParams(id = listOf("urn:ngsi-ld:Beekeeper:1231"), expandedType = "Beekeeper"),
+            QueryParams(id = listOf("urn:ngsi-ld:Beekeeper:1231".toUri()), expandedType = "Beekeeper"),
             sub,
             offset,
             limit,
@@ -513,7 +514,7 @@ class StandaloneNeo4jSearchRepositoryTests : WithNeo4jContainer {
             listOf("Beekeeper")
         )
         val entities = searchRepository.getEntities(
-            QueryParams(id = listOf("urn:ngsi-ld:Beekeeper:1231")),
+            QueryParams(id = listOf("urn:ngsi-ld:Beekeeper:1231".toUri())),
             sub,
             offset,
             limit,
@@ -538,7 +539,7 @@ class StandaloneNeo4jSearchRepositoryTests : WithNeo4jContainer {
             listOf("Beekeeper")
         )
         val entitiesCount = searchRepository.getEntities(
-            QueryParams(id = listOf("urn:ngsi-ld:Beekeeper:1231"), q = "createdAt>2021-07-10T00:00:00Z"),
+            QueryParams(id = listOf("urn:ngsi-ld:Beekeeper:1231".toUri()), q = "createdAt>2021-07-10T00:00:00Z"),
             sub,
             offset,
             limit,
@@ -595,7 +596,7 @@ class StandaloneNeo4jSearchRepositoryTests : WithNeo4jContainer {
         )
         val entities = searchRepository.getEntities(
             QueryParams(
-                id = listOf("urn:ngsi-ld:Beekeeper:1231", "urn:ngsi-ld:Beekeeper:1232"),
+                id = listOf("urn:ngsi-ld:Beekeeper:1231", "urn:ngsi-ld:Beekeeper:1232").toListOfUri(),
                 expandedType = "Beekeeper"
             ),
             sub,

--- a/shared/src/main/kotlin/com/egm/stellio/shared/model/QueryParams.kt
+++ b/shared/src/main/kotlin/com/egm/stellio/shared/model/QueryParams.kt
@@ -1,7 +1,9 @@
 package com.egm.stellio.shared.model
 
+import java.net.URI
+
 data class QueryParams(
-    val id: List<String>? = null,
+    val id: List<URI>? = null,
     val expandedType: String? = null,
     val idPattern: String? = null,
     val q: String? = null,


### PR DESCRIPTION
- as per 5.7.2.4, ensure provided ids are URIs, and return a 400 if not
