### PR TITLE
refactor: separate CSR, RegistrationInfo and EntityInfo

### DIFF
--- a/search-service/src/main/kotlin/com/egm/stellio/search/csr/model/EntityInfo.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/csr/model/EntityInfo.kt
@@ -1,0 +1,75 @@
+package com.egm.stellio.search.csr.model
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import com.egm.stellio.shared.model.BadRequestDataException
+import com.egm.stellio.shared.model.areTypesInSelection
+import com.egm.stellio.shared.queryparameter.QP
+import com.egm.stellio.shared.util.JsonLdUtils.compactTerm
+import com.egm.stellio.shared.util.JsonLdUtils.expandJsonLdTerm
+import com.egm.stellio.shared.util.toTypeSelection
+import com.fasterxml.jackson.annotation.JsonFormat
+import com.fasterxml.jackson.annotation.JsonProperty
+import org.springframework.util.CollectionUtils
+import org.springframework.util.MultiValueMap
+import java.net.URI
+import java.util.regex.Pattern
+
+/**
+ * EntityInfo type as defined in 5.2.8
+ */
+data class EntityInfo(
+    val id: URI? = null,
+    val idPattern: String? = null,
+    // no WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED because it is used for the database
+    @JsonFormat(with = [JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY])
+    @JsonProperty("type")
+    val types: List<String>
+) {
+    fun expand(contexts: List<String>): EntityInfo =
+        this.copy(
+            types = types.map { expandJsonLdTerm(it, contexts) },
+        )
+
+    fun compact(contexts: List<String>): EntityInfo =
+        this.copy(
+            types = types.map { compactTerm(it, contexts) },
+        )
+
+    fun validate(): Either<BadRequestDataException, Unit> {
+        val result = runCatching {
+            idPattern?.let { Pattern.compile(it) }
+            true
+        }.fold({ true }, { false })
+
+        return if (result)
+            Unit.right()
+        else BadRequestDataException("Invalid idPattern found in contextSourceRegistration").left()
+    }
+
+    fun matchCSF(csrFilters: CSRFilters) =
+        this.id?.let {
+            csrFilters.ids.isEmpty() || csrFilters.ids.contains(it)
+        } ?: true &&
+            csrFilters.typeSelection?.let { typeSelection ->
+                areTypesInSelection(this.types, typeSelection)
+            } ?: true &&
+            this.idPattern?.let { pattern ->
+                csrFilters.ids.isEmpty() || csrFilters.ids.any { pattern.toRegex().matches(it.toString()) }
+            } ?: true
+
+    companion object {
+
+        fun MultiValueMap<String, String>.addFilterForEntityInfo(
+            entityInfo: EntityInfo
+        ): MultiValueMap<String, String> {
+            val newParams = CollectionUtils.toMultiValueMap(this.toMutableMap())
+            newParams[QP.TYPE.key] = entityInfo.types.toTypeSelection()
+            entityInfo.id?.let { id -> newParams[QP.ID.key] = id.toString() }
+            if (this.getFirst(QP.ID_PATTERN.key) == null && entityInfo.idPattern != null)
+                newParams[QP.ID_PATTERN.key] = entityInfo.idPattern
+            return newParams
+        }
+    }
+}

