### PR TITLE
refactor: remove contexts from expanded entity representation

### DIFF
--- a/search-service/src/main/kotlin/com/egm/stellio/search/authorization/EnabledAuthorizationService.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/authorization/EnabledAuthorizationService.kt
@@ -128,7 +128,7 @@ class EnabledAuthorizationService(
                 } else entityAccessControl
             }
             .map { it.serializeProperties(contexts) }
-            .map { ExpandedEntity(it, contexts) }
+            .map { ExpandedEntity(it) }
 
         val count = entityAccessRightsService.getSubjectAccessRightsCount(
             sub,
@@ -162,7 +162,7 @@ class EnabledAuthorizationService(
             }
 
         val jsonLdEntities = groups.second.map {
-            ExpandedEntity(it.serializeProperties(), contexts)
+            ExpandedEntity(it.serializeProperties())
         }
 
         Pair(groups.first, jsonLdEntities)
@@ -177,7 +177,7 @@ class EnabledAuthorizationService(
         val usersCount = subjectReferentialService.getUsersCount().bind()
 
         val jsonLdEntities = users.map {
-            ExpandedEntity(it.serializeProperties(contexts), contexts)
+            ExpandedEntity(it.serializeProperties(contexts))
         }
 
         Pair(usersCount, jsonLdEntities)

--- a/search-service/src/main/kotlin/com/egm/stellio/search/util/TemporalEntityBuilder.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/util/TemporalEntityBuilder.kt
@@ -29,17 +29,15 @@ object TemporalEntityBuilder {
 
     fun buildTemporalEntities(
         queryResult: List<EntityTemporalResult>,
-        temporalEntitiesQuery: TemporalEntitiesQuery,
-        contexts: List<String>
+        temporalEntitiesQuery: TemporalEntitiesQuery
     ): List<ExpandedEntity> =
         queryResult.map {
-            buildTemporalEntity(it, temporalEntitiesQuery, contexts)
+            buildTemporalEntity(it, temporalEntitiesQuery)
         }
 
     fun buildTemporalEntity(
         entityTemporalResult: EntityTemporalResult,
-        temporalEntitiesQuery: TemporalEntitiesQuery,
-        contexts: List<String>
+        temporalEntitiesQuery: TemporalEntitiesQuery
     ): ExpandedEntity {
         val temporalAttributes = buildTemporalAttributes(
             entityTemporalResult.teaInstancesResult,
@@ -55,7 +53,7 @@ object TemporalEntityBuilder {
         val expandedTemporalEntity = entityTemporalResult.entityPayload.serializeProperties()
             .plus(temporalAttributes)
             .plus(scopeAttributeInstances)
-        return ExpandedEntity(expandedTemporalEntity, contexts)
+        return ExpandedEntity(expandedTemporalEntity)
     }
 
     private fun buildTemporalAttributes(

--- a/search-service/src/main/kotlin/com/egm/stellio/search/web/EntityHandler.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/web/EntityHandler.kt
@@ -240,13 +240,12 @@ class EntityHandler(
 
         authorizationService.userCanReadEntity(entityId, sub).bind()
 
-        val expandedEntity = queryService.queryEntity(entityId, contexts).bind()
+        val expandedEntity = queryService.queryEntity(entityId).bind()
 
         expandedEntity.checkContainsAnyOf(queryParams.attrs).bind()
 
         val filteredExpandedEntity = ExpandedEntity(
-            expandedEntity.filterOnAttributes(queryParams.attrs),
-            expandedEntity.contexts
+            expandedEntity.filterOnAttributes(queryParams.attrs)
         )
         val compactedEntity = compactEntity(filteredExpandedEntity, contexts)
 

--- a/search-service/src/main/kotlin/com/egm/stellio/search/web/TemporalEntityHandler.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/web/TemporalEntityHandler.kt
@@ -65,8 +65,7 @@ class TemporalEntityHandler(
             val expandedEntity = ExpandedEntity(
                 sortedJsonLdInstances
                     .keepFirstInstances()
-                    .addCoreMembers(jsonLdTemporalEntity.id, jsonLdTemporalEntity.types),
-                contexts
+                    .addCoreMembers(jsonLdTemporalEntity.id, jsonLdTemporalEntity.types)
             )
             val ngsiLdEntity = expandedEntity.toNgsiLdEntity().bind()
 
@@ -191,11 +190,7 @@ class TemporalEntityHandler(
         val temporalEntitiesQuery =
             composeTemporalEntitiesQuery(applicationProperties.pagination, params, contexts).bind()
 
-        val temporalEntity = queryService.queryTemporalEntity(
-            entityId,
-            temporalEntitiesQuery,
-            contexts
-        ).bind()
+        val temporalEntity = queryService.queryTemporalEntity(entityId, temporalEntitiesQuery).bind()
 
         val compactedEntity = compactEntity(temporalEntity, contexts)
 

--- a/search-service/src/main/kotlin/db/migration/V0_29__JsonLd_migration.kt
+++ b/search-service/src/main/kotlin/db/migration/V0_29__JsonLd_migration.kt
@@ -133,7 +133,7 @@ class V0_29__JsonLd_migration : BaseJavaMigration() {
                 """.trimIndent()
             )
 
-            val jsonLdEntity = ExpandedEntity(expandedEntity, contexts)
+            val jsonLdEntity = ExpandedEntity(expandedEntity)
             val ngsiLdEntity = runBlocking {
                 jsonLdEntity.toNgsiLdEntity()
             }

--- a/search-service/src/test/kotlin/com/egm/stellio/search/service/QueryServiceTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/service/QueryServiceTests.kt
@@ -56,7 +56,7 @@ class QueryServiceTests {
     fun `it should return a JSON-LD entity when querying by id`() = runTest {
         coEvery { entityPayloadService.retrieve(any<URI>()) } returns gimmeEntityPayload().right()
 
-        queryService.queryEntity(entityUri, APIC_COMPOUND_CONTEXTS)
+        queryService.queryEntity(entityUri)
             .shouldSucceedWith {
                 assertEquals(entityUri.toString(), it.id)
                 assertEquals(listOf(BEEHIVE_TYPE), it.types)
@@ -68,7 +68,7 @@ class QueryServiceTests {
     fun `it should return an API exception if no entity exists with the given id`() = runTest {
         coEvery { entityPayloadService.retrieve(any<URI>()) } returns ResourceNotFoundException("").left()
 
-        queryService.queryEntity(entityUri, APIC_COMPOUND_CONTEXTS)
+        queryService.queryEntity(entityUri)
             .shouldFail {
                 assertTrue(it is ResourceNotFoundException)
             }
@@ -120,8 +120,7 @@ class QueryServiceTests {
                 withTemporalValues = false,
                 withAudit = false,
                 withAggregatedValues = false
-            ),
-            APIC_COMPOUND_CONTEXTS
+            )
         ).fold({
             assertInstanceOf(ResourceNotFoundException::class.java, it)
             assertEquals(
@@ -172,8 +171,7 @@ class QueryServiceTests {
                 withTemporalValues = false,
                 withAudit = false,
                 withAggregatedValues = false
-            ),
-            APIC_COMPOUND_CONTEXTS
+            )
         )
 
         coVerify {

--- a/search-service/src/test/kotlin/com/egm/stellio/search/util/TemporalEntityBuilderTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/util/TemporalEntityBuilderTests.kt
@@ -47,8 +47,7 @@ class TemporalEntityBuilderTests {
                 withTemporalValues = false,
                 withAudit = false,
                 withAggregatedValues = false
-            ),
-            APIC_COMPOUND_CONTEXTS
+            )
         )
         assertJsonPayloadsAreEqual(
             loadSampleData("expectations/beehive_empty_outgoing.jsonld"),
@@ -81,8 +80,7 @@ class TemporalEntityBuilderTests {
                 withTemporalValues,
                 withAudit,
                 false
-            ),
-            APIC_COMPOUND_CONTEXTS
+            )
         )
         assertJsonPayloadsAreEqual(
             expectation,
@@ -107,8 +105,7 @@ class TemporalEntityBuilderTests {
                 withTemporalValues,
                 withAudit,
                 false
-            ),
-            APIC_COMPOUND_CONTEXTS
+            )
         )
         assertJsonPayloadsAreEqual(
             expectation,
@@ -186,8 +183,7 @@ class TemporalEntityBuilderTests {
                 withTemporalValues = false,
                 withAudit = false,
                 withAggregatedValues = true
-            ),
-            APIC_COMPOUND_CONTEXTS
+            )
         )
 
         assertJsonPayloadsAreEqual(

--- a/search-service/src/test/kotlin/com/egm/stellio/search/web/EntityAccessControlHandlerTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/web/EntityAccessControlHandlerTests.kt
@@ -691,8 +691,7 @@ class EntityAccessControlHandlerTests {
                         "@id" to "urn:ngsi-ld:group:1",
                         "@type" to listOf(GROUP_TYPE),
                         NGSILD_NAME_PROPERTY to buildExpandedPropertyValue("egm")
-                    ),
-                    listOf(NGSILD_TEST_CORE_CONTEXT)
+                    )
                 )
             )
         ).right()
@@ -732,8 +731,7 @@ class EntityAccessControlHandlerTests {
                         "@type" to listOf(GROUP_TYPE),
                         NGSILD_NAME_PROPERTY to buildExpandedPropertyValue("egm"),
                         AuthContextModel.AUTH_REL_IS_MEMBER_OF to buildExpandedPropertyValue("true")
-                    ),
-                    listOf(AUTHZ_TEST_COMPOUND_CONTEXT)
+                    )
                 )
             )
         ).right()
@@ -836,8 +834,7 @@ class EntityAccessControlHandlerTests {
                         "givenName",
                         "familyName",
                         mapOf("profile" to "stellio-user", "username" to "username")
-                    ).serializeProperties(AUTHZ_TEST_COMPOUND_CONTEXTS),
-                    listOf(NGSILD_TEST_CORE_CONTEXT)
+                    ).serializeProperties(AUTHZ_TEST_COMPOUND_CONTEXTS)
                 )
             )
         ).right()
@@ -867,12 +864,9 @@ class EntityAccessControlHandlerTests {
             .jsonPath("[0].modifiedAt").doesNotExist()
     }
 
-    private suspend fun createJsonLdEntity(
-        entityAccessRights: EntityAccessRights,
-        context: String = NGSILD_TEST_CORE_CONTEXT
-    ): ExpandedEntity {
+    private suspend fun createJsonLdEntity(entityAccessRights: EntityAccessRights): ExpandedEntity {
         val earSerialized = entityAccessRights.serializeProperties(AUTHZ_TEST_COMPOUND_CONTEXTS)
-        return ExpandedEntity(earSerialized, listOf(context))
+        return ExpandedEntity(earSerialized)
     }
 
     private fun createEntityAccessRight(

--- a/search-service/src/test/kotlin/com/egm/stellio/search/web/EntityHandlerTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/web/EntityHandlerTests.kt
@@ -287,7 +287,7 @@ class EntityHandlerTests {
         mockkDefaultBehaviorForGetEntityById()
 
         val returnedExpandedEntity = mockkClass(ExpandedEntity::class, relaxed = true)
-        coEvery { queryService.queryEntity(any(), any()) } returns returnedExpandedEntity.right()
+        coEvery { queryService.queryEntity(any()) } returns returnedExpandedEntity.right()
         every { returnedExpandedEntity.checkContainsAnyOf(any()) } returns Unit.right()
 
         webClient.get()
@@ -301,7 +301,7 @@ class EntityHandlerTests {
     fun `get entity by id should correctly serialize temporal properties`() {
         mockkDefaultBehaviorForGetEntityById()
 
-        coEvery { queryService.queryEntity(any(), any()) } returns ExpandedEntity(
+        coEvery { queryService.queryEntity(any()) } returns ExpandedEntity(
             mapOf(
                 NGSILD_CREATED_AT_PROPERTY to
                     mapOf(
@@ -310,8 +310,7 @@ class EntityHandlerTests {
                     ),
                 "@id" to beehiveId.toString(),
                 "@type" to listOf("Beehive")
-            ),
-            listOf(NGSILD_TEST_CORE_CONTEXT)
+            )
         ).right()
 
         webClient.get()
@@ -333,7 +332,7 @@ class EntityHandlerTests {
     fun `get entity by id should correctly filter the asked attributes`() {
         mockkDefaultBehaviorForGetEntityById()
 
-        coEvery { queryService.queryEntity(any(), any()) } returns ExpandedEntity(
+        coEvery { queryService.queryEntity(any()) } returns ExpandedEntity(
             mapOf(
                 "@id" to beehiveId.toString(),
                 "@type" to listOf("Beehive"),
@@ -349,8 +348,7 @@ class EntityHandlerTests {
                         "@value" to "some value 2"
                     )
                 )
-            ),
-            listOf(NGSILD_TEST_CORE_CONTEXT)
+            )
         ).right()
 
         webClient.get()
@@ -367,7 +365,7 @@ class EntityHandlerTests {
     fun `get entity by id should correctly return the simplified representation of an entity`() {
         mockkDefaultBehaviorForGetEntityById()
 
-        coEvery { queryService.queryEntity(any(), any()) } returns ExpandedEntity(
+        coEvery { queryService.queryEntity(any()) } returns ExpandedEntity(
             mapOf(
                 "@id" to beehiveId.toString(),
                 "@type" to listOf("Beehive"),
@@ -383,8 +381,7 @@ class EntityHandlerTests {
                         JSONLD_ID to "urn:ngsi-ld:Entity:1234"
                     )
                 )
-            ),
-            listOf(NGSILD_TEST_CORE_CONTEXT)
+            )
         ).right()
 
         webClient.get()
@@ -410,12 +407,11 @@ class EntityHandlerTests {
     fun `get entity by id should return 404 if the entity has none of the requested attributes`() {
         mockkDefaultBehaviorForGetEntityById()
 
-        coEvery { queryService.queryEntity(any(), any()) } returns ExpandedEntity(
+        coEvery { queryService.queryEntity(any()) } returns ExpandedEntity(
             mapOf(
                 "@id" to beehiveId.toString(),
                 "@type" to listOf(BEEHIVE_TYPE)
-            ),
-            listOf(NGSILD_TEST_CORE_CONTEXT)
+            )
         ).right()
 
         val expectedMessage = entityOrAttrsNotFoundMessage(
@@ -442,12 +438,11 @@ class EntityHandlerTests {
     fun `get entity by id should not include temporal properties if optional query param sysAttrs is not present`() {
         mockkDefaultBehaviorForGetEntityById()
 
-        coEvery { queryService.queryEntity(any(), any()) } returns ExpandedEntity(
+        coEvery { queryService.queryEntity(any()) } returns ExpandedEntity(
             mapOf(
                 "@id" to beehiveId.toString(),
                 "@type" to listOf("Beehive")
-            ),
-            listOf(NGSILD_TEST_CORE_CONTEXT)
+            )
         ).right()
 
         webClient.get()
@@ -463,7 +458,7 @@ class EntityHandlerTests {
     @Test
     fun `get entity by id should correctly serialize properties of type DateTime and display sysAttrs asked`() {
         mockkDefaultBehaviorForGetEntityById()
-        coEvery { queryService.queryEntity(any(), any()) } returns ExpandedEntity(
+        coEvery { queryService.queryEntity(any()) } returns ExpandedEntity(
             mapOf(
                 NGSILD_CREATED_AT_PROPERTY to
                     mapOf(
@@ -489,8 +484,7 @@ class EntityHandlerTests {
                 ),
                 "@id" to beehiveId.toString(),
                 "@type" to listOf("Beehive")
-            ),
-            listOf(NGSILD_TEST_CORE_CONTEXT)
+            )
         ).right()
 
         webClient.get()
@@ -521,7 +515,7 @@ class EntityHandlerTests {
     fun `get entity by id should correctly serialize properties of type Date`() {
         mockkDefaultBehaviorForGetEntityById()
 
-        coEvery { queryService.queryEntity(any(), any()) } returns ExpandedEntity(
+        coEvery { queryService.queryEntity(any()) } returns ExpandedEntity(
             mapOf(
                 "https://uri.etsi.org/ngsi-ld/default-context/testedAt" to mapOf(
                     "@type" to "https://uri.etsi.org/ngsi-ld/Property",
@@ -532,8 +526,7 @@ class EntityHandlerTests {
                 ),
                 "@id" to beehiveId.toString(),
                 "@type" to listOf("Beehive")
-            ),
-            listOf(NGSILD_TEST_CORE_CONTEXT)
+            )
         ).right()
 
         webClient.get()
@@ -561,7 +554,7 @@ class EntityHandlerTests {
     fun `get entity by id should correctly serialize properties of type Time`() {
         mockkDefaultBehaviorForGetEntityById()
 
-        coEvery { queryService.queryEntity(any(), any()) } returns ExpandedEntity(
+        coEvery { queryService.queryEntity(any()) } returns ExpandedEntity(
             mapOf(
                 "https://uri.etsi.org/ngsi-ld/default-context/testedAt" to mapOf(
                     "@type" to "https://uri.etsi.org/ngsi-ld/Property",
@@ -572,8 +565,7 @@ class EntityHandlerTests {
                 ),
                 "@id" to "urn:ngsi-ld:Beehive:4567",
                 "@type" to listOf("Beehive")
-            ),
-            listOf(NGSILD_TEST_CORE_CONTEXT)
+            )
         ).right()
 
         webClient.get()
@@ -601,7 +593,7 @@ class EntityHandlerTests {
     fun `get entity by id should correctly serialize multi-attribute property having one instance`() {
         mockkDefaultBehaviorForGetEntityById()
 
-        coEvery { queryService.queryEntity(any(), any()) } returns ExpandedEntity(
+        coEvery { queryService.queryEntity(any()) } returns ExpandedEntity(
             mapOf(
                 "https://uri.etsi.org/ngsi-ld/default-context/name" to
                     mapOf(
@@ -613,8 +605,7 @@ class EntityHandlerTests {
                     ),
                 JSONLD_ID to "urn:ngsi-ld:Beehive:4567",
                 JSONLD_TYPE to listOf("Beehive")
-            ),
-            listOf(NGSILD_TEST_CORE_CONTEXT)
+            )
         ).right()
 
         webClient.get()
@@ -638,7 +629,7 @@ class EntityHandlerTests {
     fun `get entity by id should correctly serialize multi-attribute property having more than one instance`() {
         mockkDefaultBehaviorForGetEntityById()
 
-        coEvery { queryService.queryEntity(any(), any()) } returns ExpandedEntity(
+        coEvery { queryService.queryEntity(any()) } returns ExpandedEntity(
             mapOf(
                 "https://uri.etsi.org/ngsi-ld/default-context/name" to
                     listOf(
@@ -659,8 +650,7 @@ class EntityHandlerTests {
                     ),
                 JSONLD_ID to "urn:ngsi-ld:Beehive:4567",
                 JSONLD_TYPE to listOf("Beehive")
-            ),
-            listOf(NGSILD_TEST_CORE_CONTEXT)
+            )
         ).right()
 
         webClient.get()
@@ -691,7 +681,7 @@ class EntityHandlerTests {
     fun `get entity by id should correctly serialize multi-attribute relationship having one instance`() {
         mockkDefaultBehaviorForGetEntityById()
 
-        coEvery { queryService.queryEntity(any(), any()) } returns ExpandedEntity(
+        coEvery { queryService.queryEntity(any()) } returns ExpandedEntity(
             mapOf(
                 "https://uri.etsi.org/ngsi-ld/default-context/managedBy" to
                     mapOf(
@@ -705,8 +695,7 @@ class EntityHandlerTests {
                     ),
                 JSONLD_ID to "urn:ngsi-ld:Beehive:4567",
                 JSONLD_TYPE to listOf("Beehive")
-            ),
-            listOf(NGSILD_TEST_CORE_CONTEXT)
+            )
         ).right()
 
         webClient.get()
@@ -734,7 +723,7 @@ class EntityHandlerTests {
     fun `get entity by id should include createdAt & modifiedAt if query param sysAttrs is present`() {
         mockkDefaultBehaviorForGetEntityById()
 
-        coEvery { queryService.queryEntity(any(), any()) } returns ExpandedEntity(
+        coEvery { queryService.queryEntity(any()) } returns ExpandedEntity(
             mapOf(
                 "https://uri.etsi.org/ngsi-ld/default-context/managedBy" to
                     mapOf(
@@ -758,8 +747,7 @@ class EntityHandlerTests {
                     ),
                 JSONLD_ID to "urn:ngsi-ld:Beehive:4567",
                 JSONLD_TYPE to listOf("Beehive")
-            ),
-            listOf(NGSILD_TEST_CORE_CONTEXT)
+            )
         ).right()
 
         webClient.get()
@@ -776,7 +764,7 @@ class EntityHandlerTests {
     fun `get entity by id should correctly serialize multi-attribute relationship having more than one instance`() {
         mockkDefaultBehaviorForGetEntityById()
 
-        coEvery { queryService.queryEntity(any(), any()) } returns ExpandedEntity(
+        coEvery { queryService.queryEntity(any()) } returns ExpandedEntity(
             mapOf(
                 "https://uri.etsi.org/ngsi-ld/default-context/managedBy" to
                     listOf(
@@ -798,8 +786,7 @@ class EntityHandlerTests {
                     ),
                 JSONLD_ID to "urn:ngsi-ld:Beehive:4567",
                 JSONLD_TYPE to listOf("Beehive")
-            ),
-            listOf(NGSILD_TEST_CORE_CONTEXT)
+            )
         ).right()
 
         webClient.get()
@@ -879,8 +866,7 @@ class EntityHandlerTests {
                     mapOf(
                         "@id" to beehiveId.toString(),
                         "@type" to listOf("Beehive")
-                    ),
-                    listOf(NGSILD_TEST_CORE_CONTEXT)
+                    )
                 )
             ),
             1
@@ -928,8 +914,7 @@ class EntityHandlerTests {
                             ),
                         "@id" to beehiveId.toString(),
                         "@type" to listOf("Beehive")
-                    ),
-                    listOf(NGSILD_TEST_CORE_CONTEXT)
+                    )
                 )
             ),
             1
@@ -959,8 +944,7 @@ class EntityHandlerTests {
         coEvery { queryService.queryEntities(any(), any()) } returns Pair(
             listOf(
                 ExpandedEntity(
-                    mapOf("@id" to "urn:ngsi-ld:Beehive:TESTC", "@type" to listOf("Beehive")),
-                    listOf(NGSILD_TEST_CORE_CONTEXT)
+                    mapOf("@id" to "urn:ngsi-ld:Beehive:TESTC", "@type" to listOf("Beehive"))
                 )
             ),
             3
@@ -1058,8 +1042,7 @@ class EntityHandlerTests {
                     mapOf(
                         "@id" to beehiveId.toString(),
                         "@type" to listOf("Beehive")
-                    ),
-                    APIC_COMPOUND_CONTEXTS
+                    )
                 )
             ),
             1

--- a/search-service/src/test/kotlin/com/egm/stellio/search/web/EntityOperationHandlerTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/web/EntityOperationHandlerTests.kt
@@ -95,7 +95,6 @@ class EntityOperationHandlerTests {
         mockedTemperatureSensorExpandedEntity = mockkClass(ExpandedEntity::class) {
             every { id } returns temperatureSensorUri.toString()
             every { members } returns emptyMap()
-            every { contexts } returns listOf(AQUAC_COMPOUND_CONTEXT)
         }
         mockedDissolvedOxygenSensorEntity = mockkClass(NgsiLdEntity::class) {
             every { id } returns dissolvedOxygenSensorUri
@@ -104,7 +103,6 @@ class EntityOperationHandlerTests {
         mockedDissolvedOxygenSensorExpandedEntity = mockkClass(ExpandedEntity::class) {
             every { id } returns dissolvedOxygenSensorUri.toString()
             every { members } returns emptyMap()
-            every { contexts } returns listOf(AQUAC_COMPOUND_CONTEXT)
         }
         mockedDeviceEntity = mockkClass(NgsiLdEntity::class) {
             every { id } returns deviceUri
@@ -113,7 +111,6 @@ class EntityOperationHandlerTests {
         mockedDeviceExpandedEntity = mockkClass(ExpandedEntity::class) {
             every { id } returns deviceUri.toString()
             every { members } returns emptyMap()
-            every { contexts } returns listOf(AQUAC_COMPOUND_CONTEXT)
         }
     }
 

--- a/search-service/src/test/kotlin/com/egm/stellio/search/web/TemporalEntityHandlerTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/web/TemporalEntityHandlerTests.kt
@@ -367,7 +367,7 @@ class TemporalEntityHandlerTests {
 
         val returnedExpandedEntity = mockkClass(ExpandedEntity::class, relaxed = true)
         coEvery {
-            queryService.queryTemporalEntity(any(), any(), any())
+            queryService.queryTemporalEntity(any(), any())
         } returns returnedExpandedEntity.right()
 
         webClient.get()
@@ -530,7 +530,7 @@ class TemporalEntityHandlerTests {
         buildDefaultMockResponsesForGetEntity()
 
         coEvery {
-            queryService.queryTemporalEntity(any(), any(), any())
+            queryService.queryTemporalEntity(any(), any())
         } throws ResourceNotFoundException("Entity urn:ngsi-ld:BeeHive:TESTC was not found")
 
         webClient.get()
@@ -557,7 +557,7 @@ class TemporalEntityHandlerTests {
 
         val returnedExpandedEntity = mockkClass(ExpandedEntity::class, relaxed = true)
         coEvery {
-            queryService.queryTemporalEntity(any(), any(), any())
+            queryService.queryTemporalEntity(any(), any())
         } returns returnedExpandedEntity.right()
 
         webClient.get()
@@ -579,8 +579,7 @@ class TemporalEntityHandlerTests {
                         ) &&
                         !temporalEntitiesQuery.withTemporalValues &&
                         !temporalEntitiesQuery.withAudit
-                },
-                eq(APIC_COMPOUND_CONTEXTS)
+                }
             )
         }
         confirmVerified(queryService)
@@ -592,7 +591,7 @@ class TemporalEntityHandlerTests {
 
         val returnedExpandedEntity = mockkClass(ExpandedEntity::class, relaxed = true)
         coEvery {
-            queryService.queryTemporalEntity(any(), any(), any())
+            queryService.queryTemporalEntity(any(), any())
         } returns returnedExpandedEntity.right()
 
         webClient.get()
@@ -613,7 +612,7 @@ class TemporalEntityHandlerTests {
 
         val returnedExpandedEntity = mockkClass(ExpandedEntity::class, relaxed = true)
         coEvery {
-            queryService.queryTemporalEntity(any(), any(), any())
+            queryService.queryTemporalEntity(any(), any())
         } returns returnedExpandedEntity.right()
 
         webClient.get()
@@ -737,7 +736,7 @@ class TemporalEntityHandlerTests {
         }
 
         coEvery {
-            queryService.queryTemporalEntity(any(), any(), any())
+            queryService.queryTemporalEntity(any(), any())
         } returns entityWith2temporalEvolutions.right()
     }
 

--- a/shared/src/main/kotlin/com/egm/stellio/shared/model/ExpandedEntity.kt
+++ b/shared/src/main/kotlin/com/egm/stellio/shared/model/ExpandedEntity.kt
@@ -14,8 +14,7 @@ import com.egm.stellio.shared.util.entityOrAttrsNotFoundMessage
 import java.time.ZonedDateTime
 
 data class ExpandedEntity(
-    val members: Map<String, Any>,
-    val contexts: List<String>
+    val members: Map<String, Any>
 ) {
     fun containsAnyOf(expandedAttributes: Set<String>): Boolean =
         expandedAttributes.isEmpty() || members.keys.any { expandedAttributes.contains(it) }
@@ -50,8 +49,7 @@ data class ExpandedEntity(
                         createdAt
                     ) as ExpandedAttributeInstance
                 }
-            }.addDateTimeProperty(NGSILD_CREATED_AT_PROPERTY, createdAt),
-            contexts = contexts
+            }.addDateTimeProperty(NGSILD_CREATED_AT_PROPERTY, createdAt)
         )
 
     /**
@@ -71,8 +69,7 @@ data class ExpandedEntity(
                 }
             }
                 .addDateTimeProperty(NGSILD_CREATED_AT_PROPERTY, createdAt)
-                .addDateTimeProperty(NGSILD_MODIFIED_AT_PROPERTY, replacedAt),
-            contexts = contexts
+                .addDateTimeProperty(NGSILD_MODIFIED_AT_PROPERTY, replacedAt)
         )
 
     val id by lazy {
@@ -111,5 +108,5 @@ data class ExpandedEntity(
 fun List<ExpandedEntity>.filterOnAttributes(includedAttributes: Set<String>): List<ExpandedEntity> =
     this.filter { it.containsAnyOf(includedAttributes) }
         .map {
-            ExpandedEntity(it.filterOnAttributes(includedAttributes), it.contexts)
+            ExpandedEntity(it.filterOnAttributes(includedAttributes))
         }

--- a/shared/src/main/kotlin/com/egm/stellio/shared/util/JsonLdUtils.kt
+++ b/shared/src/main/kotlin/com/egm/stellio/shared/util/JsonLdUtils.kt
@@ -138,14 +138,14 @@ object JsonLdUtils {
         runCatching {
             doJsonLdExpansion(input, contexts)
         }.fold({
-            ExpandedEntity(it, contexts).right()
+            ExpandedEntity(it).right()
         }, {
             if (it is APIException) it.left()
             else it.toAPIException().left()
         })
 
     suspend fun expandJsonLdEntity(input: Map<String, Any>, contexts: List<String>): ExpandedEntity =
-        ExpandedEntity(doJsonLdExpansion(input, contexts), contexts)
+        ExpandedEntity(doJsonLdExpansion(input, contexts))
 
     suspend fun expandJsonLdEntity(input: String, contexts: List<String>): ExpandedEntity =
         expandJsonLdEntity(input.deserializeAsMap(), contexts)

--- a/shared/src/test/kotlin/com/egm/stellio/shared/model/ExpandedEntityTests.kt
+++ b/shared/src/test/kotlin/com/egm/stellio/shared/model/ExpandedEntityTests.kt
@@ -12,8 +12,7 @@ class ExpandedEntityTests {
     @Test
     fun `it should find an expanded attribute contained in the entity`() {
         val expandedEntity = ExpandedEntity(
-            mapOf(INCOMING_PROPERTY to "", OUTGOING_PROPERTY to ""),
-            NGSILD_TEST_CORE_CONTEXTS
+            mapOf(INCOMING_PROPERTY to "", OUTGOING_PROPERTY to "")
         )
 
         val checkResult = expandedEntity.checkContainsAnyOf(setOf(TEMPERATURE_PROPERTY, INCOMING_PROPERTY))
@@ -26,8 +25,7 @@ class ExpandedEntityTests {
     @Test
     fun `it should not find an expanded attribute contained in the entity`() {
         val expandedEntity = ExpandedEntity(
-            mapOf(INCOMING_PROPERTY to "", OUTGOING_PROPERTY to "", JSONLD_ID to "urn:ngsi-ld:Entity:01"),
-            NGSILD_TEST_CORE_CONTEXTS
+            mapOf(INCOMING_PROPERTY to "", OUTGOING_PROPERTY to "", JSONLD_ID to "urn:ngsi-ld:Entity:01")
         )
 
         val checkResult = expandedEntity.checkContainsAnyOf(setOf(TEMPERATURE_PROPERTY, NGSILD_NAME_PROPERTY))

--- a/subscription-service/src/main/kotlin/com/egm/stellio/subscription/listener/EntityEventListenerService.kt
+++ b/subscription-service/src/main/kotlin/com/egm/stellio/subscription/listener/EntityEventListenerService.kt
@@ -52,59 +52,51 @@ class EntityEventListenerService(
                     tenantName,
                     entityEvent.operationPayload.getUpdatedAttributes(),
                     entityEvent.getEntity(),
-                    NotificationTrigger.ENTITY_CREATED,
-                    entityEvent.contexts
+                    NotificationTrigger.ENTITY_CREATED
                 )
                 is EntityReplaceEvent -> entityEvent.operationPayload.getUpdatedAttributes().forEach { attribute ->
                     handleEntityEvent(
                         tenantName,
                         setOf(attribute),
                         entityEvent.getEntity(),
-                        NotificationTrigger.ATTRIBUTE_CREATED,
-                        entityEvent.contexts
+                        NotificationTrigger.ATTRIBUTE_CREATED
                     )
                 }
                 is EntityDeleteEvent -> handleEntityEvent(
                     tenantName,
                     entityEvent.deletedEntity?.getUpdatedAttributes() ?: emptySet(),
                     entityEvent.getEntity() ?: serializeObject(emptyMap<String, Any>()),
-                    NotificationTrigger.ENTITY_DELETED,
-                    entityEvent.contexts
+                    NotificationTrigger.ENTITY_DELETED
                 )
                 is AttributeAppendEvent -> handleEntityEvent(
                     tenantName,
                     setOf(entityEvent.attributeName),
                     entityEvent.getEntity(),
-                    NotificationTrigger.ATTRIBUTE_CREATED,
-                    entityEvent.contexts
+                    NotificationTrigger.ATTRIBUTE_CREATED
                 )
                 is AttributeReplaceEvent -> handleEntityEvent(
                     tenantName,
                     setOf(entityEvent.attributeName),
                     entityEvent.getEntity(),
-                    NotificationTrigger.ATTRIBUTE_UPDATED,
-                    entityEvent.contexts
+                    NotificationTrigger.ATTRIBUTE_UPDATED
                 )
                 is AttributeUpdateEvent -> handleEntityEvent(
                     tenantName,
                     setOf(entityEvent.attributeName),
                     entityEvent.getEntity(),
-                    NotificationTrigger.ATTRIBUTE_UPDATED,
-                    entityEvent.contexts
+                    NotificationTrigger.ATTRIBUTE_UPDATED
                 )
                 is AttributeDeleteEvent -> handleEntityEvent(
                     tenantName,
                     setOf(entityEvent.attributeName),
                     entityEvent.getEntity(),
-                    NotificationTrigger.ATTRIBUTE_DELETED,
-                    entityEvent.contexts
+                    NotificationTrigger.ATTRIBUTE_DELETED
                 )
                 is AttributeDeleteAllInstancesEvent -> handleEntityEvent(
                     tenantName,
                     setOf(entityEvent.attributeName),
                     entityEvent.getEntity(),
-                    NotificationTrigger.ATTRIBUTE_DELETED,
-                    entityEvent.contexts
+                    NotificationTrigger.ATTRIBUTE_DELETED
                 )
             }
         }.onFailure {
@@ -116,11 +108,10 @@ class EntityEventListenerService(
         tenantName: String,
         updatedAttributes: Set<ExpandedTerm>,
         entityPayload: String,
-        notificationTrigger: NotificationTrigger,
-        contexts: List<String>
+        notificationTrigger: NotificationTrigger
     ): Either<APIException, Disposable> = either {
         logger.debug("Attributes considered in the event: {}", updatedAttributes)
-        val expandedEntity = ExpandedEntity(entityPayload.deserializeAsMap(), contexts)
+        val expandedEntity = ExpandedEntity(entityPayload.deserializeAsMap())
         mono {
             notificationService.notifyMatchingSubscribers(
                 expandedEntity,

--- a/subscription-service/src/main/kotlin/com/egm/stellio/subscription/service/NotificationService.kt
+++ b/subscription-service/src/main/kotlin/com/egm/stellio/subscription/service/NotificationService.kt
@@ -44,7 +44,7 @@ class NotificationService(
                     else AttributeRepresentation.NORMALIZED
 
                 val compactedEntity = compactEntity(
-                    ExpandedEntity(filteredEntity, it.contexts),
+                    ExpandedEntity(filteredEntity),
                     it.contexts
                 ).toFinalRepresentation(
                     NgsiLdDataRepresentation(


### PR DESCRIPTION
Once an entity is expanded, the contexts used to do the expansion should not be used anymore. So remove them to avoid any misuse of them.