### PR TITLE
feat: add the possibility to make queries only on ids

### DIFF
--- a/entity-service/config/detekt/baseline.xml
+++ b/entity-service/config/detekt/baseline.xml
@@ -2,6 +2,7 @@
 <SmellBaseline>
   <ManuallySuppressedIssues></ManuallySuppressedIssues>
   <CurrentIssues>
+    <ID>ComplexCondition:EntityHandler.kt$EntityHandler$queryParams.ids.isNullOrEmpty() &amp;&amp; queryParams.q.isNullOrEmpty() &amp;&amp; queryParams.types.isNullOrEmpty() &amp;&amp; queryParams.attrs.isNullOrEmpty()</ID>
     <ID>EmptyFunctionBlock:StandaloneAuthorizationService.kt$StandaloneAuthorizationService${}</ID>
     <ID>LongMethod:EntityAccessControlHandlerTests.kt$EntityAccessControlHandlerTests$@Test fun `get authorized entities should return entities I have a right on`()</ID>
     <ID>LongMethod:EntityEventServiceTests.kt$EntityEventServiceTests$@Test fun `it should publish ATTRIBUTE_APPEND and ATTRIBUTE_REPLACE events if attributes were appended and replaced`()</ID>

--- a/entity-service/src/main/kotlin/com/egm/stellio/entity/web/EntityHandler.kt
+++ b/entity-service/src/main/kotlin/com/egm/stellio/entity/web/EntityHandler.kt
@@ -92,11 +92,16 @@ class EntityHandler(
             contextLink
         )
 
-        if (queryParams.q.isNullOrEmpty() && queryParams.types.isNullOrEmpty() && queryParams.attrs.isNullOrEmpty())
+        if (
+            queryParams.ids.isNullOrEmpty() &&
+            queryParams.q.isNullOrEmpty() &&
+            queryParams.types.isNullOrEmpty() &&
+            queryParams.attrs.isNullOrEmpty()
+        )
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).contentType(MediaType.APPLICATION_JSON)
                 .body(
                     BadRequestDataResponse(
-                        "one of 'q', 'type' and 'attrs' request parameters have to be specified"
+                        "one of 'id', 'q', 'type' and 'attrs' request parameters have to be specified"
                     )
                 )
 

--- a/entity-service/src/test/kotlin/com/egm/stellio/entity/repository/Neo4jSearchRepositoryTests.kt
+++ b/entity-service/src/test/kotlin/com/egm/stellio/entity/repository/Neo4jSearchRepositoryTests.kt
@@ -361,6 +361,41 @@ class Neo4jSearchRepositoryTests : WithNeo4jContainer {
         assertTrue(entities.containsAll(expectedEntitiesIds))
     }
 
+    @Test
+    fun `it should return matching entities requested by ids`() {
+        val userEntity = createEntity(userUri, listOf(USER_TYPE), mutableListOf())
+        val firstEntity = createEntity(
+            "urn:ngsi-ld:Beekeeper:01231".toUri(),
+            listOf("Beekeeper"),
+            mutableListOf(Property(name = expandedNameProperty, value = "Scalpa"))
+        )
+        val secondEntity = createEntity(
+            "urn:ngsi-ld:Beekeeper:01232".toUri(),
+            listOf("Beekeeper"),
+            mutableListOf(Property(name = expandedNameProperty, value = "Scalpa2"))
+        )
+        val thirdEntity = createEntity(
+            "urn:ngsi-ld:Beekeeper:03432".toUri(),
+            listOf("Beekeeper"),
+            mutableListOf(Property(name = expandedNameProperty, value = "Scalpa3"))
+        )
+        createRelationship(EntitySubjectNode(userEntity.id), AUTH_REL_CAN_READ, firstEntity.id)
+        createRelationship(EntitySubjectNode(userEntity.id), AUTH_REL_CAN_READ, secondEntity.id)
+        createRelationship(EntitySubjectNode(userEntity.id), AUTH_REL_CAN_READ, thirdEntity.id)
+
+        val entities = searchRepository.getEntities(
+            QueryParams(
+                ids = setOf("urn:ngsi-ld:Beekeeper:01232".toUri(), "urn:ngsi-ld:Beekeeper:03432".toUri()),
+                offset = offset,
+                limit = limit
+            ),
+            sub,
+            DEFAULT_CONTEXTS
+        ).second
+
+        assertTrue(entities.containsAll(listOf(secondEntity.id, thirdEntity.id)))
+    }
+
     fun createEntity(
         id: URI,
         type: List<String>,

--- a/entity-service/src/test/kotlin/com/egm/stellio/entity/web/EntityHandlerTests.kt
+++ b/entity-service/src/test/kotlin/com/egm/stellio/entity/web/EntityHandlerTests.kt
@@ -637,6 +637,49 @@ class EntityHandlerTests {
     }
 
     @Test
+    fun `get entities with request parameter id should return 200`() {
+        every { entityService.exists(any()) } returns true
+        every {
+            entityService.searchEntities(
+                QueryParams(
+                    ids = setOf(beehiveId),
+                    offset = 0,
+                    limit = 30
+                ),
+                any(),
+                any<String>()
+            )
+        } returns Pair(
+            1,
+            listOf(
+                JsonLdEntity(
+                    mapOf(
+                        "@id" to beehiveId.toString(),
+                        "@type" to listOf("Beehive")
+                    ),
+                    listOf(NGSILD_CORE_CONTEXT)
+                )
+            )
+        )
+
+        webClient.get()
+            .uri("/ngsi-ld/v1/entities?id=$beehiveId")
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .exchange()
+            .expectStatus().isOk
+            .expectBody().json(
+                """[
+                        {
+                            "id": "$beehiveId",
+                            "type": "Beehive",
+                            "@context": ["$NGSILD_CORE_CONTEXT"]
+                        }
+                    ]
+                """.trimMargin()
+            )
+    }
+
+    @Test
     fun `get entities should return 200 and the number of results`() {
         every { entityService.exists(any()) } returns true
         every { entityService.searchEntities(any(), any(), any<String>()) } returns Pair(
@@ -1100,7 +1143,7 @@ class EntityHandlerTests {
                 {
                     "type":"https://uri.etsi.org/ngsi-ld/errors/BadRequestData",
                     "title":"The request includes input data which does not meet the requirements of the operation",
-                    "detail":"one of 'q', 'type' and 'attrs' request parameters have to be specified"
+                    "detail":"one of 'id', 'q', 'type' and 'attrs' request parameters have to be specified"
                 }
                 """.trimIndent()
             )


### PR DESCRIPTION
Currently we can make queries with the parameter q, type and/or attrs but also on an id but not on a list of ids.

This feature allows you to make a request on a list of ids.
