### PR TITLE
feat(infra): remove heap size settings from Docker images

### DIFF
--- a/api-gateway/build.gradle.kts
+++ b/api-gateway/build.gradle.kts
@@ -27,7 +27,6 @@ springBoot {
 jib.from.image = project.ext["jibFromImage"].toString()
 jib.from.platforms.addAll(project.ext["jibFromPlatforms"] as List<PlatformParameters>)
 jib.to.image = "stellio/stellio-api-gateway:${project.version}"
-jib.container.jvmFlags = listOf("-Xms64m", "-Xmx128m")
 jib.container.ports = listOf("8080")
 jib.container.creationTime.set(project.ext["jibContainerCreationTime"].toString())
 jib.container.labels.putAll(project.ext["jibContainerLabels"] as Map<String, String>)

--- a/search-service/build.gradle.kts
+++ b/search-service/build.gradle.kts
@@ -52,7 +52,6 @@ jib.pluginExtensions {
         implementation = "com.google.cloud.tools.jib.gradle.extension.springboot.JibSpringBootExtension"
     }
 }
-jib.container.jvmFlags = listOf("-Xms512m", "-Xmx1024m")
 jib.container.ports = listOf("8083")
 jib.container.creationTime.set(project.ext["jibContainerCreationTime"].toString())
 jib.container.labels.putAll(project.ext["jibContainerLabels"] as Map<String, String>)

--- a/subscription-service/build.gradle.kts
+++ b/subscription-service/build.gradle.kts
@@ -50,7 +50,6 @@ jib.pluginExtensions {
         implementation = "com.google.cloud.tools.jib.gradle.extension.springboot.JibSpringBootExtension"
     }
 }
-jib.container.jvmFlags = listOf("-Xms256m", "-Xmx768m")
 jib.container.ports = listOf("8084")
 jib.container.creationTime.set(project.ext["jibContainerCreationTime"].toString())
 jib.container.labels.putAll(project.ext["jibContainerLabels"] as Map<String, String>)


### PR DESCRIPTION
- let containers use default JVM settings (see https://learn.microsoft.com/en-us/azure/developer/java/containers/overview#understand-jvm-default-ergonomics)
- added instructions in https://stellio.readthedocs.io/en/latest/admin/misc_configuration_tips.html#change-the-jvm-parameters-in-a-container
