### PR TITLE
chore(subscription): resize type column for entity info

### DIFF
--- a/subscription-service/src/main/resources/db/migration/V0_17__resize_entity_info_type_column.sql
+++ b/subscription-service/src/main/resources/db/migration/V0_17__resize_entity_info_type_column.sql
@@ -1,0 +1,1 @@
+alter table entity_info alter COLUMN "type" type varchar(128);


### PR DESCRIPTION
Size of column was previously 64 chars, which can be a bit short for some long expanded types