### PR TITLE
fix(temp): use deleted entity in notifications

### DIFF
--- a/subscription-service/src/main/kotlin/com/egm/stellio/subscription/service/NotificationService.kt
+++ b/subscription-service/src/main/kotlin/com/egm/stellio/subscription/service/NotificationService.kt
@@ -48,6 +48,8 @@ class NotificationService(
             notificationTrigger
         ).bind()
             .map {
+                // using the "previous" entity (it is actually the previous only for deleted entity events)
+                // to be able to send deleted attributes in case of a entityDeleted event
                 val filteredEntity = previousAndUpdatedExpandedEntities.first.filterAttributes(
                     it.notification.attributes?.toSet().orEmpty(),
                     it.datasetId?.toSet().orEmpty()

--- a/subscription-service/src/main/kotlin/com/egm/stellio/subscription/service/NotificationService.kt
+++ b/subscription-service/src/main/kotlin/com/egm/stellio/subscription/service/NotificationService.kt
@@ -48,7 +48,7 @@ class NotificationService(
             notificationTrigger
         ).bind()
             .map {
-                val filteredEntity = previousAndUpdatedExpandedEntities.second.filterAttributes(
+                val filteredEntity = previousAndUpdatedExpandedEntities.first.filterAttributes(
                     it.notification.attributes?.toSet().orEmpty(),
                     it.datasetId?.toSet().orEmpty()
                 )


### PR DESCRIPTION
Temporary solution while `showChanges` is not implemented. It allows to have access to attributes in case of a `entityDeleted` event. For other events, previous and updated entity are the same.