### PR TITLE
fix(search): handling of service account ids when checking rights for clients

### DIFF
--- a/search-service/src/main/kotlin/com/egm/stellio/search/service/SubjectReferentialService.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/service/SubjectReferentialService.kt
@@ -69,7 +69,7 @@ class SubjectReferentialService(
         databaseClient
             .sql(
                 """
-                SELECT subject_id, groups_memberships
+                SELECT subject_id, service_account_id, groups_memberships
                 FROM subject_referential
                 WHERE (subject_id = :subject_id OR service_account_id = :subject_id)
                 """.trimIndent()
@@ -78,8 +78,11 @@ class SubjectReferentialService(
             .fetch()
             .one()
             .map {
-                ((it["groups_memberships"] as Array<Sub>?)?.toList() ?: emptyList())
+                val subs = ((it["groups_memberships"] as Array<Sub>?)?.toList() ?: emptyList())
                     .plus(it["subject_id"] as Sub)
+                if (it["service_account_id"] != null)
+                    subs.plus(it["service_account_id"] as Sub)
+                else subs
             }
 
     fun hasStellioAdminRole(sub: Option<Sub>): Mono<Boolean> =

--- a/search-service/src/main/resources/db/migration/V0_25__swap_client_and_service_account_info.sql
+++ b/search-service/src/main/resources/db/migration/V0_25__swap_client_and_service_account_info.sql
@@ -1,0 +1,7 @@
+update entity_access_rights
+set subject_id = (
+    select service_account_id
+    from subject_referential
+    where subject_referential.subject_id = entity_access_rights.subject_id
+)
+where subject_id in (select subject_id from subject_referential where subject_type = 'CLIENT')

--- a/search-service/src/main/resources/db/migration/V0_25__swap_client_and_service_account_info.sql
+++ b/search-service/src/main/resources/db/migration/V0_25__swap_client_and_service_account_info.sql
@@ -1,7 +1,20 @@
+-- since newly created entities have been manually synchronized with the sync endpoint
+-- there are duplicated entities (one row with client id, another one with service account id)
+-- thus first remove duplicates under the service account id key
+delete from entity_access_rights as A
+where subject_id in (select service_account_id from subject_referential)
+and exists (
+    select subject_id
+    from entity_access_rights
+    where subject_id in (select subject_id from subject_referential where subject_type = 'CLIENT')
+    and A.entity_id = entity_access_rights.entity_id
+);
+
+-- then update rows referencing client id to a reference to a service account id
 update entity_access_rights
 set subject_id = (
     select service_account_id
     from subject_referential
     where subject_referential.subject_id = entity_access_rights.subject_id
 )
-where subject_id in (select subject_id from subject_referential where subject_type = 'CLIENT')
+where subject_id in (select subject_id from subject_referential where subject_type = 'CLIENT');


### PR DESCRIPTION
This is a quick fix to correctly handle the service account id of clients:
- When we get the subject's id along with its groups, we are getting the client id and not the service account id, so the access is denied for clients
- There was a bug in the initializer job as it populated the entity_access_rights table with client ids, and not with service accounts ids (and it works thanks to the problem in the previous point)! To be fixed later for future syncs.

In a near future, this client id / service account id will have to be cleaned up globally as it is currently quite confusing.