### PR TITLE
feat(subscription): update to receiver / notifier info in notification params

### DIFF
--- a/subscription-service/config/detekt/baseline.xml
+++ b/subscription-service/config/detekt/baseline.xml
@@ -4,7 +4,7 @@
   <CurrentIssues>
     <ID>CyclomaticComplexMethod:SubscriptionServiceTests.kt$SubscriptionServiceTests$@Test fun `it should load a subscription with all possible members`()</ID>
     <ID>LongMethod:EntityEventListenerService.kt$EntityEventListenerService$internal suspend fun dispatchEntityEvent(content: String)</ID>
-    <ID>LongParameterList:FixtureUtils.kt$( withQueryAndGeoQuery: Pair&lt;Boolean, Boolean&gt; = Pair(true, true), withEndpointInfo: Boolean = true, withNotifParams: Pair&lt;FormatType, List&lt;String&gt;&gt; = Pair(FormatType.NORMALIZED, emptyList()), withModifiedAt: Boolean = false, georel: String = "within", geometry: String = "Polygon", coordinates: String = "[[[100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0]]]", timeInterval: Int? = null, contexts: List&lt;String&gt; = listOf(NGSILD_CORE_CONTEXT) )</ID>
+    <ID>LongParameterList:FixtureUtils.kt$( withQueryAndGeoQuery: Pair&lt;Boolean, Boolean&gt; = Pair(true, true), withEndpointReceiverInfo: Boolean = true, withNotifParams: Pair&lt;FormatType, List&lt;String&gt;&gt; = Pair(FormatType.NORMALIZED, emptyList()), withModifiedAt: Boolean = false, georel: String = "within", geometry: String = "Polygon", coordinates: String = "[[[100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0]]]", timeInterval: Int? = null, contexts: List&lt;String&gt; = listOf(NGSILD_CORE_CONTEXT) )</ID>
     <ID>TooGenericExceptionCaught:SubscriptionService.kt$SubscriptionService$e: Exception</ID>
     <ID>TooManyFunctions:SubscriptionService.kt$SubscriptionService</ID>
   </CurrentIssues>

