### PR TITLE
fix: incorrect behaviors in Batch Entity Upsert endpoint

### DIFF
--- a/search-service/src/main/kotlin/com/egm/stellio/search/entity/web/BatchAPIResponses.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/entity/web/BatchAPIResponses.kt
@@ -27,16 +27,6 @@ data class BatchOperationResult(
         entities.forEach {
             errors.add(BatchEntityError(it.first.toUri(), arrayListOf(it.second.message)))
         }
-
-    @JsonIgnore
-    fun addEntitiesToErrors(entities: List<NgsiLdEntity>, errorMessage: String) =
-        addIdsToErrors(entities.map { it.id }, errorMessage)
-
-    @JsonIgnore
-    fun addIdsToErrors(entitiesIds: List<URI>, errorMessage: String) =
-        errors.addAll(
-            entitiesIds.map { BatchEntityError(it, arrayListOf(errorMessage)) }
-        )
 }
 
 data class BatchEntitySuccess(
@@ -53,7 +43,6 @@ data class BatchEntityError(
 
 typealias JsonLdNgsiLdEntity = Pair<ExpandedEntity, NgsiLdEntity>
 
-fun List<JsonLdNgsiLdEntity>.extractNgsiLdEntities(): List<NgsiLdEntity> = this.map { it.second }
 fun JsonLdNgsiLdEntity.entityId(): URI = this.second.id
 
 // a temporary data class to hold the result of deserializing, expanding and transforming to NGSI-LD entities

--- a/search-service/src/main/kotlin/com/egm/stellio/search/entity/web/EntityOperationHandler.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/entity/web/EntityOperationHandler.kt
@@ -109,7 +109,9 @@ class EntityOperationHandler(
         )
         @RequestParam queryParams: MultiValueMap<String, String>
     ): ResponseEntity<*> = either {
-        val options = queryParams.getFirst(QP.OPTIONS.key)
+        val options = queryParams.getFirst(QP.OPTIONS.key)?.split(",")
+        val disallowOverwrite = options?.any { it == OptionsValue.NO_OVERWRITE.value } == true
+        val updateMode = options?.any { it == OptionsValue.UPDATE_MODE.value } == true
         val sub = getSubFromSecurityContext()
 
         val (parsedEntities, unparsableEntities) = prepareEntitiesFromRequestBody(requestBody, httpHeaders).bind()
@@ -121,7 +123,8 @@ class EntityOperationHandler(
         val newUniqueEntities = if (parsedEntities.isNotEmpty()) {
             val (updateOperationResult, newUniqueEntities) = entityOperationService.upsert(
                 parsedEntities,
-                options,
+                disallowOverwrite,
+                updateMode,
                 sub.getOrNull()
             )
 
@@ -155,11 +158,11 @@ class EntityOperationHandler(
         @RequestParam queryParams: MultiValueMap<String, String>
     ): ResponseEntity<*> = either {
         val options = queryParams.getFirst(QP.OPTIONS.key)
+        val disallowOverwrite = options?.let { it == OptionsValue.NO_OVERWRITE.value } == true
+
         val sub = getSubFromSecurityContext()
 
         val (parsedEntities, unparsableEntities) = prepareEntitiesFromRequestBody(requestBody, httpHeaders).bind()
-
-        val disallowOverwrite = options?.let { it == OptionsValue.NO_OVERWRITE.value } ?: false
 
         val batchOperationResult = BatchOperationResult().apply {
             addEntitiesToErrors(unparsableEntities)
@@ -201,8 +204,7 @@ class EntityOperationHandler(
         }
 
         if (parsedEntities.isNotEmpty()) {
-            val mergeOperationResult =
-                entityOperationService.merge(parsedEntities, sub.getOrNull())
+            val mergeOperationResult = entityOperationService.merge(parsedEntities, sub.getOrNull())
             batchOperationResult.errors.addAll(mergeOperationResult.errors)
             batchOperationResult.success.addAll(mergeOperationResult.success)
         }

--- a/search-service/src/test/kotlin/com/egm/stellio/search/entity/service/EntityOperationServiceTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/entity/service/EntityOperationServiceTests.kt
@@ -40,9 +40,6 @@ class EntityOperationServiceTests {
     @MockkBean
     private lateinit var entityService: EntityService
 
-    @MockkBean(relaxed = true)
-    private lateinit var entityAttributeService: EntityAttributeService
-
     @MockkBean
     private lateinit var entityQueryService: EntityQueryService
 
@@ -282,11 +279,8 @@ class EntityOperationServiceTests {
     @Test
     fun `batch replace should ask to replace entities`() = runTest {
         coEvery {
-            entityAttributeService.deleteAttributes(any())
+            entityService.replaceEntity(any(), any(), any(), any())
         } returns Unit.right()
-        coEvery {
-            entityService.appendAttributes(any(), any(), any(), any())
-        } returns EMPTY_UPDATE_RESULT.right()
 
         val batchOperationResult = entityOperationService.replace(
             listOf(
@@ -302,14 +296,7 @@ class EntityOperationServiceTests {
         )
         assertTrue(batchOperationResult.errors.isEmpty())
 
-        coVerify { entityAttributeService.deleteAttributes(firstEntityURI) }
-        coVerify { entityAttributeService.deleteAttributes(secondEntityURI) }
-        coVerify {
-            entityService.appendAttributes(eq(firstEntityURI), any(), false, sub)
-        }
-        coVerify {
-            entityService.appendAttributes(eq(secondEntityURI), any(), false, sub)
-        }
+        coVerify { entityService.replaceEntity(firstEntityURI, any(), any(), any()) }
     }
 
     @Test
@@ -457,7 +444,8 @@ class EntityOperationServiceTests {
                 firstExpandedEntity to firstEntity,
                 secondExpandedEntity to secondEntity
             ),
-            null,
+            disallowOverwrite = false,
+            updateMode = false,
             sub
         )
 
@@ -484,7 +472,8 @@ class EntityOperationServiceTests {
                 firstExpandedEntity to firstEntity,
                 secondExpandedEntity to secondEntity
             ),
-            "update",
+            disallowOverwrite = false,
+            updateMode = true,
             sub
         )
 
@@ -523,7 +512,8 @@ class EntityOperationServiceTests {
                 firstExpandedEntity to firstEntity,
                 secondExpandedEntity to secondEntity
             ),
-            "update",
+            disallowOverwrite = false,
+            updateMode = true,
             sub
         )
 
@@ -567,7 +557,8 @@ class EntityOperationServiceTests {
                 firstExpandedEntity to firstEntity,
                 secondExpandedEntity to secondEntity
             ),
-            null,
+            disallowOverwrite = false,
+            updateMode = false,
             sub
         )
 

--- a/shared/src/main/kotlin/com/egm/stellio/shared/queryparameter/OptionsValue.kt
+++ b/shared/src/main/kotlin/com/egm/stellio/shared/queryparameter/OptionsValue.kt
@@ -3,5 +3,7 @@ package com.egm.stellio.shared.queryparameter
 enum class OptionsValue(val value: String) {
     SYS_ATTRS("sysAttrs"),
     KEY_VALUES("keyValues"),
-    NO_OVERWRITE("noOverwrite")
+    NO_OVERWRITE("noOverwrite"),
+    UPDATE_MODE("update"),
+    REPLACE_MODE("replace")
 }


### PR DESCRIPTION
- noOverwrite option is not handled whereas it should be passed when in update mode
- replace mode was only replacing the attributes of the entity (and thus was missing all the other needed actions: replace types and scopes, send events...)