--- a/search-service/src/main/kotlin/com/egm/stellio/search/csr/model/RegistrationInfo.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/csr/model/RegistrationInfo.kt
@@ -1,0 +1,75 @@
+package com.egm.stellio.search.csr.model
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.raise.either
+import arrow.core.right
+import com.egm.stellio.shared.model.BadRequestDataException
+import com.egm.stellio.shared.util.JsonLdUtils.compactTerm
+import com.egm.stellio.shared.util.JsonLdUtils.expandJsonLdTerm
+import com.fasterxml.jackson.annotation.JsonIgnore
+
+/**
+ * RegistrationInfo type as defined in 5.2.10
+ */
+data class RegistrationInfo(
+    val entities: List<EntityInfo>? = null,
+    val propertyNames: List<String>? = null,
+    val relationshipNames: List<String>? = null
+) {
+    fun expand(contexts: List<String>): RegistrationInfo =
+        RegistrationInfo(
+            entities = entities?.map { it.expand(contexts) },
+            propertyNames = propertyNames?.map { expandJsonLdTerm(it, contexts) },
+            relationshipNames = relationshipNames?.map { expandJsonLdTerm(it, contexts) },
+        )
+
+    fun compact(contexts: List<String>): RegistrationInfo =
+        RegistrationInfo(
+            entities = entities?.map { it.compact(contexts) },
+            propertyNames = propertyNames?.map { compactTerm(it, contexts) },
+            relationshipNames = relationshipNames?.map { compactTerm(it, contexts) }
+        )
+
+    fun validate(): Either<BadRequestDataException, Unit> = either {
+        return if (entities != null || propertyNames != null || relationshipNames != null) {
+            entities?.forEach { it.validate().bind() }
+            Unit.right()
+        } else {
+            BadRequestDataException("RegistrationInfo should have at least one element").left()
+        }
+    }
+
+    @JsonIgnore
+    fun getAttributeNames(): Set<String>? = when {
+        this.propertyNames == null && this.relationshipNames == null -> null
+        this.propertyNames == null -> this.relationshipNames?.toSet()
+        this.relationshipNames == null -> this.propertyNames.toSet()
+        else -> this.propertyNames.toMutableSet().plus(this.relationshipNames.toSet())
+    }
+
+    fun matchCSF(csrFilters: CSRFilters): Boolean =
+        entities?.any { entityInfo ->
+            entityInfo.matchCSF(csrFilters)
+        } ?: true &&
+            (
+                csrFilters.attrs.isEmpty() ||
+                    getAttributeNames()?.any { it in csrFilters.attrs } ?: true
+                )
+
+    @JsonIgnore
+    fun computeAttrsQueryParam(
+        csrFilters: CSRFilters,
+        contexts: List<String>
+    ): String? {
+        val csrAttrs = getAttributeNames()
+        val queryAttrs = csrFilters.attrs
+        val matchingAttrs = when {
+            queryAttrs.isEmpty() -> csrAttrs
+            csrAttrs.isNullOrEmpty() -> queryAttrs
+            else -> csrAttrs.intersect(queryAttrs)
+        }
+        return if (matchingAttrs.isNullOrEmpty()) null
+        else matchingAttrs.joinToString(",") { compactTerm(it, contexts) }
+    }
+}

--- a/search-service/src/main/kotlin/com/egm/stellio/search/csr/service/ContextSourceRegistrationService.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/csr/service/ContextSourceRegistrationService.kt
@@ -16,10 +16,10 @@ import com.egm.stellio.search.common.util.toUri
 import com.egm.stellio.search.common.util.toZonedDateTime
 import com.egm.stellio.search.csr.model.CSRFilters
 import com.egm.stellio.search.csr.model.ContextSourceRegistration
-import com.egm.stellio.search.csr.model.ContextSourceRegistration.RegistrationInfo
 import com.egm.stellio.search.csr.model.ContextSourceRegistration.TimeInterval
 import com.egm.stellio.search.csr.model.Mode
 import com.egm.stellio.search.csr.model.Operation
+import com.egm.stellio.search.csr.model.RegistrationInfo
 import com.egm.stellio.shared.model.APIException
 import com.egm.stellio.shared.model.AlreadyExistsException
 import com.egm.stellio.shared.model.ResourceNotFoundException

--- a/search-service/src/main/kotlin/com/egm/stellio/search/csr/service/DistributedEntityConsumptionService.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/csr/service/DistributedEntityConsumptionService.kt
@@ -8,7 +8,7 @@ import arrow.core.right
 import arrow.core.separateEither
 import arrow.fx.coroutines.parMap
 import com.egm.stellio.search.csr.model.CSRFilters
