### PR TITLE
fix: encoded type and q parameter when we call entity service

### DIFF
--- a/shared/src/main/kotlin/com/egm/stellio/shared/util/HttpUtils.kt
+++ b/shared/src/main/kotlin/com/egm/stellio/shared/util/HttpUtils.kt
@@ -2,6 +2,7 @@ package com.egm.stellio.shared.util
 
 import org.slf4j.LoggerFactory
 import java.net.URLDecoder
+import java.net.URLEncoder
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
@@ -28,3 +29,6 @@ object HttpUtils {
 
 fun String.decode(): String =
     URLDecoder.decode(this, "UTF-8")
+
+fun String.encode(): String =
+    URLEncoder.encode(this, "UTF-8")

--- a/subscription-service/src/main/kotlin/com/egm/stellio/subscription/job/TimeIntervalNotificationJob.kt
+++ b/subscription-service/src/main/kotlin/com/egm/stellio/subscription/job/TimeIntervalNotificationJob.kt
@@ -35,10 +35,10 @@ class TimeIntervalNotificationJob(
 
     fun extractParam(entityInfo: EntityInfo, q: String?): String {
         val param = java.lang.StringBuilder()
-        param.append("?$QUERY_PARAM_TYPE=${entityInfo.type}")
+        param.append("?$QUERY_PARAM_TYPE=${entityInfo.type.encode()}")
         if (entityInfo.id != null) param.append("&$QUERY_PARAM_ID=${entityInfo.id}")
         if (entityInfo.idPattern != null) param.append("&$QUERY_PARAM_ID_PATTERN=${entityInfo.idPattern}")
-        if (q != null) param.append("&$QUERY_PARAM_FILTER=$q")
+        if (q != null) param.append("&$QUERY_PARAM_FILTER=${q.encode()}")
         return param.toString()
     }
 

--- a/subscription-service/src/test/kotlin/com/egm/stellio/subscription/job/TimeIntervalNotificationJobTest.kt
+++ b/subscription-service/src/test/kotlin/com/egm/stellio/subscription/job/TimeIntervalNotificationJobTest.kt
@@ -89,7 +89,7 @@ class TimeIntervalNotificationJobTest {
             EntityInfo(
                 id = "urn:ngsi-ld:FishContainment:1234567890".toUri(),
                 idPattern = ".*FishContainment.*",
-                type = "FishContainment"
+                type = "https://uri.fiware.org/ns/data-models#FishContainment"
             )
         )
         val q = "speed>50;foodName==dietary fibres"
@@ -97,25 +97,25 @@ class TimeIntervalNotificationJobTest {
         assertEquals(
             "?type=FishContainment" +
                 "&id=urn:ngsi-ld:FishContainment:1234567890" +
-                "&q=speed>50;foodName==dietary fibres",
+                "&q=speed%3E50%3BfoodName%3D%3Ddietary+fibres",
             timeIntervalNotificationJob.extractParam(entities.elementAt(0), q)
         )
         assertEquals(
             "?type=FishContainment" +
-                "&q=speed>50;foodName==dietary fibres",
+                "&q=speed%3E50%3BfoodName%3D%3Ddietary+fibres",
             timeIntervalNotificationJob.extractParam(entities.elementAt(1), q)
         )
         assertEquals(
             "?type=FishContainment" +
                 "&idPattern=.*FishContainment.*" +
-                "&q=speed>50;foodName==dietary fibres",
+                "&q=speed%3E50%3BfoodName%3D%3Ddietary+fibres",
             timeIntervalNotificationJob.extractParam(entities.elementAt(2), q)
         )
         assertEquals(
-            "?type=FishContainment" +
+            "?type=https%3A%2F%2Furi.fiware.org%2Fns%2Fdata-models%23FishContainment" +
                 "&id=urn:ngsi-ld:FishContainment:1234567890" +
                 "&idPattern=.*FishContainment.*" +
-                "&q=speed>50;foodName==dietary fibres",
+                "&q=speed%3E50%3BfoodName%3D%3Ddietary+fibres",
             timeIntervalNotificationJob.extractParam(entities.elementAt(3), q)
         )
     }


### PR DESCRIPTION
## Proposed changes

I encoded the type and q parameters in the url when calling the service entity.

## Types of changes

-   [ x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

-   [x ] I have read the [CONTRIBUTING](https://github.com/stellio-hub/stellio-context-broker/blob/develop/CONTRIBUTING.md) doc
-   [x ] I have signed the [CLA](https://fiware.github.io/contribution-requirements/individual-cla.pdf)
-   [ x] I have added tests that prove my fix is effective or that my feature works
-   [ x] I have added necessary documentation (if appropriate)
-   [ x] Any dependent changes have been merged and published in downstream modules
