### PR TITLE
hotfix(entity): support case-insensitive regex matching on attributes

### DIFF
--- a/entity-service/src/test/kotlin/com/egm/stellio/entity/repository/StandaloneNeo4jSearchRepositoryTests.kt
+++ b/entity-service/src/test/kotlin/com/egm/stellio/entity/repository/StandaloneNeo4jSearchRepositoryTests.kt
@@ -232,6 +232,22 @@ class StandaloneNeo4jSearchRepositoryTests : WithNeo4jContainer {
     }
 
     @Test
+    fun `it should return an entity if given name regex matches the case insensitive value of the name attrbute`() {
+        val entity = createEntity(
+            beekeeperUri,
+            listOf("Beekeeper"),
+            mutableListOf(Property(name = expandedNameProperty, value = "Scalpa"))
+        )
+        val entities = searchRepository.getEntities(
+            QueryParams(types = setOf("Beekeeper"), q = "name=~\"(?i)scalpa.*$\"", offset = offset, limit = limit),
+            sub,
+            DEFAULT_CONTEXTS
+        ).second
+
+        assertTrue(entities.contains(entity.id))
+    }
+
+    @Test
     fun `it should not return an entity if given name regex does not match the value of the name attrbute`() {
         val entity = createEntity(
             beekeeperUri,


### PR DESCRIPTION
Quick and dirty solution until we fully and cleanly implement whole support for NGSI-LD Query Langage