-import com.egm.stellio.search.csr.model.ContextSourceRegistration.EntityInfo.Companion.addFilterForEntityInfo
+import com.egm.stellio.search.csr.model.EntityInfo.Companion.addFilterForEntityInfo
 import com.egm.stellio.search.csr.model.MiscellaneousPersistentWarning
 import com.egm.stellio.search.csr.model.MiscellaneousWarning
 import com.egm.stellio.search.csr.model.NGSILDWarning

--- a/search-service/src/test/kotlin/com/egm/stellio/search/csr/CsrUtils.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/csr/CsrUtils.kt
@@ -1,8 +1,10 @@
 package com.egm.stellio.search.csr
 
 import com.egm.stellio.search.csr.model.ContextSourceRegistration
+import com.egm.stellio.search.csr.model.EntityInfo
 import com.egm.stellio.search.csr.model.Mode
 import com.egm.stellio.search.csr.model.Operation
+import com.egm.stellio.search.csr.model.RegistrationInfo
 import com.egm.stellio.shared.util.APIARY_TYPE
 import com.egm.stellio.shared.util.ngsiLdDateTime
 import com.egm.stellio.shared.util.toUri
@@ -12,9 +14,9 @@ object CsrUtils {
     fun gimmeRawCSR(
         id: URI = "urn:ngsi-ld:ContextSourceRegistration:test".toUri(),
         endpoint: URI = "http://localhost:8089".toUri(),
-        information: List<ContextSourceRegistration.RegistrationInfo> = listOf(
-            ContextSourceRegistration.RegistrationInfo(
-                listOf(ContextSourceRegistration.EntityInfo(types = listOf(APIARY_TYPE)))
+        information: List<RegistrationInfo> = listOf(
+            RegistrationInfo(
+                listOf(EntityInfo(types = listOf(APIARY_TYPE)))
             )
         ),
         operations: List<Operation> = listOf(Operation.FEDERATION_OPS),

--- a/search-service/src/test/kotlin/com/egm/stellio/search/csr/model/ContextSourceRegistrationTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/csr/model/ContextSourceRegistrationTests.kt
@@ -1,16 +1,12 @@
 package com.egm.stellio.search.csr.model
 
 import com.egm.stellio.search.csr.CsrUtils.gimmeRawCSR
-import com.egm.stellio.search.csr.model.ContextSourceRegistration.RegistrationInfo
 import com.egm.stellio.shared.model.BadRequestDataException
 import com.egm.stellio.shared.util.APIC_COMPOUND_CONTEXT
-import com.egm.stellio.shared.util.APIC_COMPOUND_CONTEXTS
 import com.egm.stellio.shared.util.BEEHIVE_TYPE
 import com.egm.stellio.shared.util.JsonLdUtils.NGSILD_CSR_TERM
-import com.egm.stellio.shared.util.MANAGED_BY_COMPACT_RELATIONSHIP
 import com.egm.stellio.shared.util.MANAGED_BY_RELATIONSHIP
 import com.egm.stellio.shared.util.NGSILD_NAME_PROPERTY
-import com.egm.stellio.shared.util.NGSILD_NAME_TERM
 import com.egm.stellio.shared.util.expandJsonLdEntity
 import com.egm.stellio.shared.util.shouldFailWith
 import com.egm.stellio.shared.util.shouldSucceed
@@ -18,8 +14,6 @@ import com.egm.stellio.shared.util.shouldSucceedAndResult
 import com.egm.stellio.shared.util.toUri
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import java.net.URI
 
@@ -148,7 +142,7 @@ class ContextSourceRegistrationTests {
             ids = setOf(entity.id),
             types = entity.types.toSet()
         )
-        val entityInfo = ContextSourceRegistration.EntityInfo(entity.id, types = entity.types)
+        val entityInfo = EntityInfo(entity.id, types = entity.types)
         val information = RegistrationInfo(
             entities = listOf(entityInfo),
             propertyNames = listOf(NGSILD_NAME_PROPERTY),
@@ -172,7 +166,7 @@ class ContextSourceRegistrationTests {
             ids = setOf(entity.id),
             types = entity.types.toSet()
         )
-        val nonMatchingEntityInfo = ContextSourceRegistration.EntityInfo(types = listOf(BEEHIVE_TYPE))
+        val nonMatchingEntityInfo = EntityInfo(types = listOf(BEEHIVE_TYPE))
         val nonMatchingInformation = RegistrationInfo(
             entities = listOf(nonMatchingEntityInfo),
             propertyNames = listOf(NGSILD_NAME_PROPERTY),
@@ -189,94 +183,18 @@ class ContextSourceRegistrationTests {
     }
 
     @Test
-    fun `getAttributeNames should merge propertyNames and relationshipNames`() = runTest {
-        val information = RegistrationInfo(
-            propertyNames = listOf(NGSILD_NAME_PROPERTY),
-            relationshipNames = listOf(MANAGED_BY_RELATIONSHIP)
-        )
-
-        val attrs = information.getAttributeNames()
-        assertThat(attrs).hasSize(2)
-        assertThat(attrs).contains(NGSILD_NAME_PROPERTY, MANAGED_BY_RELATIONSHIP)
-    }
-
-    @Test
-    fun `getAttributeNames should keep relationshipNames if propertyNames is null`() = runTest {
-        val information = RegistrationInfo(
-            propertyNames = null,
-            relationshipNames = listOf(MANAGED_BY_RELATIONSHIP)
-        )
-
-        val attrs = information.getAttributeNames()
-        assertEquals(setOf(MANAGED_BY_RELATIONSHIP), attrs)
-    }
-
-    @Test
-    fun `getAttributeNames should keep propertyNames if relationshipNames is null`() = runTest {
-        val information = RegistrationInfo(
-            propertyNames = listOf(NGSILD_NAME_PROPERTY),
-            relationshipNames = null
-        )
-
-        val attrs = information.getAttributeNames()
-        assertEquals(setOf(NGSILD_NAME_PROPERTY), attrs)
-    }
-
-    @Test
-    fun `getAttributeNames should return null if propertyNames and relationshipNames are null`() = runTest {
-        val information = RegistrationInfo(
-            propertyNames = null,
-            relationshipNames = null
-        )
-
-        val attrs = information.getAttributeNames()
-        assertNull(attrs)
-    }
-
-    @Test
-    fun `computeAttrsQueryParam should intersect the csf and the registration attributes`() = runTest {
-        val registrationInfo = RegistrationInfo(
-            propertyNames = listOf(MANAGED_BY_RELATIONSHIP, NGSILD_NAME_PROPERTY)
-        )
-        val csrFilters = CSRFilters(attrs = setOf(NGSILD_NAME_PROPERTY))
-
-        val attrs = registrationInfo.computeAttrsQueryParam(csrFilters, APIC_COMPOUND_CONTEXTS)
-        assertEquals(NGSILD_NAME_TERM, attrs)
-    }
-
-    @Test
-    fun `computeAttrsQueryParam should return the registration attributes if the csf is empty`() = runTest {
-        val registrationInfo = RegistrationInfo(
-            propertyNames = listOf(MANAGED_BY_RELATIONSHIP, NGSILD_NAME_PROPERTY)
-        )
-        val csrFilters = CSRFilters()
-
-        val attrs = registrationInfo.computeAttrsQueryParam(csrFilters, APIC_COMPOUND_CONTEXTS)
-        assertEquals("$MANAGED_BY_COMPACT_RELATIONSHIP,$NGSILD_NAME_TERM", attrs)
-    }
-
-    @Test
-    fun `computeAttrsQueryParam should return the csf attributes if the registration have no attributes`() = runTest {
-        val registrationInfo = RegistrationInfo()
-        val csrFilters = CSRFilters(attrs = setOf(NGSILD_NAME_PROPERTY))
-
-        val attrs = registrationInfo.computeAttrsQueryParam(csrFilters, APIC_COMPOUND_CONTEXTS)
-        assertEquals(NGSILD_NAME_TERM, attrs)
-    }
-
-    @Test
     fun `toSingleEntityInfoCSRList should return a list of csr with one entityInfo each`() = runTest {
         val registrationInformations = listOf(
             RegistrationInfo(
                 entities = listOf(
-                    ContextSourceRegistration.EntityInfo(id = "urn:1".toUri(), types = listOf(BEEHIVE_TYPE)),
-                    ContextSourceRegistration.EntityInfo(id = "urn:2".toUri(), types = listOf(BEEHIVE_TYPE))
+                    EntityInfo(id = "urn:1".toUri(), types = listOf(BEEHIVE_TYPE)),
+                    EntityInfo(id = "urn:2".toUri(), types = listOf(BEEHIVE_TYPE))
                 )
             ),
             RegistrationInfo(
                 entities = listOf(
-                    ContextSourceRegistration.EntityInfo(id = "urn:3".toUri(), types = listOf(BEEHIVE_TYPE)),
-                    ContextSourceRegistration.EntityInfo(id = "urn:4".toUri(), types = listOf(BEEHIVE_TYPE))
+                    EntityInfo(id = "urn:3".toUri(), types = listOf(BEEHIVE_TYPE)),
+                    EntityInfo(id = "urn:4".toUri(), types = listOf(BEEHIVE_TYPE))
                 )
             )
         )
@@ -293,14 +211,14 @@ class ContextSourceRegistrationTests {
         val registrationInformations = listOf(
             RegistrationInfo(
                 entities = listOf(
-                    ContextSourceRegistration.EntityInfo(id = "urn:1".toUri(), types = listOf(BEEHIVE_TYPE)),
-                    ContextSourceRegistration.EntityInfo(id = "urn:2".toUri(), types = listOf(BEEHIVE_TYPE))
+                    EntityInfo(id = "urn:1".toUri(), types = listOf(BEEHIVE_TYPE)),
+                    EntityInfo(id = "urn:2".toUri(), types = listOf(BEEHIVE_TYPE))
                 )
             ),
             RegistrationInfo(
                 entities = listOf(
-                    ContextSourceRegistration.EntityInfo(id = "urn:3".toUri(), types = listOf(BEEHIVE_TYPE)),
-                    ContextSourceRegistration.EntityInfo(id = "urn:4".toUri(), types = listOf(BEEHIVE_TYPE))
+                    EntityInfo(id = "urn:3".toUri(), types = listOf(BEEHIVE_TYPE)),
+                    EntityInfo(id = "urn:4".toUri(), types = listOf(BEEHIVE_TYPE))
                 )
             )
         )

--- a/search-service/src/test/kotlin/com/egm/stellio/search/csr/model/RegistrationInfoTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/csr/model/RegistrationInfoTests.kt
@@ -1,0 +1,90 @@
+package com.egm.stellio.search.csr.model
+
+import com.egm.stellio.shared.util.APIC_COMPOUND_CONTEXTS
+import com.egm.stellio.shared.util.MANAGED_BY_COMPACT_RELATIONSHIP
+import com.egm.stellio.shared.util.MANAGED_BY_RELATIONSHIP
+import com.egm.stellio.shared.util.NGSILD_NAME_PROPERTY
+import com.egm.stellio.shared.util.NGSILD_NAME_TERM
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class RegistrationInfoTests {
+
+    @Test
+    fun `getAttributesName should merge propertyNames and relationshipNames`() = runTest {
+        val information = RegistrationInfo(
+            propertyNames = listOf(NGSILD_NAME_PROPERTY, MANAGED_BY_RELATIONSHIP),
+            relationshipNames = listOf(MANAGED_BY_RELATIONSHIP)
+        )
+
+        val attrs = information.getAttributeNames()
+        assertThat(attrs).hasSize(2)
+        assertThat(attrs).contains(NGSILD_NAME_PROPERTY, MANAGED_BY_RELATIONSHIP)
+    }
+
+    @Test
+    fun `getAttributesName should keep propertyNames if relationShipNames is null`() = runTest {
+        val information = RegistrationInfo(
+            propertyNames = null,
+            relationshipNames = listOf(MANAGED_BY_RELATIONSHIP)
+        )
+
+        val attrs = information.getAttributeNames()
+        assertEquals(attrs, setOf(MANAGED_BY_RELATIONSHIP))
+    }
+
+    @Test
+    fun `getAttributesName should keep relationShipNames if propertyNames is null`() = runTest {
+        val information = RegistrationInfo(
+            propertyNames = listOf(MANAGED_BY_RELATIONSHIP),
+            relationshipNames = null
+        )
+
+        val attrs = information.getAttributeNames()
+        assertEquals(attrs, setOf(MANAGED_BY_RELATIONSHIP))
+    }
+
+    @Test
+    fun `getAttributesName should return null if propertyNames and relationshipNames are null`() = runTest {
+        val information = RegistrationInfo(
+            propertyNames = null,
+            relationshipNames = null
+        )
+
+        val attrs = information.getAttributeNames()
+        assertEquals(attrs, null)
+    }
+
+    @Test
+    fun `computeAttrsQueryParam should intersect the csf and the registration attributes`() = runTest {
+        val registrationInfo = RegistrationInfo(
+            propertyNames = listOf(MANAGED_BY_RELATIONSHIP, NGSILD_NAME_PROPERTY)
+        )
+        val csrFilters = CSRFilters(attrs = setOf(NGSILD_NAME_PROPERTY))
+
+        val attrs = registrationInfo.computeAttrsQueryParam(csrFilters, APIC_COMPOUND_CONTEXTS)
+        assertEquals(NGSILD_NAME_TERM, attrs)
+    }
+
+    @Test
+    fun `computeAttrsQueryParam should return the registration attributes if the csf is empty`() = runTest {
+        val registrationInfo = RegistrationInfo(
+            propertyNames = listOf(MANAGED_BY_RELATIONSHIP, NGSILD_NAME_PROPERTY)
+        )
+        val csrFilters = CSRFilters()
+
+        val attrs = registrationInfo.computeAttrsQueryParam(csrFilters, APIC_COMPOUND_CONTEXTS)
+        assertEquals("$MANAGED_BY_COMPACT_RELATIONSHIP,$NGSILD_NAME_TERM", attrs)
+    }
+
+    @Test
+    fun `computeAttrsQueryParam should return the csf attributes if the registration have no attributes`() = runTest {
+        val registrationInfo = RegistrationInfo()
+        val csrFilters = CSRFilters(attrs = setOf(NGSILD_NAME_PROPERTY))
+
+        val attrs = registrationInfo.computeAttrsQueryParam(csrFilters, APIC_COMPOUND_CONTEXTS)
+        assertEquals(NGSILD_NAME_TERM, attrs)
+    }
+}

--- a/search-service/src/test/kotlin/com/egm/stellio/search/csr/service/ContextSourceRegistrationServiceTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/csr/service/ContextSourceRegistrationServiceTests.kt
@@ -4,8 +4,8 @@ import arrow.core.Some
 import com.egm.stellio.search.csr.model.CSRFilters
 import com.egm.stellio.search.csr.model.ContextSourceRegistration
 import com.egm.stellio.search.csr.model.ContextSourceRegistration.Companion.notFoundMessage
-import com.egm.stellio.search.csr.model.ContextSourceRegistration.RegistrationInfo
 import com.egm.stellio.search.csr.model.Operation
+import com.egm.stellio.search.csr.model.RegistrationInfo
 import com.egm.stellio.search.support.WithKafkaContainer
 import com.egm.stellio.search.support.WithTimescaleContainer
 import com.egm.stellio.shared.model.AlreadyExistsException

--- a/search-service/src/test/kotlin/com/egm/stellio/search/csr/service/DistributedEntityConsumptionServiceTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/csr/service/DistributedEntityConsumptionServiceTests.kt
@@ -4,9 +4,10 @@ import arrow.core.left
 import arrow.core.right
 import com.egm.stellio.search.csr.CsrUtils.gimmeRawCSR
 import com.egm.stellio.search.csr.model.CSRFilters
-import com.egm.stellio.search.csr.model.ContextSourceRegistration
+import com.egm.stellio.search.csr.model.EntityInfo
 import com.egm.stellio.search.csr.model.MiscellaneousPersistentWarning
 import com.egm.stellio.search.csr.model.MiscellaneousWarning
+import com.egm.stellio.search.csr.model.RegistrationInfo
 import com.egm.stellio.search.csr.model.RevalidationFailedWarning
 import com.egm.stellio.search.entity.model.EntitiesQueryFromGet
 import com.egm.stellio.search.entity.util.composeEntitiesQueryFromGet
@@ -198,27 +199,27 @@ class DistributedEntityConsumptionServiceTests : WithTimescaleContainer, WithKaf
             val id = "test:1".toUri()
             val firstCSR = gimmeRawCSR(
                 information = listOf(
-                    ContextSourceRegistration.RegistrationInfo(
+                    RegistrationInfo(
                         listOf(
-                            ContextSourceRegistration.EntityInfo(types = listOf(APIARY_TYPE)),
-                            ContextSourceRegistration.EntityInfo(id = id, types = listOf(APIARY_TYPE)),
+                            EntityInfo(types = listOf(APIARY_TYPE)),
+                            EntityInfo(id = id, types = listOf(APIARY_TYPE)),
                         )
                     )
                 )
             )
             val secondCSR = gimmeRawCSR(
                 information = listOf(
-                    ContextSourceRegistration.RegistrationInfo(
-                        listOf(ContextSourceRegistration.EntityInfo(idPattern = idPattern, types = listOf(APIARY_TYPE)))
+                    RegistrationInfo(
+                        listOf(EntityInfo(idPattern = idPattern, types = listOf(APIARY_TYPE)))
                     ),
-                    ContextSourceRegistration.RegistrationInfo(
-                        listOf(ContextSourceRegistration.EntityInfo(id = id, types = listOf(APIARY_TYPE)))
+                    RegistrationInfo(
+                        listOf(EntityInfo(id = id, types = listOf(APIARY_TYPE)))
                     )
                 )
             )
             val thirdCSR = gimmeRawCSR(
                 information = listOf(
-                    ContextSourceRegistration.RegistrationInfo(propertyNames = listOf(TEMPERATURE_PROPERTY)),
+                    RegistrationInfo(propertyNames = listOf(TEMPERATURE_PROPERTY)),
                 )
             )
 
@@ -435,7 +436,7 @@ class DistributedEntityConsumptionServiceTests : WithTimescaleContainer, WithKaf
     fun `getDistributedInformation should filter the attributes based on the csr and the received request`() = runTest {
         val csr = gimmeRawCSR().copy(
             information = listOf(
-                ContextSourceRegistration.RegistrationInfo(null, listOf("a", "b", "c"), null)
+                RegistrationInfo(null, listOf("a", "b", "c"), null)
             )
         ).expand(contexts = APIC_COMPOUND_CONTEXTS)
         val path = "/ngsi-ld/v1/entities/$apiaryId"


### PR DESCRIPTION
The contextSourceRegistration Class was too complex i removed the RegistrationInfo and EntityInfo from it.