### PR TITLE
chore: allow unknown properties when unmarshalling to a data class

### DIFF
--- a/search-service/src/test/kotlin/com/egm/stellio/search/service/IAMListenerTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/service/IAMListenerTests.kt
@@ -73,6 +73,29 @@ class IAMListenerTests {
     }
 
     @Test
+    fun `it should handle a create event with unknwon properties for a client`() = runTest {
+        val subjectCreateEvent = loadSampleData("events/authorization/ClientCreateEventUnknownProperties.json")
+
+        coEvery { subjectReferentialService.create(any()) } returns Unit.right()
+
+        iamListener.dispatchIamMessage(subjectCreateEvent)
+
+        coVerify(timeout = 1000L) {
+            subjectReferentialService.create(
+                match {
+                    it.subjectId == "191a6f0d-df07-4697-afde-da9d8a91d954" &&
+                        it.subjectType == SubjectType.CLIENT &&
+                        it.subjectInfo.asString() ==
+                        """
+                        {"type":"Property","value":{"clientId":"stellio-client"}}
+                        """.trimIndent() &&
+                        it.globalRoles == null
+                }
+            )
+        }
+    }
+
+    @Test
     fun `it should handle a create event for a group`() = runTest {
         val subjectCreateEvent = loadSampleData("events/authorization/GroupCreateEvent.json")
 

--- a/shared/src/main/kotlin/com/egm/stellio/shared/util/JsonUtils.kt
+++ b/shared/src/main/kotlin/com/egm/stellio/shared/util/JsonUtils.kt
@@ -3,6 +3,7 @@ package com.egm.stellio.shared.util
 import com.egm.stellio.shared.model.InvalidRequestException
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter
@@ -16,6 +17,7 @@ val mapper: ObjectMapper =
         .setSerializationInclusion(JsonInclude.Include.NON_NULL)
         .findAndRegisterModules()
         .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
 
 object JsonUtils {
 

--- a/shared/src/testFixtures/resources/ngsild/events/authorization/ClientCreateEventUnknownProperties.json
+++ b/shared/src/testFixtures/resources/ngsild/events/authorization/ClientCreateEventUnknownProperties.json
@@ -1,0 +1,12 @@
+{
+  "aNewUnexpectedProperty": "aValue",
+  "operationType": "ENTITY_CREATE",
+  "tenantUri": "urn:ngsi-ld:tenant:default",
+  "entityId": "urn:ngsi-ld:Client:191a6f0d-df07-4697-afde-da9d8a91d954",
+  "entityTypes": ["Client"],
+  "operationPayload": "{\"id\":\"urn:ngsi-ld:Client:191a6f0d-df07-4697-afde-da9d8a91d954\",\"type\":\"Client\",\"clientId\":{\"type\":\"Property\",\"value\":\"stellio-client\"}}",
+  "contexts": [
+    "https://raw.githubusercontent.com/easy-global-market/ngsild-api-data-models/master/authorization/jsonld-contexts/authorization.jsonld",
+    "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.3.jsonld"
+  ]
+}


### PR DESCRIPTION
It is specifically needed before deploying tenants since a new property (`tenantUri`) is added to events sent by KC and it must not break instances that have not yet switched to the version having tenants.