### PR TITLE
feat: use Logbook for logging of HTTP requests and responses

### DIFF
--- a/api-gateway/build.gradle.kts
+++ b/api-gateway/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
 
 dependencies {
     implementation("org.springframework.cloud:spring-cloud-starter-gateway")
+    implementation("org.zalando:logbook-spring-boot-webflux-autoconfigure:3.0.0")
 
     detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.0")
 }

--- a/api-gateway/src/main/kotlin/com/egm/stellio/apigateway/ApiGatewayApplication.kt
+++ b/api-gateway/src/main/kotlin/com/egm/stellio/apigateway/ApiGatewayApplication.kt
@@ -1,14 +1,11 @@
 package com.egm.stellio.apigateway
 
-import io.netty.handler.logging.LogLevel
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.cloud.gateway.route.RouteLocator
 import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder
 import org.springframework.context.annotation.Bean
-import reactor.netty.http.client.HttpClient
-import reactor.netty.transport.logging.AdvancedByteBufFormat
 
 @SpringBootApplication
 class ApiGatewayApplication {
@@ -18,10 +15,6 @@ class ApiGatewayApplication {
 
     @Value("\${application.subscription-service.url:subscription-service}")
     private val subscriptionServiceUrl: String = ""
-
-    @Bean
-    fun httpClient(): HttpClient =
-        HttpClient.create().wiretap("LoggingFilter", LogLevel.INFO, AdvancedByteBufFormat.TEXTUAL)
 
     @Bean
     fun myRoutes(builder: RouteLocatorBuilder): RouteLocator =

--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -43,6 +43,15 @@ management:
     health:
       enabled: true
 
+logbook:
+  include:
+    - /ngsi-ld/v1/**
+  exclude:
+    - /actuator/**
+  format.style: http
+  strategy: body-only-if-status-at-least
+  minimum-status: 200
+
 # Default values for sending log data to a Gelf compatible endpoint
 # Log data is sent only if the 'gelflogs' Spring profile is active
 # application.graylog.host: localhost

--- a/api-gateway/src/main/resources/logback-spring.xml
+++ b/api-gateway/src/main/resources/logback-spring.xml
@@ -30,8 +30,8 @@
     </appender>
 
     <logger name="com.egm.stellio" level="DEBUG"/>
-    <logger name="reactor.netty" level="INFO" />
     <logger name="org.springframework.cloud.gateway" level="INFO" />
+    <logger name="org.zalando.logbook" level="TRACE" />
 
     <root level="INFO">
         <appender-ref ref="console" />


### PR DESCRIPTION
Easier to read logging of requests and responses, for instance:

```
 2023-06-03 17:43:31,921 [ctor-http-nio-7] TRACE org.zalando.logbook.Logbook              - write - Incoming Request: bdda58947cdf7e80
Remote: /[0:0:0:0:0:0:0:1]:60943
GET http://localhost:8080/ngsi-ld/v1/entities HTTP/1.1
Accept: */*
Accept-Encoding: gzip, deflate
Authorization: XXX
Connection: keep-alive
Host: localhost:8080
NGSILD-Tenant: urn:ngsi-ld:tenant:stellio-dev
User-Agent: HTTPie/3.2.2
 2023-06-03 17:43:31,922 [ctor-http-nio-7] TRACE org.zalando.logbook.Logbook              - write - Outgoing Response: bdda58947cdf7e80
Duration: 41 ms
HTTP/1.1 400 Bad Request
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Content-Length: 245
Content-Type: application/json
Expires: 0
NGSILD-Tenant: urn:ngsi-ld:tenant:stellio-dev
Pragma: no-cache
Referrer-Policy: no-referrer
Vary: Origin, Access-Control-Request-Method, Access-Control-Request-Headers
X-Content-Type-Options: nosniff
X-Frame-Options: DENY
X-XSS-Protection: 0

{"detail":"one of 'id', 'q', 'type' and 'attrs' request parameters have to be specified","type":"https://uri.etsi.org/ngsi-ld/errors/BadRequestData","title":"The request includes input data which does not meet the requirements of the operation"}
 ```

Other nice points:
- it does not automatically chunk the bodies, making it easy to see what are the payloads
- It can easy be disabled (`logbook.filter.enabled=false`)
- It automatically obfuscates the `Authorization` header (as can be seen above) 