### PR TITLE
fix(entity): handle entities without specific attributes in authz checks

### DIFF
--- a/entity-service/src/main/kotlin/com/egm/stellio/entity/authorization/AuthorizationService.kt
+++ b/entity-service/src/main/kotlin/com/egm/stellio/entity/authorization/AuthorizationService.kt
@@ -47,9 +47,9 @@ interface AuthorizationService {
     fun checkAttributesAreAuthorized(
         ngsiLdAttributes: List<NgsiLdAttribute>
     ): Either<APIException, Unit> =
-        ngsiLdAttributes.traverseEither { ngsiLdAttribute ->
+        ngsiLdAttributes.traverse { ngsiLdAttribute ->
             checkAttributeIsAuthorized(ngsiLdAttribute.name)
-        }.map { it.first() }
+        }.map {}
 
     fun checkAttributeIsAuthorized(attributeName: ExpandedTerm): Either<APIException, Unit> =
         if (attributeName == AuthContextModel.AUTH_PROP_SAP)


### PR DESCRIPTION
If provided with a minimal entity containing only an id and a type, the previous check was crashing since the list of attributes is empty (and calling `.first()` on an empty list raises an exception).

Instead, just mapping over the list is enough to get the expected result.