### PR TITLE
refactor: better SoC in core API services and query improvements

### DIFF
--- a/search-service/config/detekt/baseline.xml
+++ b/search-service/config/detekt/baseline.xml
@@ -14,20 +14,19 @@
     <ID>LongMethod:EntityEventServiceTests.kt$EntityEventServiceTests$@Test fun `it should publish ATTRIBUTE_REPLACE events if two attributes are replaced`()</ID>
     <ID>LongMethod:ParameterizedTests.kt$ParameterizedTests.Companion$@JvmStatic fun rawResultsProvider(): Stream&lt;Arguments&gt;</ID>
     <ID>LongMethod:QueryServiceTests.kt$QueryServiceTests$@Test fun `it should query temporal entities as requested by query params`()</ID>
-    <ID>LongMethod:TemporalEntityAttributeService.kt$TemporalEntityAttributeService$@Transactional suspend fun appendEntityAttributes( entityUri: URI, ngsiLdAttributes: List&lt;NgsiLdAttribute&gt;, jsonLdAttributes: Map&lt;String, Any&gt;, disallowOverwrite: Boolean, sub: Sub? ): Either&lt;APIException, UpdateResult&gt;</ID>
-    <ID>LongMethod:TemporalEntityAttributeService.kt$TemporalEntityAttributeService$@Transactional suspend fun partialUpdateEntityAttribute( entityId: URI, expandedPayload: Map&lt;String, List&lt;Map&lt;String, List&lt;Any&gt;&gt;&gt;&gt;, sub: Sub? ): Either&lt;APIException, UpdateResult&gt;</ID>
     <ID>LongMethod:V0_29__JsonLd_migration.kt$V0_29__JsonLd_migration$override fun migrate(context: Context)</ID>
     <ID>LongParameterList:AttributeInstance.kt$AttributeInstance.Companion$( temporalEntityAttribute: UUID, instanceId: URI? = null, timeProperty: TemporalProperty, time: ZonedDateTime, value: String? = null, measuredValue: Double? = null, geoValue: WKTCoordinates? = null, payload: ExpandedAttributePayloadEntry, sub: String? = null )</ID>
     <ID>LongParameterList:EntityEventService.kt$EntityEventService$( sub: String?, entityId: URI, attributeName: String, datasetId: URI? = null, deleteAll: Boolean, contexts: List&lt;String&gt; )</ID>
     <ID>LongParameterList:EntityEventService.kt$EntityEventService$( sub: String?, entityId: URI, jsonLdAttributes: Map&lt;String, Any&gt;, updateResult: UpdateResult, overwrite: Boolean, contexts: List&lt;String&gt; )</ID>
-    <ID>LongParameterList:EntityHandler.kt$EntityHandler$( private val applicationProperties: ApplicationProperties, private val entityPayloadService: EntityPayloadService, private val temporalEntityAttributeService: TemporalEntityAttributeService, private val queryService: QueryService, private val authorizationService: AuthorizationService, private val entityAccessRightsService: EntityAccessRightsService, private val entityEventService: EntityEventService )</ID>
     <ID>LongParameterList:EntityPayloadService.kt$EntityPayloadService$( entityId: URI, types: List&lt;ExpandedTerm&gt;, createdAt: ZonedDateTime, entityPayload: String, contexts: List&lt;String&gt;, specificAccessPolicy: SpecificAccessPolicy? = null )</ID>
     <ID>LongParameterList:TemporalEntityAttributeService.kt$TemporalEntityAttributeService$( entityId: URI, ngsiLdAttribute: NgsiLdAttribute, attributeMetadata: AttributeMetadata, createdAt: ZonedDateTime, attributePayload: ExpandedAttributePayloadEntry, sub: Sub? )</ID>
+    <ID>LongParameterList:TemporalEntityAttributeService.kt$TemporalEntityAttributeService$( entityUri: URI, ngsiLdAttributes: List&lt;NgsiLdAttribute&gt;, jsonLdAttributes: Map&lt;String, Any&gt;, disallowOverwrite: Boolean, createdAt: ZonedDateTime, sub: Sub? )</ID>
     <ID>LongParameterList:TemporalEntityAttributeService.kt$TemporalEntityAttributeService$( temporalEntityAttribute: TemporalEntityAttribute, ngsiLdAttribute: NgsiLdAttribute, attributeMetadata: AttributeMetadata, createdAt: ZonedDateTime, attributePayload: ExpandedAttributePayloadEntry, sub: Sub? )</ID>
     <ID>LongParameterList:V0_29__JsonLd_migration.kt$V0_29__JsonLd_migration$( entityId: URI, attributeName: ExpandedTerm, datasetId: URI?, attributePayload: ExpandedAttributePayloadEntry, ngsiLdAttributeInstance: NgsiLdAttributeInstance, defaultCreatedAt: ZonedDateTime )</ID>
     <ID>NestedBlockDepth:V0_29__JsonLd_migration.kt$V0_29__JsonLd_migration$override fun migrate(context: Context)</ID>
     <ID>SwallowedException:QueryUtils.kt$e: IllegalArgumentException</ID>
     <ID>ThrowsCount:QueryUtils.kt$fun buildTemporalQuery(params: MultiValueMap&lt;String, String&gt;, inQueryEntities: Boolean = false): TemporalQuery</ID>
+    <ID>TooManyFunctions:EntityPayloadService.kt$EntityPayloadService</ID>
     <ID>TooManyFunctions:TemporalEntityAttributeService.kt$TemporalEntityAttributeService</ID>
     <ID>UtilityClassWithPublicConstructor:ParameterizedTests.kt$ParameterizedTests</ID>
     <ID>UtilityClassWithPublicConstructor:QueryParameterizedTests.kt$QueryParameterizedTests</ID>

