### PR TITLE
feat: allow setting a specific timezone for aggregates

### DIFF
--- a/search-service/src/main/kotlin/com/egm/stellio/search/common/config/SearchProperties.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/common/config/SearchProperties.kt
@@ -5,5 +5,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @ConfigurationProperties("search")
 data class SearchProperties(
     val payloadMaxBodySize: Int,
-    var onOwnerDeleteCascadeEntities: Boolean
+    val onOwnerDeleteCascadeEntities: Boolean,
+    val timezoneForTimeBuckets: String = "GMT"
 )

--- a/search-service/src/main/kotlin/com/egm/stellio/search/scope/ScopeService.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/scope/ScopeService.kt
@@ -4,6 +4,7 @@ import arrow.core.Either
 import arrow.core.left
 import arrow.core.raise.either
 import arrow.core.right
+import com.egm.stellio.search.common.config.SearchProperties
 import com.egm.stellio.search.common.util.*
 import com.egm.stellio.search.entity.model.*
 import com.egm.stellio.search.entity.model.Attribute.AttributeValueType
@@ -29,7 +30,8 @@ import java.time.ZonedDateTime
 
 @Service
 class ScopeService(
-    private val databaseClient: DatabaseClient
+    private val databaseClient: DatabaseClient,
+    private val searchProperties: SearchProperties
 ) {
 
     @Transactional
@@ -150,7 +152,7 @@ class ScopeService(
                 val computedOrigin = origin ?: temporalQuery.timeAt
                 """
                 SELECT entity_id,
-                   public.time_bucket('$aggrPeriodDuration', time, TIMESTAMPTZ '${computedOrigin!!}') as start,
+                   public.time_bucket('$aggrPeriodDuration', time, '${searchProperties.timezoneForTimeBuckets}', TIMESTAMPTZ '${computedOrigin!!}') as start,
                    $allAggregates
                 """
             } else

--- a/search-service/src/main/kotlin/com/egm/stellio/search/temporal/service/AttributeInstanceService.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/temporal/service/AttributeInstanceService.kt
@@ -5,6 +5,7 @@ import arrow.core.left
 import arrow.core.raise.either
 import arrow.core.right
 import arrow.fx.coroutines.parMap
+import com.egm.stellio.search.common.config.SearchProperties
 import com.egm.stellio.search.common.util.*
 import com.egm.stellio.search.entity.model.Attribute
 import com.egm.stellio.search.entity.model.AttributeMetadata
@@ -28,7 +29,8 @@ import java.util.UUID
 
 @Service
 class AttributeInstanceService(
-    private val databaseClient: DatabaseClient
+    private val databaseClient: DatabaseClient,
+    private val searchProperties: SearchProperties
 ) {
 
     private val attributesInstancesTables = listOf("attribute_instance", "attribute_instance_audit")
@@ -223,7 +225,7 @@ class AttributeInstanceService(
                 val computedOrigin = origin ?: temporalQuery.timeAt
                 """
                 SELECT temporal_entity_attribute,
-                    public.time_bucket('$aggrPeriodDuration', time, TIMESTAMPTZ '${computedOrigin!!}') as start,
+                    public.time_bucket('$aggrPeriodDuration', time, '${searchProperties.timezoneForTimeBuckets}', TIMESTAMPTZ '${computedOrigin!!}') as start,
                     $allAggregates
                 """.trimIndent()
             } else

--- a/search-service/src/main/resources/application.properties
+++ b/search-service/src/main/resources/application.properties
@@ -15,3 +15,7 @@ server.port = 8083
 search.payload-max-body-size = 2048000
 
 search.on-owner-delete-cascade-entities = false
+# by default, bucket start times are aligned at 00:00:00UTC
+# https://docs.timescale.com/use-timescale/latest/time-buckets/about-time-buckets/#timezones
+# this property allows to align them different timezones which is useful for weekly or monthly aggregates for instance
+search.timezone-for-time-buckets = GMT

--- a/search-service/src/test/kotlin/com/egm/stellio/search/temporal/service/AttributeInstanceServiceTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/temporal/service/AttributeInstanceServiceTests.kt
@@ -1,5 +1,6 @@
 package com.egm.stellio.search.temporal.service
 
+import com.egm.stellio.search.common.config.SearchProperties
 import com.egm.stellio.search.entity.model.Attribute
 import com.egm.stellio.search.entity.model.AttributeMetadata
 import com.egm.stellio.search.entity.service.EntityAttributeService
@@ -60,6 +61,9 @@ class AttributeInstanceServiceTests : WithTimescaleContainer, WithKafkaContainer
 
     @Autowired
     private lateinit var databaseClient: DatabaseClient
+
+    @Autowired
+    private lateinit var searchProperties: SearchProperties
 
     @Autowired
     private lateinit var r2dbcEntityTemplate: R2dbcEntityTemplate
@@ -562,7 +566,10 @@ class AttributeInstanceServiceTests : WithTimescaleContainer, WithKafkaContainer
 
     @Test
     fun `it should create an attribute instance if it has a non null value`() = runTest {
-        val attributeInstanceService = spyk(AttributeInstanceService(databaseClient), recordPrivateCalls = true)
+        val attributeInstanceService = spyk(
+            AttributeInstanceService(databaseClient, searchProperties),
+            recordPrivateCalls = true
+        )
         val attributeMetadata = AttributeMetadata(
             measuredValue = 550.0,
             value = null,
@@ -621,7 +628,10 @@ class AttributeInstanceServiceTests : WithTimescaleContainer, WithKafkaContainer
 
     @Test
     fun `it should create an attribute instance with boolean value`() = runTest {
-        val attributeInstanceService = spyk(AttributeInstanceService(databaseClient), recordPrivateCalls = true)
+        val attributeInstanceService = spyk(
+            AttributeInstanceService(databaseClient, searchProperties),
+            recordPrivateCalls = true
+        )
         val attributeMetadata = AttributeMetadata(
             measuredValue = null,
             value = false.toString(),


### PR DESCRIPTION
By default, bucket start times are aligned at 00:00:00UTC (see https://docs.timescale.com/use-timescale/latest/time-buckets/about-time-buckets/#timezones). This property allows to align them different timezones which is useful for weekly or monthly aggregates for instance.