--- a/subscription-service/src/main/kotlin/com/egm/stellio/subscription/model/Endpoint.kt
+++ b/subscription-service/src/main/kotlin/com/egm/stellio/subscription/model/Endpoint.kt
@@ -7,7 +7,8 @@ import java.net.URI
 data class Endpoint(
     val uri: URI,
     val accept: AcceptType = JSON,
-    val info: List<EndpointInfo>? = null
+    val receiverInfo: List<EndpointInfo>? = null,
+    val notifierInfo: List<EndpointInfo>? = null
 ) {
 
     enum class AcceptType(val accept: String) {

--- a/subscription-service/src/main/kotlin/com/egm/stellio/subscription/service/NotificationService.kt
+++ b/subscription-service/src/main/kotlin/com/egm/stellio/subscription/service/NotificationService.kt
@@ -69,7 +69,7 @@ class NotificationService(
                 }
                 if (tenantUri != DEFAULT_TENANT_URI)
                     it.set(NGSILD_TENANT_HEADER, tenantUri.toString())
-                subscription.notification.endpoint.info?.forEach { endpointInfo ->
+                subscription.notification.endpoint.receiverInfo?.forEach { endpointInfo ->
                     it.set(endpointInfo.key, endpointInfo.value)
                 }
             }

--- a/subscription-service/src/main/resources/db/migration/V0_24__update_to_receiver_notifier_info.sql
+++ b/subscription-service/src/main/resources/db/migration/V0_24__update_to_receiver_notifier_info.sql
@@ -1,0 +1,5 @@
+alter table subscription
+    rename column endpoint_info to endpoint_receiver_info;
+
+alter table subscription
+    add column endpoint_notifier_info jsonb;

--- a/subscription-service/src/test/kotlin/com/egm/stellio/subscription/job/TimeIntervalNotificationJobTest.kt
+++ b/subscription-service/src/test/kotlin/com/egm/stellio/subscription/job/TimeIntervalNotificationJobTest.kt
@@ -158,7 +158,7 @@ class TimeIntervalNotificationJobTest {
 
     @Test
     fun `it should not return twice the same entity if there is overlap between 2 entity infos`() {
-        val subscription = gimmeRawSubscription(withEndpointInfo = false).copy(
+        val subscription = gimmeRawSubscription(withEndpointReceiverInfo = false).copy(
             entities = setOf(
                 EntitySelector(
                     id = "urn:ngsi-ld:BeeHive:TESTC".toUri(),
@@ -226,7 +226,7 @@ class TimeIntervalNotificationJobTest {
     @Test
     fun `it should notify the recurring subscriptions that have reached the time interval`() = runTest {
         val entity = loadSampleData("beehive.jsonld")
-        val subscription = gimmeRawSubscription(withEndpointInfo = false).copy(
+        val subscription = gimmeRawSubscription(withEndpointReceiverInfo = false).copy(
             entities = setOf(
                 EntitySelector(
                     id = null,

--- a/subscription-service/src/test/kotlin/com/egm/stellio/subscription/model/SubscriptionTest.kt
+++ b/subscription-service/src/test/kotlin/com/egm/stellio/subscription/model/SubscriptionTest.kt
@@ -17,7 +17,7 @@ import org.springframework.http.MediaType
 
 class SubscriptionTest {
 
-    private val endpointInfo =
+    private val endpointReceiverInfo =
         listOf(EndpointInfo(key = "Authorization-token", value = "Authorization-token-value"))
 
     private val subscription = Subscription(
@@ -44,7 +44,7 @@ class SubscriptionTest {
             endpoint = Endpoint(
                 uri = "http://localhost:8089/notification".toUri(),
                 accept = Endpoint.AcceptType.JSONLD,
-                info = endpointInfo
+                receiverInfo = endpointReceiverInfo
             )
         ),
         contexts = listOf(APIC_COMPOUND_CONTEXT)

--- a/subscription-service/src/test/kotlin/com/egm/stellio/subscription/service/SubscriptionServiceTests.kt
+++ b/subscription-service/src/test/kotlin/com/egm/stellio/subscription/service/SubscriptionServiceTests.kt
@@ -721,7 +721,7 @@ class SubscriptionServiceTests : WithTimescaleContainer {
             "endpoint" to mapOf(
                 "accept" to "application/ld+json",
                 "uri" to "http://localhost:8080",
-                "info" to listOf(
+                "receiverInfo" to listOf(
                     mapOf("key" to "Authorization-token", "value" to "Authorization-token-newValue")
                 )
             )
@@ -736,10 +736,9 @@ class SubscriptionServiceTests : WithTimescaleContainer {
                     it.notification.format.name == "KEY_VALUES" &&
                     it.notification.endpoint.accept.name == "JSONLD" &&
                     it.notification.endpoint.uri.toString() == "http://localhost:8080" &&
-                    it.notification.endpoint.info == listOf(
+                    it.notification.endpoint.receiverInfo == listOf(
                         EndpointInfo("Authorization-token", "Authorization-token-newValue")
-                    ) &&
-                    it.notification.endpoint.info!!.size == 1
+                    )
             }
     }
 

--- a/subscription-service/src/test/kotlin/com/egm/stellio/subscription/utils/FixtureUtils.kt
+++ b/subscription-service/src/test/kotlin/com/egm/stellio/subscription/utils/FixtureUtils.kt
@@ -33,7 +33,7 @@ fun gimmeSubscriptionFromMembers(
 
 fun gimmeRawSubscription(
     withQueryAndGeoQuery: Pair<Boolean, Boolean> = Pair(true, true),
-    withEndpointInfo: Boolean = true,
+    withEndpointReceiverInfo: Boolean = true,
     withNotifParams: Pair<FormatType, List<String>> = Pair(FormatType.NORMALIZED, emptyList()),
     withModifiedAt: Boolean = false,
     georel: String = "within",
@@ -59,8 +59,8 @@ fun gimmeRawSubscription(
         else
             null
 
-    val endpointInfo =
-        if (withEndpointInfo)
+    val endpointReceiverInfo =
+        if (withEndpointReceiverInfo)
             listOf(EndpointInfo(key = "Authorization-token", value = "Authorization-token-value"))
         else
             null
@@ -81,7 +81,7 @@ fun gimmeRawSubscription(
             endpoint = Endpoint(
                 uri = "http://localhost:8089/notification".toUri(),
                 accept = Endpoint.AcceptType.JSONLD,
-                info = endpointInfo
+                receiverInfo = endpointReceiverInfo
             )
         ),
         contexts = contexts

--- a/subscription-service/src/test/resources/ngsild/subscription_full.json
+++ b/subscription-service/src/test/resources/ngsild/subscription_full.json
@@ -30,7 +30,7 @@
     "endpoint": {
       "uri": "http://localhost:8084",
       "accept": "application/json",
-      "info": [
+      "receiverInfo": [
         { "key": "Authorization-token", "value": "Authorization-token-value" }
       ]
     }


### PR DESCRIPTION
- was still on pre-1.3 data model with only an info field