--- a/search-service/src/main/kotlin/com/egm/stellio/search/authorization/AuthorizationService.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/authorization/AuthorizationService.kt
@@ -16,8 +16,10 @@ interface AuthorizationService {
     suspend fun userCanReadEntity(entityId: URI, sub: Option<Sub>): Either<APIException, Unit>
     suspend fun userCanUpdateEntity(entityId: URI, sub: Option<Sub>): Either<APIException, Unit>
     suspend fun userCanAdminEntity(entityId: URI, sub: Option<Sub>): Either<APIException, Unit>
-    suspend fun createAdminLink(entityId: URI, sub: Option<Sub>): Either<APIException, Unit>
-    suspend fun createAdminLinks(entitiesId: List<URI>, sub: Option<Sub>): Either<APIException, Unit>
+
+    suspend fun createAdminRight(entityId: URI, sub: Option<Sub>): Either<APIException, Unit>
+    suspend fun createAdminRights(entitiesId: List<URI>, sub: Option<Sub>): Either<APIException, Unit>
+    suspend fun removeRightsOnEntity(entityId: URI): Either<APIException, Unit>
 
     suspend fun getAuthorizedEntities(
         queryParams: QueryParams,

--- a/search-service/src/main/kotlin/com/egm/stellio/search/authorization/DisabledAuthorizationService.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/authorization/DisabledAuthorizationService.kt
@@ -29,13 +29,15 @@ class DisabledAuthorizationService : AuthorizationService {
     override suspend fun userCanAdminEntity(entityId: URI, sub: Option<Sub>): Either<APIException, Unit> =
         Unit.right()
 
-    override suspend fun createAdminLink(entityId: URI, sub: Option<Sub>): Either<APIException, Unit> =
+    override suspend fun createAdminRight(entityId: URI, sub: Option<Sub>): Either<APIException, Unit> =
         Unit.right()
 
-    override suspend fun createAdminLinks(
+    override suspend fun createAdminRights(
         entitiesId: List<URI>,
         sub: Option<Sub>
     ): Either<APIException, Unit> = Unit.right()
+
+    override suspend fun removeRightsOnEntity(entityId: URI): Either<APIException, Unit> = Unit.right()
 
     override suspend fun getAuthorizedEntities(
         queryParams: QueryParams,

--- a/search-service/src/main/kotlin/com/egm/stellio/search/authorization/EnabledAuthorizationService.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/authorization/EnabledAuthorizationService.kt
@@ -82,13 +82,16 @@ class EnabledAuthorizationService(
             rights
         )
 
-    override suspend fun createAdminLink(entityId: URI, sub: Option<Sub>): Either<APIException, Unit> =
-        createAdminLinks(listOf(entityId), sub)
+    override suspend fun createAdminRight(entityId: URI, sub: Option<Sub>): Either<APIException, Unit> =
+        createAdminRights(listOf(entityId), sub)
 
-    override suspend fun createAdminLinks(entitiesId: List<URI>, sub: Option<Sub>): Either<APIException, Unit> =
+    override suspend fun createAdminRights(entitiesId: List<URI>, sub: Option<Sub>): Either<APIException, Unit> =
         entitiesId.parTraverseEither {
             entityAccessRightsService.setAdminRoleOnEntity((sub as Some).value, it)
         }.map { it.first() }
+
+    override suspend fun removeRightsOnEntity(entityId: URI): Either<APIException, Unit> =
+        entityAccessRightsService.removeRolesOnEntity(entityId)
 
     override suspend fun getAuthorizedEntities(
         queryParams: QueryParams,

--- a/search-service/src/main/kotlin/com/egm/stellio/search/authorization/SubjectReferential.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/authorization/SubjectReferential.kt
@@ -1,18 +1,19 @@
 package com.egm.stellio.search.authorization
 
+import com.egm.stellio.search.util.deserializeAsMap
 import com.egm.stellio.shared.util.GlobalRole
 import com.egm.stellio.shared.util.JsonLdUtils.JSONLD_VALUE
 import com.egm.stellio.shared.util.JsonUtils
-import com.egm.stellio.shared.util.JsonUtils.deserializeAsMap
 import com.egm.stellio.shared.util.Sub
 import com.egm.stellio.shared.util.SubjectType
+import io.r2dbc.postgresql.codec.Json
 import org.springframework.data.annotation.Id
 
 data class SubjectReferential(
     @Id
     val subjectId: Sub,
     val subjectType: SubjectType,
-    val subjectInfo: String,
+    val subjectInfo: Json,
     val serviceAccountId: Sub? = null,
     val globalRoles: List<GlobalRole>? = null,
     val groupsMemberships: List<Sub>? = null

--- a/search-service/src/main/kotlin/com/egm/stellio/search/authorization/SubjectReferentialService.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/authorization/SubjectReferentialService.kt
@@ -10,7 +10,6 @@ import com.egm.stellio.shared.model.AccessDeniedException
 import com.egm.stellio.shared.util.GlobalRole
 import com.egm.stellio.shared.util.Sub
 import com.egm.stellio.shared.util.SubjectType
-import io.r2dbc.postgresql.codec.Json
 import org.springframework.data.r2dbc.core.R2dbcEntityTemplate
 import org.springframework.data.relational.core.query.Criteria
 import org.springframework.data.relational.core.query.Query
@@ -43,7 +42,7 @@ class SubjectReferentialService(
             )
             .bind("subject_id", subjectReferential.subjectId)
             .bind("subject_type", subjectReferential.subjectType.toString())
-            .bind("subject_info", Json.of(subjectReferential.subjectInfo))
+            .bind("subject_info", subjectReferential.subjectInfo)
             .bind("service_account_id", subjectReferential.serviceAccountId)
             .bind("global_roles", subjectReferential.globalRoles?.map { it.key }?.toTypedArray())
             .bind("groups_memberships", subjectReferential.groupsMemberships?.toTypedArray())
@@ -287,7 +286,7 @@ class SubjectReferentialService(
         SubjectReferential(
             subjectId = row["subject_id"] as Sub,
             subjectType = SubjectType.valueOf(row["subject_type"] as String),
-            subjectInfo = toJsonString(row["subject_info"]),
+            subjectInfo = toJson(row["subject_info"]),
             serviceAccountId = row["service_account_id"] as? Sub,
             globalRoles = toOptionalList<String>(row["global_roles"])
                 ?.mapNotNull { GlobalRole.forKey(it).getOrElse { null } },

--- a/search-service/src/main/kotlin/com/egm/stellio/search/listener/ObservationEventListener.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/listener/ObservationEventListener.kt
@@ -3,7 +3,7 @@ package com.egm.stellio.search.listener
 import arrow.core.Either
 import arrow.core.left
 import com.egm.stellio.search.service.EntityEventService
-import com.egm.stellio.search.service.TemporalEntityAttributeService
+import com.egm.stellio.search.service.EntityPayloadService
 import com.egm.stellio.shared.model.*
 import com.egm.stellio.shared.util.JsonLdUtils.expandJsonLdFragment
 import com.egm.stellio.shared.util.JsonLdUtils.expandJsonLdTerms
@@ -17,7 +17,7 @@ import org.springframework.stereotype.Component
 
 @Component
 class ObservationEventListener(
-    private val temporalEntityAttributeService: TemporalEntityAttributeService,
+    private val entityPayloadService: EntityPayloadService,
     private val entityEventService: EntityEventService
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
@@ -54,7 +54,7 @@ class ObservationEventListener(
     }
 
     suspend fun handleEntityCreate(observationEvent: EntityCreateEvent): Either<APIException, Unit> =
-        temporalEntityAttributeService.createEntityTemporalReferences(
+        entityPayloadService.createEntity(
             observationEvent.operationPayload,
             observationEvent.contexts,
             observationEvent.sub
@@ -74,7 +74,7 @@ class ObservationEventListener(
             observationEvent.contexts
         )
 
-        return temporalEntityAttributeService.partialUpdateEntityAttribute(
+        return entityPayloadService.partialUpdateAttribute(
             observationEvent.entityId,
             expandedPayload,
             observationEvent.sub
@@ -107,7 +107,7 @@ class ObservationEventListener(
         )
 
         val ngsiLdAttributes = parseToNgsiLdAttributes(expandedPayload)
-        return temporalEntityAttributeService.appendEntityAttributes(
+        return entityPayloadService.appendAttributes(
             observationEvent.entityId,
             ngsiLdAttributes,
             expandedPayload,

--- a/search-service/src/main/kotlin/com/egm/stellio/search/model/AttributeInstance.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/model/AttributeInstance.kt
@@ -6,6 +6,7 @@ import com.egm.stellio.shared.util.JsonLdUtils.NGSILD_INSTANCE_ID_PROPERTY
 import com.egm.stellio.shared.util.JsonLdUtils.buildNonReifiedProperty
 import com.egm.stellio.shared.util.JsonUtils.serializeObject
 import com.egm.stellio.shared.util.toUri
+import io.r2dbc.postgresql.codec.Json
 import java.net.URI
 import java.time.ZonedDateTime
 import java.util.UUID
@@ -18,7 +19,7 @@ data class AttributeInstance private constructor(
     val value: String? = null,
     val measuredValue: Double? = null,
     val geoValue: WKTCoordinates? = null,
-    val payload: String,
+    val payload: Json,
     val sub: String? = null
 ) {
     companion object {
@@ -49,7 +50,7 @@ data class AttributeInstance private constructor(
                 value = value,
                 measuredValue = measuredValue,
                 geoValue = geoValue,
-                payload = serializeObject(parsedPayload),
+                payload = Json.of(serializeObject(parsedPayload)),
                 sub = sub
             )
         }

--- a/search-service/src/main/kotlin/com/egm/stellio/search/model/EntityPayload.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/model/EntityPayload.kt
@@ -13,6 +13,7 @@ import com.egm.stellio.shared.util.JsonLdUtils.NGSILD_MODIFIED_AT_PROPERTY
 import com.egm.stellio.shared.util.JsonLdUtils.buildExpandedProperty
 import com.egm.stellio.shared.util.JsonLdUtils.buildNonReifiedDateTime
 import com.egm.stellio.shared.util.JsonLdUtils.compactTerm
+import io.r2dbc.postgresql.codec.Json
 import java.net.URI
 import java.time.ZonedDateTime
 
@@ -24,7 +25,7 @@ data class EntityPayload(
     // creation time contexts
     // FIXME only stored because needed to compact types at deletion time...
     val contexts: List<String>,
-    val entityPayload: String,
+    val payload: Json,
     val specificAccessPolicy: SpecificAccessPolicy? = null
 ) {
     fun serializeProperties(

--- a/search-service/src/main/kotlin/com/egm/stellio/search/model/TemporalEntityAttribute.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/model/TemporalEntityAttribute.kt
@@ -1,6 +1,7 @@
 package com.egm.stellio.search.model
 
 import com.egm.stellio.shared.model.ExpandedTerm
+import io.r2dbc.postgresql.codec.Json
 import org.springframework.data.annotation.Id
 import java.net.URI
 import java.time.ZonedDateTime
@@ -16,7 +17,7 @@ data class TemporalEntityAttribute(
     val datasetId: URI? = null,
     val createdAt: ZonedDateTime,
     val modifiedAt: ZonedDateTime? = null,
-    val payload: String
+    val payload: Json
 ) {
     enum class AttributeValueType {
         NUMBER,

--- a/search-service/src/main/kotlin/com/egm/stellio/search/model/UpdateResult.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/model/UpdateResult.kt
@@ -60,8 +60,8 @@ enum class UpdateOperationResult {
     fun isSuccessResult(): Boolean = listOf(APPENDED, REPLACED, UPDATED).contains(this)
 }
 
-fun List<UpdateAttributeResult>.hasSuccessfulUpdate(): Boolean =
-    this.any { it.isSuccessfullyUpdated() }
+fun UpdateResult.hasSuccessfulUpdate(): Boolean =
+    this.updated.isNotEmpty()
 
 fun updateResultFromDetailedResult(updateStatuses: List<UpdateAttributeResult>): UpdateResult {
     val updated = updateStatuses.filter { it.isSuccessfullyUpdated() }

--- a/search-service/src/main/kotlin/com/egm/stellio/search/service/AttributeInstanceService.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/service/AttributeInstanceService.kt
@@ -15,7 +15,6 @@ import com.egm.stellio.shared.util.JsonLdUtils.NGSILD_PROPERTY_VALUE
 import com.egm.stellio.shared.util.JsonLdUtils.getPropertyValueFromMap
 import com.egm.stellio.shared.util.JsonLdUtils.getPropertyValueFromMapAsDateTime
 import com.egm.stellio.shared.util.instanceNotFoundMessage
-import io.r2dbc.postgresql.codec.Json
 import org.springframework.r2dbc.core.DatabaseClient
 import org.springframework.r2dbc.core.bind
 import org.springframework.stereotype.Service
@@ -89,7 +88,7 @@ class AttributeInstanceService(
             }
             .bind("temporal_entity_attribute", attributeInstance.temporalEntityAttribute)
             .bind("instance_id", attributeInstance.instanceId)
-            .bind("payload", Json.of(attributeInstance.payload))
+            .bind("payload", attributeInstance.payload)
             .let {
                 if (attributeInstance.timeProperty != AttributeInstance.TemporalProperty.OBSERVED_AT)
                     it.bind("time_property", attributeInstance.timeProperty.toString())

--- a/search-service/src/main/kotlin/com/egm/stellio/search/service/EntityAttributeCleanerService.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/service/EntityAttributeCleanerService.kt
@@ -1,0 +1,32 @@
+package com.egm.stellio.search.service
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import java.net.URI
+
+@Component
+class EntityAttributeCleanerService(
+    private val temporalEntityAttributeService: TemporalEntityAttributeService,
+    private val attributeInstanceService: AttributeInstanceService
+) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    private val coroutineScope = CoroutineScope(Dispatchers.Default)
+
+    fun deleteEntityAttributes(entityId: URI): Job =
+        coroutineScope.launch {
+            attributeInstanceService.deleteInstancesOfEntity(entityId)
+                .onLeft {
+                    logger.error("Unable to delete attributes instances of $entityId: $it")
+                }
+            temporalEntityAttributeService.deleteTemporalAttributesOfEntity(entityId)
+                .onLeft {
+                    logger.error("Unable to delete attributes of $entityId: $it")
+                }
+        }
+}

--- a/search-service/src/main/kotlin/com/egm/stellio/search/service/IAMListener.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/service/IAMListener.kt
@@ -18,6 +18,7 @@ import com.egm.stellio.shared.util.JsonUtils
 import com.egm.stellio.shared.util.JsonUtils.deserializeAsMap
 import com.egm.stellio.shared.util.SubjectType
 import com.egm.stellio.shared.util.extractSub
+import io.r2dbc.postgresql.codec.Json
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -73,7 +74,7 @@ class IAMListener(
         val subjectReferential = SubjectReferential(
             subjectId = entityCreateEvent.entityId.extractSub(),
             subjectType = SubjectType.valueOf(entityCreateEvent.entityTypes.first().uppercase()),
-            subjectInfo = subjectInfo,
+            subjectInfo = Json.of(subjectInfo),
             globalRoles = roles
         )
 

--- a/search-service/src/main/kotlin/com/egm/stellio/search/service/QueryService.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/service/QueryService.kt
@@ -6,8 +6,8 @@ import arrow.core.getOrElse
 import arrow.core.left
 import arrow.core.right
 import com.egm.stellio.search.model.*
+import com.egm.stellio.search.util.deserializeAsMap
 import com.egm.stellio.shared.model.*
-import com.egm.stellio.shared.util.JsonUtils.deserializeObject
 import com.egm.stellio.shared.util.entityOrAttrsNotFoundMessage
 import com.egm.stellio.shared.util.wktToGeoJson
 import org.springframework.stereotype.Service
@@ -195,7 +195,7 @@ class QueryService(
         entityPayload: EntityPayload,
         contexts: List<String>
     ): JsonLdEntity {
-        val deserializedEntity = deserializeObject(entityPayload.entityPayload)
+        val deserializedEntity = entityPayload.payload.deserializeAsMap()
         return JsonLdEntity(deserializedEntity, contexts)
     }
 }

--- a/search-service/src/main/kotlin/com/egm/stellio/search/service/TemporalEntityAttributeService.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/service/TemporalEntityAttributeService.kt
@@ -25,9 +25,6 @@ import com.savvasdalkitsis.jsonmerger.JsonMerger
 import io.r2dbc.postgresql.codec.Json
 import org.json.JSONObject
 import org.slf4j.LoggerFactory
-import org.springframework.data.r2dbc.core.R2dbcEntityTemplate
-import org.springframework.data.relational.core.query.Criteria.where
-import org.springframework.data.relational.core.query.Query.query
 import org.springframework.r2dbc.core.DatabaseClient
 import org.springframework.r2dbc.core.bind
 import org.springframework.stereotype.Service
@@ -41,9 +38,7 @@ import java.util.regex.Pattern
 @Service
 class TemporalEntityAttributeService(
     private val databaseClient: DatabaseClient,
-    private val r2dbcEntityTemplate: R2dbcEntityTemplate,
-    private val attributeInstanceService: AttributeInstanceService,
-    private val entityPayloadService: EntityPayloadService
+    private val attributeInstanceService: AttributeInstanceService
 ) {
 
     private val logger = LoggerFactory.getLogger(javaClass)
@@ -67,7 +62,7 @@ class TemporalEntityAttributeService(
             .bind("attribute_value_type", temporalEntityAttribute.attributeValueType.toString())
             .bind("created_at", temporalEntityAttribute.createdAt)
             .bind("dataset_id", temporalEntityAttribute.datasetId)
-            .bind("payload", Json.of(temporalEntityAttribute.payload))
+            .bind("payload", temporalEntityAttribute.payload)
             .execute()
 
     @Transactional
@@ -95,12 +90,18 @@ class TemporalEntityAttributeService(
             .bind("payload", Json.of(payload))
             .execute()
 
+    /**
+     * Currently only used in the tests for easy creation of attributes.
+     *
+     * To be removed at some point later.
+     */
     @Transactional
     suspend fun createEntityTemporalReferences(
         payload: String,
         contexts: List<String>,
         sub: String? = null
     ): Either<APIException, Unit> {
+        val createdAt = ZonedDateTime.now(ZoneOffset.UTC)
         val jsonLdEntity = expandJsonLdEntity(payload, contexts)
         val ngsiLdEntity = jsonLdEntity.toNgsiLdEntity()
         return ngsiLdEntity.prepareTemporalAttributes()
@@ -109,6 +110,7 @@ class TemporalEntityAttributeService(
                     jsonLdEntity.toNgsiLdEntity(),
                     jsonLdEntity,
                     it,
+                    createdAt,
                     sub
                 )
             }
@@ -119,12 +121,10 @@ class TemporalEntityAttributeService(
         ngsiLdEntity: NgsiLdEntity,
         jsonLdEntity: JsonLdEntity,
         attributesMetadata: List<Pair<ExpandedTerm, AttributeMetadata>>,
+        createdAt: ZonedDateTime,
         sub: String? = null
     ): Either<APIException, Unit> = either {
-        val createdAt = ZonedDateTime.now(ZoneOffset.UTC)
         logger.debug("Creating ${attributesMetadata.size} attributes in entity: ${ngsiLdEntity.id}")
-
-        entityPayloadService.createEntityPayload(ngsiLdEntity, createdAt, jsonLdEntity).bind()
 
         attributesMetadata
             .filter {
@@ -144,7 +144,7 @@ class TemporalEntityAttributeService(
                     attributeValueType = attributeMetadata.valueType,
                     datasetId = attributeMetadata.datasetId,
                     createdAt = createdAt,
-                    payload = serializeObject(attributePayload)
+                    payload = Json.of(serializeObject(attributePayload))
                 )
                 create(temporalEntityAttribute).bind()
 
@@ -214,7 +214,7 @@ class TemporalEntityAttributeService(
                 attributeValueType = attributeMetadata.valueType,
                 datasetId = attributeMetadata.datasetId,
                 createdAt = createdAt,
-                payload = serializeObject(attributePayload)
+                payload = Json.of(serializeObject(attributePayload))
             )
             create(temporalEntityAttribute).bind()
 
@@ -277,17 +277,14 @@ class TemporalEntityAttributeService(
             }
         }
 
-    suspend fun deleteTemporalEntityReferences(entityId: URI): Either<APIException, Unit> =
-        either {
-            logger.debug("Deleting entity $entityId")
-            attributeInstanceService.deleteInstancesOfEntity(entityId).bind()
-            deleteTemporalAttributesOfEntity(entityId).bind()
-            entityPayloadService.deleteEntityPayload(entityId).bind()
-        }
-
     suspend fun deleteTemporalAttributesOfEntity(entityId: URI): Either<APIException, Unit> =
-        r2dbcEntityTemplate.delete(TemporalEntityAttribute::class.java)
-            .matching(query(where("entity_id").`is`(entityId)))
+        databaseClient.sql(
+            """
+            DELETE FROM temporal_entity_attribute
+            WHERE entity_id = :entity_id
+            """.trimIndent()
+        )
+            .bind("entity_id", entityId)
             .execute()
 
     suspend fun deleteTemporalAttribute(
@@ -305,11 +302,6 @@ class TemporalEntityAttributeService(
                 attributeInstanceService.deleteInstancesOfAttribute(entityId, attributeName, datasetId).bind()
                 deleteTemporalAttributeReferences(entityId, attributeName, datasetId).bind()
             }
-            entityPayloadService.updateState(
-                entityId,
-                ZonedDateTime.now(ZoneOffset.UTC),
-                getForEntity(entityId, emptySet())
-            ).bind()
         }
 
     @Transactional
@@ -664,7 +656,7 @@ class TemporalEntityAttributeService(
             datasetId = toOptionalUri(row["dataset_id"]),
             createdAt = toZonedDateTime(row["created_at"]),
             modifiedAt = toOptionalZonedDateTime(row["modified_at"]),
-            payload = toJsonString(row["payload"])
+            payload = toJson(row["payload"])
         )
 
     suspend fun checkEntityAndAttributeExistence(
@@ -713,11 +705,11 @@ class TemporalEntityAttributeService(
         ngsiLdAttributes: List<NgsiLdAttribute>,
         jsonLdAttributes: Map<String, Any>,
         disallowOverwrite: Boolean,
+        createdAt: ZonedDateTime,
         sub: Sub?
     ): Either<APIException, UpdateResult> =
         either {
             val attributeInstances = ngsiLdAttributes.flatOnInstances()
-            val createdAt = ZonedDateTime.now(ZoneOffset.UTC)
             attributeInstances.parTraverseEither { (ngsiLdAttribute, ngsiLdAttributeInstance) ->
                 logger.debug("Appending attribute ${ngsiLdAttribute.name} in entity $entityUri")
                 val currentTea =
@@ -769,12 +761,6 @@ class TemporalEntityAttributeService(
                         null
                     ).right()
                 }
-            }.onRight {
-                // update modifiedAt in entity if at least one attribute has been added
-                if (it.hasSuccessfulUpdate()) {
-                    val teas = getForEntity(entityUri, emptySet())
-                    entityPayloadService.updateState(entityUri, createdAt, teas).bind()
-                }
             }.fold({
                 it
             }, {
@@ -787,11 +773,11 @@ class TemporalEntityAttributeService(
         entityUri: URI,
         ngsiLdAttributes: List<NgsiLdAttribute>,
         jsonLdAttributes: Map<String, Any>,
+        createdAt: ZonedDateTime,
         sub: Sub?
     ): Either<APIException, UpdateResult> =
         either {
             val attributeInstances = ngsiLdAttributes.flatOnInstances()
-            val createdAt = ZonedDateTime.now(ZoneOffset.UTC)
             attributeInstances.parTraverseEither { (ngsiLdAttribute, ngsiLdAttributeInstance) ->
                 logger.debug("Updating attribute ${ngsiLdAttribute.name} in entity $entityUri")
                 val currentTea =
@@ -831,12 +817,6 @@ class TemporalEntityAttributeService(
                         message
                     ).right()
                 }
-            }.onRight {
-                // update modifiedAt in entity if at least one attribute has been added
-                if (it.hasSuccessfulUpdate()) {
-                    val teas = getForEntity(entityUri, emptySet())
-                    entityPayloadService.updateState(entityUri, createdAt, teas).bind()
-                }
             }.fold({
                 it
             }, {
@@ -848,12 +828,12 @@ class TemporalEntityAttributeService(
     suspend fun partialUpdateEntityAttribute(
         entityId: URI,
         expandedPayload: Map<String, List<Map<String, List<Any>>>>,
+        modifiedAt: ZonedDateTime,
         sub: Sub?
     ): Either<APIException, UpdateResult> =
         either {
             val expandedAttributeName = expandedPayload.keys.first()
             val attributeValues = expandedPayload.values.first()[0]
-            val modifiedAt = ZonedDateTime.now(ZoneOffset.UTC)
             logger.debug("Updating attribute $expandedAttributeName of entity $entityId with values: $attributeValues")
 
             val datasetId = attributeValues.getDatasetId()
@@ -862,7 +842,7 @@ class TemporalEntityAttributeService(
                 if (exists) {
                     // first update payload in temporal entity attribute
                     val tea = getForEntityAndAttribute(entityId, expandedAttributeName, datasetId).bind()
-                    val jsonSourceObject = JSONObject(tea.payload)
+                    val jsonSourceObject = JSONObject(tea.payload.asString())
                     val jsonUpdateObject = JSONObject(attributeValues)
                     val jsonMerger = JsonMerger(
                         arrayMergeMode = JsonMerger.ArrayMergeMode.REPLACE_ARRAY,
@@ -910,11 +890,6 @@ class TemporalEntityAttributeService(
                         "Unknown attribute $expandedAttributeName with datasetId $datasetId in entity $entityId"
                     )
                 }
-
-            if (updateAttributeResult.isSuccessfullyUpdated()) {
-                val teas = getForEntity(entityId, emptySet())
-                entityPayloadService.updateState(entityId, modifiedAt, teas).bind()
-            }
 
             updateResultFromDetailedResult(listOf(updateAttributeResult))
         }

--- a/search-service/src/main/kotlin/com/egm/stellio/search/support/ApiTestsBootstrapper.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/support/ApiTestsBootstrapper.kt
@@ -4,6 +4,7 @@ import com.egm.stellio.search.authorization.SubjectReferential
 import com.egm.stellio.search.authorization.SubjectReferentialService
 import com.egm.stellio.shared.util.GlobalRole
 import com.egm.stellio.shared.util.SubjectType
+import io.r2dbc.postgresql.codec.Json
 import kotlinx.coroutines.runBlocking
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.CommandLineRunner
@@ -100,10 +101,11 @@ class ApiTestsBootstrapper(
         SubjectReferential(
             subjectId = subjectId,
             subjectType = SubjectType.USER,
-            subjectInfo =
-            """
-            {"type":"Property","value":{"username":"$username"}}
-            """.trimIndent(),
+            subjectInfo = Json.of(
+                """
+                {"type":"Property","value":{"username":"$username"}}
+                """.trimIndent()
+            ),
             globalRoles = globalRoles,
             groupsMemberships =
             if (!groupMembership.isNullOrEmpty())
@@ -115,10 +117,11 @@ class ApiTestsBootstrapper(
         SubjectReferential(
             subjectId = subjectId,
             subjectType = SubjectType.GROUP,
-            subjectInfo =
-            """
-            {"type":"Property","value":{"name":"$groupName"}}
-            """.trimIndent()
+            subjectInfo = Json.of(
+                """
+                {"type":"Property","value":{"name":"$groupName"}}
+                """.trimIndent()
+            )
         )
 
     suspend fun createSubject(subjectId: String, subjectReferential: SubjectReferential) =

--- a/search-service/src/main/kotlin/com/egm/stellio/search/util/DBConversionUtils.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/util/DBConversionUtils.kt
@@ -1,5 +1,7 @@
 package com.egm.stellio.search.util
 
+import com.egm.stellio.shared.util.JsonUtils.deserializeAsMap
+import com.egm.stellio.shared.util.JsonUtils.deserializeExpandedPayload
 import com.egm.stellio.shared.util.toUri
 import io.r2dbc.postgresql.codec.Json
 import java.net.URI
@@ -18,8 +20,12 @@ fun toOptionalZonedDateTime(entry: Any?): ZonedDateTime? =
     (entry as? OffsetDateTime)?.atZoneSameInstant(ZoneOffset.UTC)
 fun <T> toList(entry: Any?): List<T> = (entry as Array<T>).toList()
 fun <T> toOptionalList(entry: Any?): List<T>? = (entry as? Array<T>)?.toList()
+fun toJson(entry: Any?): Json = entry as Json
 fun toJsonString(entry: Any?): String = (entry as Json).asString()
 inline fun <reified T : Enum<T>> toEnum(entry: Any) = enumValueOf<T>(entry as String)
 inline fun <reified T : Enum<T>> toOptionalEnum(entry: Any?) =
     (entry as? String)?.let { enumValueOf<T>(it) }
 fun toInt(entry: Any?): Int = (entry as Long).toInt()
+
+fun Json.deserializeExpandedPayload(): Map<String, List<Any>> = this.asString().deserializeExpandedPayload()
+fun Json.deserializeAsMap(): Map<String, Any> = this.asString().deserializeAsMap()

--- a/search-service/src/main/kotlin/com/egm/stellio/search/web/EntityOperationHandler.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/web/EntityOperationHandler.kt
@@ -267,7 +267,7 @@ class EntityOperationHandler(
     ) {
         if (entitiesToCreate.isNotEmpty()) {
             val createOperationResult = entityOperationService.create(entitiesToCreate, jsonLdEntities, sub.orNull())
-            authorizationService.createAdminLinks(createOperationResult.getSuccessfulEntitiesIds(), sub)
+            authorizationService.createAdminRights(createOperationResult.getSuccessfulEntitiesIds(), sub)
             entitiesToCreate
                 .filter { it.id in createOperationResult.getSuccessfulEntitiesIds() }
                 .forEach {

--- a/search-service/src/test/kotlin/com/egm/stellio/search/authorization/EnabledAuthorizationServiceTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/authorization/EnabledAuthorizationServiceTests.kt
@@ -182,7 +182,7 @@ class EnabledAuthorizationServiceTests {
     fun `it should create admin link for a set of entities`() = runTest {
         coEvery { entityAccessRightsService.setAdminRoleOnEntity(any(), any()) } returns Unit.right()
 
-        enabledAuthorizationService.createAdminLinks(listOf(entityId01, entityId02), Some(subjectUuid))
+        enabledAuthorizationService.createAdminRights(listOf(entityId01, entityId02), Some(subjectUuid))
             .shouldSucceed()
 
         coVerifyAll {

--- a/search-service/src/test/kotlin/com/egm/stellio/search/authorization/EntityAccessRightsServiceTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/authorization/EntityAccessRightsServiceTests.kt
@@ -5,6 +5,7 @@ import arrow.core.right
 import com.egm.stellio.search.model.EntityPayload
 import com.egm.stellio.search.service.EntityPayloadService
 import com.egm.stellio.search.support.WithTimescaleContainer
+import com.egm.stellio.search.util.EMPTY_PAYLOAD
 import com.egm.stellio.shared.model.AccessDeniedException
 import com.egm.stellio.shared.model.ExpandedTerm
 import com.egm.stellio.shared.util.*
@@ -17,6 +18,7 @@ import com.ninjasquad.springmockk.SpykBean
 import io.mockk.Called
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.r2dbc.postgresql.codec.Json
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
@@ -381,7 +383,7 @@ class EntityAccessRightsServiceTests : WithTimescaleContainer {
     @Test
     fun `it should return nothing when list of entities is empty`() = runTest {
         entityAccessRightsService.getAccessRightsForEntities(Some(subjectUuid), emptyList())
-            .shouldSucceedWith { assertTrue(it.isNullOrEmpty()) }
+            .shouldSucceedWith { assertTrue(it.isEmpty()) }
     }
 
     @Test
@@ -475,7 +477,7 @@ class EntityAccessRightsServiceTests : WithTimescaleContainer {
     private suspend fun createSubjectReferential(
         subjectId: String,
         subjectType: SubjectType,
-        subjectInfo: String,
+        subjectInfo: Json,
         serviceAccountId: String? = null
     ) {
         subjectReferentialService.create(

--- a/search-service/src/test/kotlin/com/egm/stellio/search/authorization/SubjectInfoUtils.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/authorization/SubjectInfoUtils.kt
@@ -1,16 +1,24 @@
 package com.egm.stellio.search.authorization
 
-internal fun getSubjectInfoForUser(username: String): String =
-    """
-    { "type": "Property", "value": { "username": "$username" } }
-    """.trimIndent()
+import io.r2dbc.postgresql.codec.Json
 
-internal fun getSubjectInfoForGroup(name: String): String =
-    """
-    { "type": "Property", "value": { "name": "$name" } }
-    """.trimIndent()
+internal fun getSubjectInfoForUser(username: String): Json =
+    Json.of(
+        """
+        { "type": "Property", "value": { "username": "$username" } }
+        """.trimIndent()
+    )
 
-internal fun getSubjectInfoForClient(clientId: String): String =
-    """
-    { "type": "Property", "value": { "clientId": "$clientId" } }
-    """.trimIndent()
+internal fun getSubjectInfoForGroup(name: String): Json =
+    Json.of(
+        """
+        { "type": "Property", "value": { "name": "$name" } }
+        """.trimIndent()
+    )
+
+internal fun getSubjectInfoForClient(clientId: String): Json =
+    Json.of(
+        """
+        { "type": "Property", "value": { "clientId": "$clientId" } }
+        """.trimIndent()
+    )

--- a/search-service/src/test/kotlin/com/egm/stellio/search/authorization/SubjectReferentialServiceTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/authorization/SubjectReferentialServiceTests.kt
@@ -2,6 +2,7 @@ package com.egm.stellio.search.authorization
 
 import arrow.core.Some
 import com.egm.stellio.search.support.WithTimescaleContainer
+import com.egm.stellio.search.util.EMPTY_JSON_PAYLOAD
 import com.egm.stellio.shared.model.AccessDeniedException
 import com.egm.stellio.shared.util.*
 import com.egm.stellio.shared.util.GlobalRole.STELLIO_ADMIN
@@ -46,7 +47,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer {
         val subjectReferential = SubjectReferential(
             subjectId = subjectUuid,
             subjectType = SubjectType.USER,
-            subjectInfo = EMPTY_PAYLOAD,
+            subjectInfo = EMPTY_JSON_PAYLOAD,
             globalRoles = listOf(STELLIO_ADMIN)
         )
 
@@ -61,7 +62,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer {
         val subjectReferential = SubjectReferential(
             subjectId = subjectUuid,
             subjectType = SubjectType.USER,
-            subjectInfo = EMPTY_PAYLOAD,
+            subjectInfo = EMPTY_JSON_PAYLOAD,
             globalRoles = listOf(STELLIO_ADMIN)
         )
 
@@ -100,7 +101,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer {
         val subjectReferential = SubjectReferential(
             subjectId = subjectUuid,
             subjectType = SubjectType.USER,
-            subjectInfo = EMPTY_PAYLOAD,
+            subjectInfo = EMPTY_JSON_PAYLOAD,
             groupsMemberships = groupsUuids
         )
 
@@ -118,7 +119,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer {
         val subjectReferential = SubjectReferential(
             subjectId = subjectUuid,
             subjectType = SubjectType.USER,
-            subjectInfo = EMPTY_PAYLOAD,
+            subjectInfo = EMPTY_JSON_PAYLOAD,
         )
 
         subjectReferentialService.create(subjectReferential)
@@ -135,7 +136,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer {
         val subjectReferential = SubjectReferential(
             subjectId = subjectUuid,
             subjectType = SubjectType.CLIENT,
-            subjectInfo = EMPTY_PAYLOAD,
+            subjectInfo = EMPTY_JSON_PAYLOAD,
             serviceAccountId = serviceAccountUuid
         )
 
@@ -154,7 +155,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer {
         val subjectReferential = SubjectReferential(
             subjectId = subjectUuid,
             subjectType = SubjectType.CLIENT,
-            subjectInfo = EMPTY_PAYLOAD,
+            subjectInfo = EMPTY_JSON_PAYLOAD,
             serviceAccountId = serviceAccountUuid,
             groupsMemberships = groupsUuids
         )
@@ -185,7 +186,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer {
         val subjectReferential = SubjectReferential(
             subjectId = subjectUuid,
             subjectType = SubjectType.USER,
-            subjectInfo = EMPTY_PAYLOAD,
+            subjectInfo = EMPTY_JSON_PAYLOAD,
             groupsMemberships = userGroupsUuids
         )
 
@@ -221,7 +222,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer {
         val subjectReferential = SubjectReferential(
             subjectId = subjectUuid,
             subjectType = SubjectType.USER,
-            subjectInfo = EMPTY_PAYLOAD,
+            subjectInfo = EMPTY_JSON_PAYLOAD,
             groupsMemberships = userGroupsUuids
         )
 
@@ -247,7 +248,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer {
     fun `it should update the global role of a subject`() = runTest {
         val subjectReferential = SubjectReferential(
             subjectId = subjectUuid,
-            subjectInfo = EMPTY_PAYLOAD,
+            subjectInfo = EMPTY_JSON_PAYLOAD,
             subjectType = SubjectType.USER
         )
 
@@ -271,7 +272,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer {
         val subjectReferential = SubjectReferential(
             subjectId = subjectUuid,
             subjectType = SubjectType.USER,
-            subjectInfo = EMPTY_PAYLOAD,
+            subjectInfo = EMPTY_JSON_PAYLOAD,
             globalRoles = listOf(STELLIO_ADMIN)
         )
 
@@ -302,7 +303,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer {
         val userAccessRights = SubjectReferential(
             subjectId = subjectUuid,
             subjectType = SubjectType.USER,
-            subjectInfo = EMPTY_PAYLOAD,
+            subjectInfo = EMPTY_JSON_PAYLOAD,
         )
 
         subjectReferentialService.create(userAccessRights)
@@ -321,7 +322,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer {
         val userAccessRights = SubjectReferential(
             subjectId = subjectUuid,
             subjectType = SubjectType.USER,
-            subjectInfo = EMPTY_PAYLOAD,
+            subjectInfo = EMPTY_JSON_PAYLOAD,
         )
 
         subjectReferentialService.create(userAccessRights)
@@ -343,7 +344,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer {
         val userAccessRights = SubjectReferential(
             subjectId = subjectUuid,
             subjectType = SubjectType.USER,
-            subjectInfo = EMPTY_PAYLOAD,
+            subjectInfo = EMPTY_JSON_PAYLOAD,
         )
 
         subjectReferentialService.create(userAccessRights)
@@ -363,7 +364,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer {
         val userAccessRights = SubjectReferential(
             subjectId = subjectUuid,
             subjectType = SubjectType.USER,
-            subjectInfo = EMPTY_PAYLOAD,
+            subjectInfo = EMPTY_JSON_PAYLOAD,
         )
 
         subjectReferentialService.create(userAccessRights)
@@ -428,7 +429,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer {
         val userAccessRights = SubjectReferential(
             subjectId = subjectUuid,
             subjectType = SubjectType.USER,
-            subjectInfo = EMPTY_PAYLOAD,
+            subjectInfo = EMPTY_JSON_PAYLOAD,
             globalRoles = listOf(STELLIO_ADMIN)
         )
 
@@ -450,7 +451,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer {
         val subjectReferential = SubjectReferential(
             subjectId = subjectUuid,
             subjectType = SubjectType.USER,
-            subjectInfo = EMPTY_PAYLOAD
+            subjectInfo = EMPTY_JSON_PAYLOAD
         )
 
         subjectReferentialService.create(subjectReferential)
@@ -465,7 +466,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer {
         val subjectReferential = SubjectReferential(
             subjectId = subjectUuid,
             subjectType = SubjectType.USER,
-            subjectInfo = EMPTY_PAYLOAD,
+            subjectInfo = EMPTY_JSON_PAYLOAD,
             globalRoles = listOf(STELLIO_ADMIN)
         )
 
@@ -483,7 +484,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer {
         val subjectReferential = SubjectReferential(
             subjectId = subjectUuid,
             subjectType = SubjectType.USER,
-            subjectInfo = EMPTY_PAYLOAD,
+            subjectInfo = EMPTY_JSON_PAYLOAD,
             globalRoles = listOf(STELLIO_CREATOR, STELLIO_ADMIN)
         )
 

--- a/search-service/src/test/kotlin/com/egm/stellio/search/listener/ObservationEventListenerTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/listener/ObservationEventListenerTests.kt
@@ -6,7 +6,7 @@ import com.egm.stellio.search.model.UpdateOperationResult
 import com.egm.stellio.search.model.UpdateResult
 import com.egm.stellio.search.model.UpdatedDetails
 import com.egm.stellio.search.service.EntityEventService
-import com.egm.stellio.search.service.TemporalEntityAttributeService
+import com.egm.stellio.search.service.EntityPayloadService
 import com.egm.stellio.shared.model.JsonLdEntity
 import com.egm.stellio.shared.util.*
 import com.ninjasquad.springmockk.MockkBean
@@ -29,7 +29,7 @@ class ObservationEventListenerTests {
     private lateinit var observationEventListener: ObservationEventListener
 
     @MockkBean(relaxed = true)
-    private lateinit var temporalEntityAttributeService: TemporalEntityAttributeService
+    private lateinit var entityPayloadService: EntityPayloadService
 
     @MockkBean(relaxed = true)
     private lateinit var entityEventService: EntityEventService
@@ -42,13 +42,13 @@ class ObservationEventListenerTests {
         val observationEvent = loadSampleData("events/entity/entityCreateEvent.json")
 
         coEvery {
-            temporalEntityAttributeService.createEntityTemporalReferences(any<String>(), any(), any())
+            entityPayloadService.createEntity(any<String>(), any(), any())
         } returns Unit.right()
 
         observationEventListener.dispatchObservationMessage(observationEvent)
 
         coVerify {
-            temporalEntityAttributeService.createEntityTemporalReferences(
+            entityPayloadService.createEntity(
                 any(),
                 listOf(APIC_COMPOUND_CONTEXT),
                 eq("0123456789-1234-5678-987654321")
@@ -70,7 +70,7 @@ class ObservationEventListenerTests {
         val observationEvent = loadSampleData("events/entity/attributeUpdateNumericPropDatasetIdEvent.json")
 
         coEvery {
-            temporalEntityAttributeService.partialUpdateEntityAttribute(any(), any(), any())
+            entityPayloadService.partialUpdateAttribute(any(), any(), any())
         } returns UpdateResult(
             updated = arrayListOf(
                 UpdatedDetails(
@@ -89,7 +89,7 @@ class ObservationEventListenerTests {
         observationEventListener.dispatchObservationMessage(observationEvent)
 
         coVerify {
-            temporalEntityAttributeService.partialUpdateEntityAttribute(
+            entityPayloadService.partialUpdateAttribute(
                 expectedEntityId,
                 match { it.containsKey(TEMPERATURE_PROPERTY) },
                 null
@@ -117,7 +117,7 @@ class ObservationEventListenerTests {
         val observationEvent = loadSampleData("events/entity/attributeUpdateNumericPropDatasetIdEvent.json")
 
         coEvery {
-            temporalEntityAttributeService.partialUpdateEntityAttribute(any(), any(), any())
+            entityPayloadService.partialUpdateAttribute(any(), any(), any())
         } returns UpdateResult(
             emptyList(),
             listOf(NotUpdatedDetails(TEMPERATURE_PROPERTY, "Property does not exist"))
@@ -133,7 +133,7 @@ class ObservationEventListenerTests {
         val observationEvent = loadSampleData("events/entity/attributeAppendNumericPropDatasetIdEvent.json")
 
         coEvery {
-            temporalEntityAttributeService.appendEntityAttributes(any(), any(), any(), any(), any())
+            entityPayloadService.appendAttributes(any(), any(), any(), any(), any())
         } returns UpdateResult(
             listOf(
                 UpdatedDetails(
@@ -153,7 +153,7 @@ class ObservationEventListenerTests {
         observationEventListener.dispatchObservationMessage(observationEvent)
 
         coVerify {
-            temporalEntityAttributeService.appendEntityAttributes(
+            entityPayloadService.appendAttributes(
                 expectedEntityId,
                 match {
                     it.size == 1 &&
@@ -189,7 +189,7 @@ class ObservationEventListenerTests {
         val observationEvent = loadSampleData("events/entity/attributeAppendNumericPropDatasetIdEvent.json")
 
         coEvery {
-            temporalEntityAttributeService.appendEntityAttributes(any(), any(), any(), any(), any())
+            entityPayloadService.appendAttributes(any(), any(), any(), any(), any())
         } returns UpdateResult(
             emptyList(),
             listOf(NotUpdatedDetails(TEMPERATURE_PROPERTY, "Property could not be appended"))
@@ -206,7 +206,7 @@ class ObservationEventListenerTests {
 
         observationEventListener.dispatchObservationMessage(observationEvent)
 
-        coVerify { temporalEntityAttributeService wasNot called }
+        coVerify { entityPayloadService wasNot called }
         verify { entityEventService wasNot called }
     }
 
@@ -223,7 +223,7 @@ class ObservationEventListenerTests {
             observationEventListener.dispatchObservationMessage(invalidObservationEvent)
         }
 
-        verify { temporalEntityAttributeService wasNot called }
+        verify { entityPayloadService wasNot called }
         verify { entityEventService wasNot called }
     }
 
@@ -240,7 +240,7 @@ class ObservationEventListenerTests {
             observationEventListener.dispatchObservationMessage(invalidObservationEvent)
         }
 
-        verify { temporalEntityAttributeService wasNot called }
+        verify { entityPayloadService wasNot called }
         verify { entityEventService wasNot called }
     }
 }

--- a/search-service/src/test/kotlin/com/egm/stellio/search/model/EntityModelTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/model/EntityModelTests.kt
@@ -1,5 +1,6 @@
 package com.egm.stellio.search.model
 
+import com.egm.stellio.search.util.EMPTY_JSON_PAYLOAD
 import com.egm.stellio.shared.util.*
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
@@ -15,7 +16,7 @@ class EntityModelTests {
         types = listOf(BEEHIVE_TYPE),
         createdAt = now,
         modifiedAt = now,
-        entityPayload = EMPTY_PAYLOAD,
+        payload = EMPTY_JSON_PAYLOAD,
         contexts = DEFAULT_CONTEXTS
     )
 

--- a/search-service/src/test/kotlin/com/egm/stellio/search/service/AttributeInstanceServiceTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/service/AttributeInstanceServiceTests.kt
@@ -7,6 +7,7 @@ import com.egm.stellio.search.model.TemporalEntityAttribute
 import com.egm.stellio.search.model.TemporalQuery
 import com.egm.stellio.search.support.WithKafkaContainer
 import com.egm.stellio.search.support.WithTimescaleContainer
+import com.egm.stellio.search.util.EMPTY_JSON_PAYLOAD
 import com.egm.stellio.search.util.execute
 import com.egm.stellio.shared.model.APIException
 import com.egm.stellio.shared.model.BadRequestDataException
@@ -69,7 +70,7 @@ class AttributeInstanceServiceTests : WithTimescaleContainer, WithKafkaContainer
             attributeName = INCOMING_PROPERTY,
             attributeValueType = TemporalEntityAttribute.AttributeValueType.NUMBER,
             createdAt = now,
-            payload = EMPTY_PAYLOAD
+            payload = EMPTY_JSON_PAYLOAD
         )
 
         createTemporalEntityAttribute(incomingTemporalEntityAttribute)
@@ -79,7 +80,7 @@ class AttributeInstanceServiceTests : WithTimescaleContainer, WithKafkaContainer
             attributeName = OUTGOING_PROPERTY,
             attributeValueType = TemporalEntityAttribute.AttributeValueType.NUMBER,
             createdAt = now,
-            payload = EMPTY_PAYLOAD
+            payload = EMPTY_JSON_PAYLOAD
         )
 
         createTemporalEntityAttribute(outgoingTemporalEntityAttribute)
@@ -210,7 +211,7 @@ class AttributeInstanceServiceTests : WithTimescaleContainer, WithKafkaContainer
             attributeName = "propWithStringValue",
             attributeValueType = TemporalEntityAttribute.AttributeValueType.STRING,
             createdAt = now,
-            payload = EMPTY_PAYLOAD
+            payload = EMPTY_JSON_PAYLOAD
         )
 
         createTemporalEntityAttribute(temporalEntityAttribute2)
@@ -472,7 +473,7 @@ class AttributeInstanceServiceTests : WithTimescaleContainer, WithKafkaContainer
             attributeName = OUTGOING_COMPACT_PROPERTY,
             attributeValueType = TemporalEntityAttribute.AttributeValueType.NUMBER,
             createdAt = now,
-            payload = EMPTY_PAYLOAD
+            payload = EMPTY_JSON_PAYLOAD
         )
 
         createTemporalEntityAttribute(temporalEntityAttribute2)
@@ -585,7 +586,7 @@ class AttributeInstanceServiceTests : WithTimescaleContainer, WithKafkaContainer
                     it.time.toString() == "2015-10-18T11:20:30.000001Z" &&
                         it.value == null &&
                         it.measuredValue == 550.0 &&
-                        it.payload.matchContent(
+                        it.payload.asString().matchContent(
                             """
                             {
                                 "https://uri.etsi.org/ngsi-ld/observedAt":[{
@@ -635,7 +636,7 @@ class AttributeInstanceServiceTests : WithTimescaleContainer, WithKafkaContainer
                     it.time.toString() == "2015-10-18T11:20:30.000001Z" &&
                         it.value == "false" &&
                         it.measuredValue == null &&
-                        it.payload.matchContent(
+                        it.payload.asString().matchContent(
                             """
                             {
                                 "https://uri.etsi.org/ngsi-ld/observedAt":[{

--- a/search-service/src/test/kotlin/com/egm/stellio/search/service/AttributeServiceTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/service/AttributeServiceTests.kt
@@ -5,6 +5,7 @@ import com.egm.stellio.search.model.*
 import com.egm.stellio.search.model.AttributeType
 import com.egm.stellio.search.support.WithKafkaContainer
 import com.egm.stellio.search.support.WithTimescaleContainer
+import com.egm.stellio.search.util.EMPTY_JSON_PAYLOAD
 import com.egm.stellio.search.util.execute
 import com.egm.stellio.search.util.toUri
 import com.egm.stellio.shared.model.APIException
@@ -216,7 +217,7 @@ class AttributeServiceTests : WithTimescaleContainer, WithKafkaContainer {
             attributeType = attributeType,
             attributeValueType = attributeValueType,
             createdAt = now,
-            payload = EMPTY_PAYLOAD
+            payload = EMPTY_JSON_PAYLOAD
         )
 
     private fun createEntityPayload(
@@ -239,7 +240,7 @@ class AttributeServiceTests : WithTimescaleContainer, WithKafkaContainer {
             entityId = toUri(id),
             types = types,
             createdAt = now,
-            entityPayload = EMPTY_PAYLOAD,
+            payload = EMPTY_JSON_PAYLOAD,
             contexts = listOf(contexts)
         )
 }

--- a/search-service/src/test/kotlin/com/egm/stellio/search/service/EntityEventServiceTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/service/EntityEventServiceTests.kt
@@ -4,9 +4,9 @@ import arrow.core.right
 import com.egm.stellio.search.model.UpdateOperationResult
 import com.egm.stellio.search.model.UpdateResult
 import com.egm.stellio.search.model.UpdatedDetails
+import com.egm.stellio.search.util.EMPTY_PAYLOAD
 import com.egm.stellio.shared.model.*
 import com.egm.stellio.shared.util.AQUAC_COMPOUND_CONTEXT
-import com.egm.stellio.shared.util.EMPTY_PAYLOAD
 import com.egm.stellio.shared.util.JsonLdUtils.expandJsonLdFragment
 import com.egm.stellio.shared.util.matchContent
 import com.egm.stellio.shared.util.toUri

--- a/search-service/src/test/kotlin/com/egm/stellio/search/service/EntityTypeServiceTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/service/EntityTypeServiceTests.kt
@@ -5,6 +5,7 @@ import com.egm.stellio.search.model.*
 import com.egm.stellio.search.model.AttributeType
 import com.egm.stellio.search.support.WithKafkaContainer
 import com.egm.stellio.search.support.WithTimescaleContainer
+import com.egm.stellio.search.util.EMPTY_JSON_PAYLOAD
 import com.egm.stellio.search.util.execute
 import com.egm.stellio.search.util.toUri
 import com.egm.stellio.shared.model.APIException
@@ -225,7 +226,7 @@ class EntityTypeServiceTests : WithTimescaleContainer, WithKafkaContainer {
             attributeType = attributeType,
             attributeValueType = attributeValueType,
             createdAt = now,
-            payload = EMPTY_PAYLOAD
+            payload = EMPTY_JSON_PAYLOAD
         )
 
     private fun createEntityPayload(
@@ -248,7 +249,7 @@ class EntityTypeServiceTests : WithTimescaleContainer, WithKafkaContainer {
             entityId = toUri(id),
             types = types,
             createdAt = now,
-            entityPayload = EMPTY_PAYLOAD,
+            payload = EMPTY_JSON_PAYLOAD,
             contexts = listOf(contexts)
         )
 }

--- a/search-service/src/test/kotlin/com/egm/stellio/search/service/IAMListenerTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/service/IAMListenerTests.kt
@@ -39,7 +39,7 @@ class IAMListenerTests {
                 match {
                     it.subjectId == "6ad19fe0-fc11-4024-85f2-931c6fa6f7e0" &&
                         it.subjectType == SubjectType.USER &&
-                        it.subjectInfo ==
+                        it.subjectInfo.asString() ==
                         """
                         {"type":"Property","value":{"username":"stellio","givenName":"John","familyName":"Doe"}}
                         """.trimIndent() &&
@@ -62,7 +62,7 @@ class IAMListenerTests {
                 match {
                     it.subjectId == "191a6f0d-df07-4697-afde-da9d8a91d954" &&
                         it.subjectType == SubjectType.CLIENT &&
-                        it.subjectInfo ==
+                        it.subjectInfo.asString() ==
                         """
                         {"type":"Property","value":{"clientId":"stellio-client"}}
                         """.trimIndent() &&
@@ -85,7 +85,7 @@ class IAMListenerTests {
                 match {
                     it.subjectId == "ab67edf3-238c-4f50-83f4-617c620c62eb" &&
                         it.subjectType == SubjectType.GROUP &&
-                        it.subjectInfo ==
+                        it.subjectInfo.asString() ==
                         """
                         {"type":"Property","value":{"name":"EGM"}}
                         """.trimIndent() &&

--- a/search-service/src/test/kotlin/com/egm/stellio/search/service/QueryServiceTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/service/QueryServiceTests.kt
@@ -3,12 +3,14 @@ package com.egm.stellio.search.service
 import arrow.core.left
 import arrow.core.right
 import com.egm.stellio.search.model.*
+import com.egm.stellio.search.util.EMPTY_JSON_PAYLOAD
 import com.egm.stellio.shared.model.QueryParams
 import com.egm.stellio.shared.model.ResourceNotFoundException
 import com.egm.stellio.shared.util.*
 import com.egm.stellio.shared.util.JsonLdUtils.NGSILD_CREATED_AT_TERM
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.*
+import io.r2dbc.postgresql.codec.Json
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
@@ -51,7 +53,7 @@ class QueryServiceTests {
         val expandedPayload = loadSampleData("beehive_expanded.jsonld")
         val entityPayload = mockkClass(EntityPayload::class) {
             every { entityId } returns entityUri
-            every { entityPayload } returns expandedPayload
+            every { payload } returns Json.of(expandedPayload)
         }
         coEvery { entityPayloadService.retrieve(any<URI>()) } returns entityPayload.right()
 
@@ -78,7 +80,7 @@ class QueryServiceTests {
         val expandedPayload = loadSampleData("beehive_expanded.jsonld")
         val entityPayload = mockkClass(EntityPayload::class) {
             every { entityId } returns entityUri
-            every { entityPayload } returns expandedPayload
+            every { payload } returns Json.of(expandedPayload)
         }
 
         coEvery { temporalEntityAttributeService.getForEntities(any(), any()) } returns listOf(entityUri)
@@ -148,7 +150,7 @@ class QueryServiceTests {
                     attributeName = it,
                     attributeValueType = TemporalEntityAttribute.AttributeValueType.NUMBER,
                     createdAt = now,
-                    payload = EMPTY_PAYLOAD
+                    payload = EMPTY_JSON_PAYLOAD
                 )
             }
         coEvery { temporalEntityAttributeService.getForEntity(any(), any()) } returns temporalEntityAttributes
@@ -204,7 +206,7 @@ class QueryServiceTests {
             attributeName = "incoming",
             attributeValueType = TemporalEntityAttribute.AttributeValueType.NUMBER,
             createdAt = now,
-            payload = EMPTY_PAYLOAD
+            payload = EMPTY_JSON_PAYLOAD
         )
         coEvery {
             temporalEntityAttributeService.getForTemporalEntities(any(), any())
@@ -284,7 +286,7 @@ class QueryServiceTests {
             attributeName = "incoming",
             attributeValueType = TemporalEntityAttribute.AttributeValueType.NUMBER,
             createdAt = now,
-            payload = EMPTY_PAYLOAD
+            payload = EMPTY_JSON_PAYLOAD
         )
 
         coEvery {

--- a/search-service/src/test/kotlin/com/egm/stellio/search/service/TemporalEntityServiceTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/service/TemporalEntityServiceTests.kt
@@ -1,6 +1,7 @@
 package com.egm.stellio.search.service
 
 import com.egm.stellio.search.model.*
+import com.egm.stellio.search.util.EMPTY_JSON_PAYLOAD
 import com.egm.stellio.shared.util.*
 import com.egm.stellio.shared.util.JsonLdUtils.NGSILD_CORE_CONTEXT
 import com.egm.stellio.shared.util.JsonLdUtils.NGSILD_NOTIFICATION_ATTR_PROPERTY
@@ -34,7 +35,7 @@ class TemporalEntityServiceTests {
             attributeName = NGSILD_NOTIFICATION_ATTR_PROPERTY,
             attributeValueType = TemporalEntityAttribute.AttributeValueType.STRING,
             createdAt = now,
-            payload = EMPTY_PAYLOAD
+            payload = EMPTY_JSON_PAYLOAD
         )
         val attributeAndResultsMap = mapOf(
             temporalEntityAttribute to emptyList<AttributeInstanceResult>()
@@ -43,7 +44,7 @@ class TemporalEntityServiceTests {
             entityId = "urn:ngsi-ld:Subscription:1234".toUri(),
             types = listOf(NGSILD_SUBSCRIPTION_PROPERTY),
             createdAt = now,
-            entityPayload = EMPTY_PAYLOAD,
+            payload = EMPTY_JSON_PAYLOAD,
             contexts = listOf(NGSILD_CORE_CONTEXT)
         )
         val temporalEntity = temporalEntityService.buildTemporalEntity(
@@ -76,7 +77,7 @@ class TemporalEntityServiceTests {
             entityId = "urn:ngsi-ld:BeeHive:TESTC".toUri(),
             types = listOf(BEEHIVE_TYPE),
             createdAt = now,
-            entityPayload = EMPTY_PAYLOAD,
+            payload = EMPTY_JSON_PAYLOAD,
             contexts = listOf(APIC_COMPOUND_CONTEXT)
         )
 
@@ -122,7 +123,7 @@ class TemporalEntityServiceTests {
             attributeName = NGSILD_NOTIFICATION_ATTR_PROPERTY,
             attributeValueType = TemporalEntityAttribute.AttributeValueType.STRING,
             createdAt = now,
-            payload = EMPTY_PAYLOAD
+            payload = EMPTY_JSON_PAYLOAD
         )
         val attributeAndResultsMap = mapOf(
             temporalEntityAttribute to listOf(
@@ -149,7 +150,7 @@ class TemporalEntityServiceTests {
             entityId = "urn:ngsi-ld:Subscription:1234".toUri(),
             types = listOf(NGSILD_SUBSCRIPTION_PROPERTY),
             createdAt = now,
-            entityPayload = EMPTY_PAYLOAD,
+            payload = EMPTY_JSON_PAYLOAD,
             contexts = listOf(NGSILD_CORE_CONTEXT)
         )
 

--- a/search-service/src/test/kotlin/com/egm/stellio/search/util/ParameterizedTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/util/ParameterizedTests.kt
@@ -3,7 +3,6 @@ package com.egm.stellio.search.util
 import com.egm.stellio.search.model.FullAttributeInstanceResult
 import com.egm.stellio.search.model.SimplifiedAttributeInstanceResult
 import com.egm.stellio.search.model.TemporalEntityAttribute
-import com.egm.stellio.shared.util.EMPTY_PAYLOAD
 import com.egm.stellio.shared.util.JsonLdUtils
 import com.egm.stellio.shared.util.loadSampleData
 import com.egm.stellio.shared.util.toUri
@@ -30,7 +29,7 @@ class ParameterizedTests {
                             attributeName = "https://ontology.eglobalmark.com/apic#incoming",
                             attributeValueType = TemporalEntityAttribute.AttributeValueType.NUMBER,
                             createdAt = now,
-                            payload = EMPTY_PAYLOAD
+                            payload = EMPTY_JSON_PAYLOAD
                         ) to
                             listOf(
                                 FullAttributeInstanceResult(
@@ -71,7 +70,7 @@ class ParameterizedTests {
                             attributeType = TemporalEntityAttribute.AttributeType.Relationship,
                             attributeValueType = TemporalEntityAttribute.AttributeValueType.STRING,
                             createdAt = now,
-                            payload = EMPTY_PAYLOAD
+                            payload = EMPTY_JSON_PAYLOAD
                         ) to
                             listOf(
                                 FullAttributeInstanceResult(
@@ -114,7 +113,7 @@ class ParameterizedTests {
                             attributeValueType = TemporalEntityAttribute.AttributeValueType.NUMBER,
                             datasetId = "urn:ngsi-ld:Dataset:01234".toUri(),
                             createdAt = now,
-                            payload = EMPTY_PAYLOAD
+                            payload = EMPTY_JSON_PAYLOAD
                         ) to
                             listOf(
                                 FullAttributeInstanceResult(
@@ -148,7 +147,7 @@ class ParameterizedTests {
                             attributeValueType = TemporalEntityAttribute.AttributeValueType.NUMBER,
                             datasetId = "urn:ngsi-ld:Dataset:45678".toUri(),
                             createdAt = now,
-                            payload = EMPTY_PAYLOAD
+                            payload = EMPTY_JSON_PAYLOAD
                         ) to
                             listOf(
                                 FullAttributeInstanceResult(
@@ -189,7 +188,7 @@ class ParameterizedTests {
                             attributeValueType = TemporalEntityAttribute.AttributeValueType.STRING,
                             datasetId = "urn:ngsi-ld:Dataset:45678".toUri(),
                             createdAt = now,
-                            payload = EMPTY_PAYLOAD
+                            payload = EMPTY_JSON_PAYLOAD
                         ) to
                             listOf(
                                 FullAttributeInstanceResult(
@@ -230,7 +229,7 @@ class ParameterizedTests {
                             attributeValueType = TemporalEntityAttribute.AttributeValueType.STRING,
                             datasetId = "urn:ngsi-ld:Dataset:45678".toUri(),
                             createdAt = now,
-                            payload = EMPTY_PAYLOAD
+                            payload = EMPTY_JSON_PAYLOAD
                         ) to
                             listOf(
                                 FullAttributeInstanceResult(
@@ -270,7 +269,7 @@ class ParameterizedTests {
                             attributeName = "https://ontology.eglobalmark.com/apic#incoming",
                             attributeValueType = TemporalEntityAttribute.AttributeValueType.STRING,
                             createdAt = now,
-                            payload = EMPTY_PAYLOAD
+                            payload = EMPTY_JSON_PAYLOAD
                         ) to
                             listOf(
                                 FullAttributeInstanceResult(
@@ -312,7 +311,7 @@ class ParameterizedTests {
                             attributeName = "https://ontology.eglobalmark.com/apic#incoming",
                             attributeValueType = TemporalEntityAttribute.AttributeValueType.NUMBER,
                             createdAt = now,
-                            payload = EMPTY_PAYLOAD
+                            payload = EMPTY_JSON_PAYLOAD
                         ) to
                             listOf(
                                 SimplifiedAttributeInstanceResult(
@@ -341,7 +340,7 @@ class ParameterizedTests {
                             attributeValueType = TemporalEntityAttribute.AttributeValueType.NUMBER,
                             datasetId = "urn:ngsi-ld:Dataset:01234".toUri(),
                             createdAt = now,
-                            payload = EMPTY_PAYLOAD
+                            payload = EMPTY_JSON_PAYLOAD
                         ) to
                             listOf(
                                 SimplifiedAttributeInstanceResult(
@@ -361,7 +360,7 @@ class ParameterizedTests {
                             attributeValueType = TemporalEntityAttribute.AttributeValueType.NUMBER,
                             datasetId = "urn:ngsi-ld:Dataset:45678".toUri(),
                             createdAt = now,
-                            payload = EMPTY_PAYLOAD
+                            payload = EMPTY_JSON_PAYLOAD
                         ) to
                             listOf(
                                 SimplifiedAttributeInstanceResult(
@@ -388,7 +387,7 @@ class ParameterizedTests {
                             attributeValueType = TemporalEntityAttribute.AttributeValueType.STRING,
                             datasetId = "urn:ngsi-ld:Dataset:45678".toUri(),
                             createdAt = now,
-                            payload = EMPTY_PAYLOAD
+                            payload = EMPTY_JSON_PAYLOAD
                         ) to
                             listOf(
                                 SimplifiedAttributeInstanceResult(
@@ -414,7 +413,7 @@ class ParameterizedTests {
                             attributeName = "https://ontology.eglobalmark.com/apic#incoming",
                             attributeValueType = TemporalEntityAttribute.AttributeValueType.STRING,
                             createdAt = now,
-                            payload = EMPTY_PAYLOAD
+                            payload = EMPTY_JSON_PAYLOAD
                         ) to
                             listOf(
                                 SimplifiedAttributeInstanceResult(
@@ -444,7 +443,7 @@ class ParameterizedTests {
                             attributeValueType = TemporalEntityAttribute.AttributeValueType.STRING,
                             datasetId = "urn:ngsi-ld:Dataset:45678".toUri(),
                             createdAt = now,
-                            payload = EMPTY_PAYLOAD
+                            payload = EMPTY_JSON_PAYLOAD
                         ) to
                             listOf(
                                 SimplifiedAttributeInstanceResult(

--- a/search-service/src/test/kotlin/com/egm/stellio/search/util/QueryParameterizedTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/util/QueryParameterizedTests.kt
@@ -25,7 +25,7 @@ class QueryParameterizedTests {
                         entityId = "urn:ngsi-ld:BeeHive:TESTC".toUri(),
                         types = listOf(BEEHIVE_TYPE),
                         createdAt = now,
-                        entityPayload = EMPTY_PAYLOAD,
+                        payload = EMPTY_JSON_PAYLOAD,
                         contexts = listOf(APIC_COMPOUND_CONTEXT)
                     ),
                     mapOf(
@@ -34,7 +34,7 @@ class QueryParameterizedTests {
                             attributeName = "https://ontology.eglobalmark.com/apic#incoming",
                             attributeValueType = TemporalEntityAttribute.AttributeValueType.NUMBER,
                             createdAt = now,
-                            payload = EMPTY_PAYLOAD
+                            payload = EMPTY_JSON_PAYLOAD
                         ) to listOf(
                             SimplifiedAttributeInstanceResult(
                                 temporalEntityAttribute = UUID.randomUUID(),
@@ -49,7 +49,7 @@ class QueryParameterizedTests {
                         entityId = "urn:ngsi-ld:BeeHive:TESTD".toUri(),
                         types = listOf(BEEHIVE_TYPE),
                         createdAt = now,
-                        entityPayload = EMPTY_PAYLOAD,
+                        payload = EMPTY_JSON_PAYLOAD,
                         contexts = listOf(APIC_COMPOUND_CONTEXT)
                     ),
                     mapOf(
@@ -58,7 +58,7 @@ class QueryParameterizedTests {
                             attributeName = "https://ontology.eglobalmark.com/apic#outgoing",
                             attributeValueType = TemporalEntityAttribute.AttributeValueType.NUMBER,
                             createdAt = now,
-                            payload = EMPTY_PAYLOAD
+                            payload = EMPTY_JSON_PAYLOAD
                         ) to listOf(
                             SimplifiedAttributeInstanceResult(
                                 temporalEntityAttribute = UUID.randomUUID(),
@@ -77,7 +77,7 @@ class QueryParameterizedTests {
                         entityId = "urn:ngsi-ld:BeeHive:TESTC".toUri(),
                         types = listOf(BEEHIVE_TYPE),
                         createdAt = now,
-                        entityPayload = EMPTY_PAYLOAD,
+                        payload = EMPTY_JSON_PAYLOAD,
                         contexts = listOf(APIC_COMPOUND_CONTEXT)
                     ),
                     mapOf(
@@ -86,7 +86,7 @@ class QueryParameterizedTests {
                             attributeName = "https://ontology.eglobalmark.com/apic#incoming",
                             attributeValueType = TemporalEntityAttribute.AttributeValueType.NUMBER,
                             createdAt = now,
-                            payload = EMPTY_PAYLOAD
+                            payload = EMPTY_JSON_PAYLOAD
                         ) to listOf(
                             FullAttributeInstanceResult(
                                 temporalEntityAttribute = UUID.randomUUID(),
@@ -108,7 +108,7 @@ class QueryParameterizedTests {
                         entityId = "urn:ngsi-ld:BeeHive:TESTD".toUri(),
                         types = listOf(BEEHIVE_TYPE),
                         createdAt = now,
-                        entityPayload = EMPTY_PAYLOAD,
+                        payload = EMPTY_JSON_PAYLOAD,
                         contexts = listOf(APIC_COMPOUND_CONTEXT)
                     ),
                     mapOf(
@@ -117,7 +117,7 @@ class QueryParameterizedTests {
                             attributeName = "https://ontology.eglobalmark.com/apic#outgoing",
                             attributeValueType = TemporalEntityAttribute.AttributeValueType.NUMBER,
                             createdAt = now,
-                            payload = EMPTY_PAYLOAD
+                            payload = EMPTY_JSON_PAYLOAD
                         ) to listOf(
                             FullAttributeInstanceResult(
                                 temporalEntityAttribute = UUID.randomUUID(),
@@ -143,7 +143,7 @@ class QueryParameterizedTests {
                         entityId = "urn:ngsi-ld:BeeHive:TESTC".toUri(),
                         types = listOf(BEEHIVE_TYPE),
                         createdAt = now,
-                        entityPayload = EMPTY_PAYLOAD,
+                        payload = EMPTY_JSON_PAYLOAD,
                         contexts = listOf(APIC_COMPOUND_CONTEXT)
                     ),
                     mapOf(
@@ -152,7 +152,7 @@ class QueryParameterizedTests {
                             attributeName = "https://ontology.eglobalmark.com/apic#incoming",
                             attributeValueType = TemporalEntityAttribute.AttributeValueType.NUMBER,
                             createdAt = now,
-                            payload = EMPTY_PAYLOAD
+                            payload = EMPTY_JSON_PAYLOAD
                         ) to listOf(
                             SimplifiedAttributeInstanceResult(
                                 temporalEntityAttribute = UUID.randomUUID(),
@@ -166,7 +166,7 @@ class QueryParameterizedTests {
                             attributeType = TemporalEntityAttribute.AttributeType.Relationship,
                             attributeValueType = TemporalEntityAttribute.AttributeValueType.NUMBER,
                             createdAt = now,
-                            payload = EMPTY_PAYLOAD
+                            payload = EMPTY_JSON_PAYLOAD
                         ) to listOf(
                             SimplifiedAttributeInstanceResult(
                                 temporalEntityAttribute = UUID.randomUUID(),
@@ -181,7 +181,7 @@ class QueryParameterizedTests {
                         entityId = "urn:ngsi-ld:BeeHive:TESTD".toUri(),
                         types = listOf(BEEHIVE_TYPE),
                         createdAt = now,
-                        entityPayload = EMPTY_PAYLOAD,
+                        payload = EMPTY_JSON_PAYLOAD,
                         contexts = listOf(APIC_COMPOUND_CONTEXT)
                     ),
                     mapOf(
@@ -190,7 +190,7 @@ class QueryParameterizedTests {
                             attributeName = "https://ontology.eglobalmark.com/apic#outgoing",
                             attributeValueType = TemporalEntityAttribute.AttributeValueType.NUMBER,
                             createdAt = now,
-                            payload = EMPTY_PAYLOAD
+                            payload = EMPTY_JSON_PAYLOAD
                         ) to listOf(
                             SimplifiedAttributeInstanceResult(
                                 temporalEntityAttribute = UUID.randomUUID(),
@@ -204,7 +204,7 @@ class QueryParameterizedTests {
                             attributeType = TemporalEntityAttribute.AttributeType.Relationship,
                             attributeValueType = TemporalEntityAttribute.AttributeValueType.NUMBER,
                             createdAt = now,
-                            payload = EMPTY_PAYLOAD
+                            payload = EMPTY_JSON_PAYLOAD
                         ) to listOf(
                             SimplifiedAttributeInstanceResult(
                                 temporalEntityAttribute = UUID.randomUUID(),

--- a/search-service/src/test/kotlin/com/egm/stellio/search/util/TestUtils.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/util/TestUtils.kt
@@ -47,4 +47,4 @@ fun buildSapAttribute(specificAccessPolicy: AuthContextModel.SpecificAccessPolic
 }
 
 const val EMPTY_PAYLOAD = "{}"
-val EMPTY_JSON_PAYLOAD = Json.of("{}")
+val EMPTY_JSON_PAYLOAD = Json.of(EMPTY_PAYLOAD)

--- a/search-service/src/test/kotlin/com/egm/stellio/search/util/TestUtils.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/util/TestUtils.kt
@@ -7,6 +7,7 @@ import com.egm.stellio.shared.util.AuthContextModel
 import com.egm.stellio.shared.util.AuthContextModel.AUTH_TERM_SAP
 import com.egm.stellio.shared.util.JsonLdUtils.expandJsonLdFragment
 import com.egm.stellio.shared.util.JsonUtils.serializeObject
+import io.r2dbc.postgresql.codec.Json
 import java.net.URI
 import java.time.ZonedDateTime
 
@@ -44,3 +45,6 @@ fun buildSapAttribute(specificAccessPolicy: AuthContextModel.SpecificAccessPolic
         expandJsonLdFragment(AUTH_TERM_SAP, sapPropertyFragment, AuthContextModel.AUTHORIZATION_API_DEFAULT_CONTEXTS)
     )[0]
 }
+
+const val EMPTY_PAYLOAD = "{}"
+val EMPTY_JSON_PAYLOAD = Json.of("{}")

--- a/search-service/src/test/kotlin/com/egm/stellio/search/web/EntityOperationHandlerTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/web/EntityOperationHandlerTests.kt
@@ -269,7 +269,7 @@ class EntityOperationHandlerTests {
             allEntitiesUris.map { BatchEntitySuccess(it) }.toMutableList(),
             arrayListOf()
         )
-        coEvery { authorizationService.createAdminLinks(any(), eq(sub)) } returns Unit.right()
+        coEvery { authorizationService.createAdminRights(any(), eq(sub)) } returns Unit.right()
         every {
             entityEventService.publishEntityCreateEvent(
                 any(),
@@ -290,7 +290,7 @@ class EntityOperationHandlerTests {
 
         assertEquals(allEntitiesUris, capturedExpandedEntities.captured.map { it.id })
 
-        coVerify { authorizationService.createAdminLinks(allEntitiesUris, sub) }
+        coVerify { authorizationService.createAdminRights(allEntitiesUris, sub) }
         verify(timeout = 1000, exactly = 3) {
             entityEventService.publishEntityCreateEvent(any(), any(), any(), any())
         }
@@ -318,7 +318,7 @@ class EntityOperationHandlerTests {
             createdEntitiesIds.map { BatchEntitySuccess(it) }.toMutableList(),
             arrayListOf()
         )
-        coEvery { authorizationService.createAdminLinks(any(), eq(sub)) } returns Unit.right()
+        coEvery { authorizationService.createAdminRights(any(), eq(sub)) } returns Unit.right()
         every {
             entityEventService.publishEntityCreateEvent(
                 any(),
@@ -350,7 +350,7 @@ class EntityOperationHandlerTests {
                 """.trimIndent()
             )
 
-        coVerify { authorizationService.createAdminLinks(createdEntitiesIds, sub) }
+        coVerify { authorizationService.createAdminRights(createdEntitiesIds, sub) }
         verify(timeout = 1000, exactly = 2) { entityEventService.publishEntityCreateEvent(any(), any(), any(), any()) }
         capturedEntitiesIds.forEach { assertTrue(it in createdEntitiesIds) }
         assertTrue(capturedEntityTypes.captured[0] in listOf(SENSOR_TYPE, DEVICE_TYPE))
@@ -433,7 +433,7 @@ class EntityOperationHandlerTests {
         )
         coEvery { authorizationService.userCanCreateEntities(any()) } returns Unit.right()
         coEvery { entityOperationService.create(any(), any(), any()) } returns createdBatchResult
-        coEvery { authorizationService.createAdminLinks(any(), eq(sub)) } returns Unit.right()
+        coEvery { authorizationService.createAdminRights(any(), eq(sub)) } returns Unit.right()
         every { entityEventService.publishEntityCreateEvent(any(), any(), any(), any()) } returns Job()
 
         coEvery { authorizationService.userCanUpdateEntity(any(), sub) } returns Unit.right()
@@ -450,7 +450,7 @@ class EntityOperationHandlerTests {
             .jsonPath("$").isArray
             .jsonPath("$[*]").isEqualTo(createdEntitiesIds.map { it.toString() })
 
-        coVerify { authorizationService.createAdminLinks(createdEntitiesIds, sub) }
+        coVerify { authorizationService.createAdminRights(createdEntitiesIds, sub) }
         verify {
             entityEventService.publishEntityCreateEvent(
                 eq(sub.value),
@@ -512,7 +512,7 @@ class EntityOperationHandlerTests {
             arrayListOf(BatchEntitySuccess(deviceUri, mockkClass(UpdateResult::class))),
             arrayListOf()
         )
-        coEvery { authorizationService.createAdminLinks(any(), eq(sub)) } returns Unit.right()
+        coEvery { authorizationService.createAdminRights(any(), eq(sub)) } returns Unit.right()
 
         coEvery { authorizationService.userCanUpdateEntity(any(), sub) } returns Unit.right()
         coEvery { entityOperationService.update(any(), any(), any()) } returns BatchOperationResult(
@@ -543,7 +543,7 @@ class EntityOperationHandlerTests {
                 """.trimIndent()
             )
 
-        coVerify { authorizationService.createAdminLinks(listOf(deviceUri), sub) }
+        coVerify { authorizationService.createAdminRights(listOf(deviceUri), sub) }
         verify(exactly = 1) { entityEventService.publishEntityCreateEvent(any(), any(), any(), any()) }
     }
 

--- a/search-service/src/test/kotlin/com/egm/stellio/search/web/TemporalEntityHandlerTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/web/TemporalEntityHandlerTests.kt
@@ -13,6 +13,7 @@ import com.egm.stellio.search.service.AttributeInstanceService
 import com.egm.stellio.search.service.EntityPayloadService
 import com.egm.stellio.search.service.QueryService
 import com.egm.stellio.search.service.TemporalEntityAttributeService
+import com.egm.stellio.search.util.EMPTY_JSON_PAYLOAD
 import com.egm.stellio.shared.WithMockCustomUser
 import com.egm.stellio.shared.model.*
 import com.egm.stellio.shared.util.*
@@ -646,7 +647,7 @@ class TemporalEntityHandlerTests {
                     attributeName = it,
                     attributeValueType = TemporalEntityAttribute.AttributeValueType.NUMBER,
                     createdAt = ZonedDateTime.now(ZoneOffset.UTC),
-                    payload = EMPTY_PAYLOAD
+                    payload = EMPTY_JSON_PAYLOAD
                 )
             }
         val entityFileName = if (withTemporalValues)

--- a/shared/src/testFixtures/kotlin/com/egm/stellio/shared/util/TestUtils.kt
+++ b/shared/src/testFixtures/kotlin/com/egm/stellio/shared/util/TestUtils.kt
@@ -5,8 +5,6 @@ import com.egm.stellio.shared.model.NgsiLdEntity
 import com.egm.stellio.shared.model.toNgsiLdEntity
 import org.springframework.core.io.ClassPathResource
 
-const val EMPTY_PAYLOAD = "{}"
-
 fun loadSampleData(filename: String = "beehive.jsonld"): String {
     val sampleData = ClassPathResource("/ngsild/$filename")
     return String(sampleData.inputStream.readAllBytes())


### PR DESCRIPTION
- use entity service as the main entrypoint for core API services (avoid cyclic dependencies)
- use native JSON type for data persisted as jsonb
- async delete of attributes and attributes instances (better performance)
