### PR TITLE
chore: use our own build of json-merge lib

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,7 @@ plugins {
 subprojects {
     repositories {
         mavenCentral()
+        maven { url = uri("https://jitpack.io") }
     }
 
     apply(plugin = "io.spring.dependency-management")

--- a/search-service/build.gradle.kts
+++ b/search-service/build.gradle.kts
@@ -19,7 +19,8 @@ dependencies {
     implementation("org.flywaydb:flyway-core")
     // implementation (and not runtime) because we are using the native jsonb encoding provided by PG
     implementation("org.postgresql:r2dbc-postgresql")
-    implementation("com.savvasdalkitsis:json-merge:0.0.6")
+    implementation("com.github.stellio-hub:json-merge:0.1.0")
+    implementation("org.json:json:20220924")
     implementation(project(":shared"))
 
     detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.22.0")


### PR DESCRIPTION
- currently includes an outdated and insecure version of org.json:json lib
- did a PR in 08/2022 but got no response so far (https://github.com/savvasdalkitsis/json-merge/pull/2)
- so forked (https://github.com/stellio-hub/json-merge) and published the lib on Jitpack (https://jitpack.io/#stellio-hub/json-merge)
