### PR TITLE
refactor: use DataTypes for subscriptions

### DIFF
--- a/search-service/src/main/kotlin/com/egm/stellio/search/csr/model/ContextSourceRegistration.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/csr/model/ContextSourceRegistration.kt
@@ -9,7 +9,9 @@ import com.egm.stellio.shared.model.BadRequestDataException
 import com.egm.stellio.shared.model.ExpandedEntity
 import com.egm.stellio.shared.model.ExpandedTerm
 import com.egm.stellio.shared.model.toAPIException
-import com.egm.stellio.shared.util.DataTypes
+import com.egm.stellio.shared.util.DataTypes.convertTo
+import com.egm.stellio.shared.util.DataTypes.serialize
+import com.egm.stellio.shared.util.DataTypes.toFinalRepresentation
 import com.egm.stellio.shared.util.JSON_LD_MEDIA_TYPE
 import com.egm.stellio.shared.util.JsonLdUtils.JSONLD_CONTEXT
 import com.egm.stellio.shared.util.JsonLdUtils.NGSILD_CSR_TERM
@@ -21,7 +23,6 @@ import com.egm.stellio.shared.util.toUri
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.fasterxml.jackson.module.kotlin.convertValue
 import org.springframework.http.MediaType
 import java.net.URI
 import java.time.ZonedDateTime
@@ -75,12 +76,12 @@ data class ContextSourceRegistration(
         mediaType: MediaType = JSON_LD_MEDIA_TYPE,
         includeSysAttrs: Boolean = false
     ): String {
-        return DataTypes.mapper.writeValueAsString(
-            DataTypes.mapper.convertValue<Map<String, Any>>(
+        return serialize(
+            convertTo<Map<String, Any>>(
                 this.compact(contexts)
             ).plus(
                 JSONLD_CONTEXT to contexts
-            ).let { DataTypes.toFinalRepresentation(it, mediaType, includeSysAttrs) }
+            ).let { toFinalRepresentation(it, mediaType, includeSysAttrs) }
         )
     }
 

--- a/shared/src/main/kotlin/com/egm/stellio/shared/util/DataTypes.kt
+++ b/shared/src/main/kotlin/com/egm/stellio/shared/util/DataTypes.kt
@@ -21,18 +21,36 @@ object DataTypes {
     inline fun <reified T> deserializeAs(content: String): T =
         mapper.readValue(content, T::class.java)
 
+    fun serialize(input: Any?): String =
+        mapper.writeValueAsString(input)
+
+    inline fun <reified T> convertTo(input: Any): T =
+        mapper.convertValue(input, T::class.java)
+
+    inline fun <reified T> convertToList(input: String): List<T> =
+        mapper.readValue(
+            input,
+            mapper.typeFactory.constructCollectionType(List::class.java, T::class.java)
+        )
+
     fun toFinalRepresentation(
         dataType: Map<String, Any>,
         mediaType: MediaType = JSON_LD_MEDIA_TYPE,
         includeSysAttrs: Boolean = false
     ): Map<String, Any> =
-        this.let {
+        dataType.let {
             if (mediaType == MediaType.APPLICATION_JSON)
-                dataType.minus(JSONLD_CONTEXT)
-            else dataType
+                it.minus(JSONLD_CONTEXT)
+            else it
         }.let {
             if (!includeSysAttrs)
-                dataType.minus(NGSILD_SYSATTRS_TERMS)
-            else dataType
+                it.minus(NGSILD_SYSATTRS_TERMS)
+            else it
         }
 }
+
+fun Map<String, Any>.toFinalRepresentation(
+    mediaType: MediaType = JSON_LD_MEDIA_TYPE,
+    includeSysAttrs: Boolean = false
+): Map<String, Any> =
+    DataTypes.toFinalRepresentation(this, mediaType, includeSysAttrs)

--- a/subscription-service/src/main/kotlin/com/egm/stellio/subscription/model/Subscription.kt
+++ b/subscription-service/src/main/kotlin/com/egm/stellio/subscription/model/Subscription.kt
@@ -2,19 +2,19 @@ package com.egm.stellio.subscription.model
 
 import com.egm.stellio.shared.model.EntitySelector
 import com.egm.stellio.shared.model.ExpandedTerm
+import com.egm.stellio.shared.util.DataTypes.convertTo
+import com.egm.stellio.shared.util.DataTypes.serialize
 import com.egm.stellio.shared.util.JSON_LD_MEDIA_TYPE
 import com.egm.stellio.shared.util.JsonLdUtils.JSONLD_CONTEXT
-import com.egm.stellio.shared.util.JsonLdUtils.NGSILD_SYSATTRS_TERMS
 import com.egm.stellio.shared.util.JsonLdUtils.compactTerm
 import com.egm.stellio.shared.util.JsonLdUtils.expandJsonLdTerm
 import com.egm.stellio.shared.util.compactTypeSelection
 import com.egm.stellio.shared.util.expandTypeSelection
 import com.egm.stellio.shared.util.ngsiLdDateTime
+import com.egm.stellio.shared.util.toFinalRepresentation
 import com.egm.stellio.shared.util.toUri
 import com.egm.stellio.subscription.model.NotificationTrigger.ATTRIBUTE_CREATED
 import com.egm.stellio.subscription.model.NotificationTrigger.ATTRIBUTE_UPDATED
-import com.egm.stellio.subscription.utils.ParsingUtils.convertToMap
-import com.egm.stellio.subscription.utils.ParsingUtils.serializeSubscription
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 import org.springframework.data.annotation.Id
@@ -103,21 +103,21 @@ data class Subscription(
             watchedAttributes = this.watchedAttributes?.map { compactTerm(it, contexts) }
         )
 
-    fun serialize(
+    fun prepareForRendering(
         contexts: List<String>,
         mediaType: MediaType = JSON_LD_MEDIA_TYPE,
         includeSysAttrs: Boolean = false
     ): String =
-        convertToMap(this.compact(contexts))
+        convertTo<Map<String, Any>>(this.compact(contexts))
             .toFinalRepresentation(mediaType, includeSysAttrs)
-            .let { serializeSubscription(it) }
+            .let { serialize(it) }
 
-    fun serialize(
+    fun prepareForRendering(
         context: String,
         mediaType: MediaType = JSON_LD_MEDIA_TYPE,
         includeSysAttrs: Boolean = false
     ): String =
-        serialize(listOf(context), mediaType, includeSysAttrs)
+        prepareForRendering(listOf(context), mediaType, includeSysAttrs)
 }
 
 // Default for booleans is false, so add a simple filter to only include "isActive" is it is false
@@ -167,30 +167,16 @@ enum class NotificationTrigger(val notificationTrigger: String) {
     }
 }
 
-fun Map<String, Any>.toFinalRepresentation(
-    mediaType: MediaType = JSON_LD_MEDIA_TYPE,
-    includeSysAttrs: Boolean = false
-): Map<String, Any> =
-    this.let {
-        if (mediaType == MediaType.APPLICATION_JSON)
-            it.minus(JSONLD_CONTEXT)
-        else it
-    }.let {
-        if (!includeSysAttrs)
-            it.minus(NGSILD_SYSATTRS_TERMS)
-        else it
-    }
-
-fun List<Subscription>.serialize(
+fun List<Subscription>.prepareForRendering(
     contexts: List<String>,
     mediaType: MediaType = JSON_LD_MEDIA_TYPE,
     includeSysAttrs: Boolean = false
 ): String =
     this.map {
-        convertToMap(it.compact(contexts))
+        convertTo<Map<String, Any>>(it.compact(contexts))
             .toFinalRepresentation(mediaType, includeSysAttrs)
     }.let {
-        serializeSubscription(it)
+        serialize(it)
     }
 
 fun List<Subscription>.mergeEntitySelectorsOnSubscriptions() =

--- a/subscription-service/src/main/kotlin/com/egm/stellio/subscription/service/SubscriptionService.kt
+++ b/subscription-service/src/main/kotlin/com/egm/stellio/subscription/service/SubscriptionService.kt
@@ -14,6 +14,7 @@ import com.egm.stellio.shared.model.NotImplementedException
 import com.egm.stellio.shared.model.WKTCoordinates
 import com.egm.stellio.shared.queryparameter.GeoQuery
 import com.egm.stellio.shared.queryparameter.GeoQuery.Companion.parseGeoQueryParameters
+import com.egm.stellio.shared.util.DataTypes.serialize
 import com.egm.stellio.shared.util.JsonLdUtils
 import com.egm.stellio.shared.util.JsonLdUtils.JSONLD_TYPE_TERM
 import com.egm.stellio.shared.util.JsonLdUtils.NGSILD_LOCATION_PROPERTY
@@ -38,12 +39,8 @@ import com.egm.stellio.subscription.model.NotificationParams.JoinType
 import com.egm.stellio.subscription.model.NotificationTrigger
 import com.egm.stellio.subscription.model.Subscription
 import com.egm.stellio.subscription.model.mergeEntitySelectorsOnSubscriptions
-import com.egm.stellio.subscription.utils.ParsingUtils.endpointInfoMapToString
-import com.egm.stellio.subscription.utils.ParsingUtils.endpointInfoToString
 import com.egm.stellio.subscription.utils.ParsingUtils.parseEndpointInfo
 import com.egm.stellio.subscription.utils.ParsingUtils.parseEntitySelector
-import com.egm.stellio.subscription.utils.ParsingUtils.toSqlColumnName
-import com.egm.stellio.subscription.utils.ParsingUtils.toSqlValue
 import com.egm.stellio.subscription.utils.allToMappedList
 import com.egm.stellio.subscription.utils.execute
 import com.egm.stellio.subscription.utils.oneToResult
@@ -57,6 +54,8 @@ import com.egm.stellio.subscription.utils.toNullableList
 import com.egm.stellio.subscription.utils.toNullableUri
 import com.egm.stellio.subscription.utils.toNullableZonedDateTime
 import com.egm.stellio.subscription.utils.toOptionalEnum
+import com.egm.stellio.subscription.utils.toSqlColumnName
+import com.egm.stellio.subscription.utils.toSqlValue
 import com.egm.stellio.subscription.utils.toUri
 import com.egm.stellio.subscription.utils.toZonedDateTime
 import com.egm.stellio.subscription.web.invalidSubscriptionAttributeMessage
@@ -235,8 +234,8 @@ class SubscriptionService(
             .bind("notif_format", subscription.notification.format.name)
             .bind("endpoint_uri", endpoint.uri)
             .bind("endpoint_accept", endpoint.accept.name)
-            .bind("endpoint_receiver_info", Json.of(endpointInfoToString(endpoint.receiverInfo)))
-            .bind("endpoint_notifier_info", Json.of(endpointInfoToString(endpoint.notifierInfo)))
+            .bind("endpoint_receiver_info", Json.of(serialize(endpoint.receiverInfo)))
+            .bind("endpoint_notifier_info", Json.of(serialize(endpoint.notifierInfo)))
             .bind("times_sent", subscription.notification.timesSent)
             .bind("is_active", subscription.isActive)
             .bind("expires_at", subscription.expiresAt)
@@ -514,8 +513,8 @@ class SubscriptionService(
                 listOf(
                     Pair("endpoint_uri", endpoint["uri"]),
                     Pair("endpoint_accept", accept),
-                    Pair("endpoint_receiver_info", Json.of(endpointInfoMapToString(endpointReceiverInfo))),
-                    Pair("endpoint_notifier_info", Json.of(endpointInfoMapToString(endpointNotifierInfo)))
+                    Pair("endpoint_receiver_info", Json.of(serialize(endpointReceiverInfo))),
+                    Pair("endpoint_notifier_info", Json.of(serialize(endpointNotifierInfo)))
                 )
             }
 

--- a/subscription-service/src/main/kotlin/com/egm/stellio/subscription/utils/DBConversionUtils.kt
+++ b/subscription-service/src/main/kotlin/com/egm/stellio/subscription/utils/DBConversionUtils.kt
@@ -22,3 +22,22 @@ inline fun <reified T : Enum<T>> toOptionalEnum(entry: Any?) =
     (entry as? String)?.let { enumValueOf<T>(it) }
 fun toInt(entry: Any?): Int = (entry as Long).toInt()
 fun toNullableInt(entry: Any?): Int? = entry as? Int
+
+fun String.toSqlColumnName(): String =
+    this.map {
+        if (it.isUpperCase()) "_${it.lowercase()}"
+        else it
+    }.joinToString("")
+
+fun Any.toSqlValue(columnName: String): Any? =
+    when (columnName) {
+        "watchedAttributes", "contexts" -> {
+            val valueAsArrayList = this as ArrayList<String>
+            if (valueAsArrayList.isEmpty())
+                null
+            else
+                valueAsArrayList.joinToString(separator = ",")
+        }
+        "notificationTrigger" -> (this as ArrayList<String>).toTypedArray()
+        else -> this
+    }

--- a/subscription-service/src/main/kotlin/com/egm/stellio/subscription/utils/ParsingUtils.kt
+++ b/subscription-service/src/main/kotlin/com/egm/stellio/subscription/utils/ParsingUtils.kt
@@ -6,27 +6,15 @@ import arrow.core.right
 import com.egm.stellio.shared.model.APIException
 import com.egm.stellio.shared.model.EntitySelector
 import com.egm.stellio.shared.model.toAPIException
+import com.egm.stellio.shared.util.DataTypes
+import com.egm.stellio.shared.util.DataTypes.deserializeAs
 import com.egm.stellio.shared.util.JsonLdUtils.JSONLD_CONTEXT
-import com.egm.stellio.shared.util.JsonUtils.deserializeAs
 import com.egm.stellio.shared.util.JsonUtils.serializeObject
 import com.egm.stellio.shared.util.expandTypeSelection
 import com.egm.stellio.subscription.model.EndpointInfo
 import com.egm.stellio.subscription.model.Subscription
-import com.fasterxml.jackson.annotation.JsonInclude
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.SerializationFeature
-import com.fasterxml.jackson.module.kotlin.convertValue
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 
 object ParsingUtils {
-
-    private val mapper: ObjectMapper =
-        jacksonObjectMapper()
-            .setSerializationInclusion(JsonInclude.Include.NON_NULL)
-            .findAndRegisterModules()
-            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
 
     fun parseSubscription(input: Map<String, Any>, contexts: List<String>): Either<APIException, Subscription> =
         runCatching {
@@ -37,51 +25,16 @@ object ParsingUtils {
             { it.toAPIException("Failed to parse subscription: ${it.message}").left() }
         )
 
-    fun convertToMap(input: Any): Map<String, Any> =
-        mapper.convertValue(input)
-
-    fun serializeSubscription(input: Any): String =
-        mapper.writeValueAsString(input)
-
     fun parseEntitySelector(input: Map<String, Any>, contexts: List<String>): EntitySelector {
-        val entitySelector = mapper.convertValue(input, EntitySelector::class.java)
+        val entitySelector = DataTypes.convertTo<EntitySelector>(input)
         return entitySelector.copy(
             typeSelection = expandTypeSelection(entitySelector.typeSelection, contexts)!!
         )
     }
 
     fun parseEndpointInfo(input: String?): List<EndpointInfo>? {
-        input?.let {
-            return mapper.readValue(
-                input,
-                mapper.typeFactory.constructCollectionType(List::class.java, EndpointInfo::class.java)
-            )
-        }
-        return null
+        return if (input != null && input != "null")
+            DataTypes.convertToList(input)
+        else null
     }
-
-    fun endpointInfoToString(input: List<EndpointInfo>?): String =
-        mapper.writeValueAsString(input)
-
-    fun endpointInfoMapToString(input: List<Map<String, String>>?): String =
-        mapper.writeValueAsString(input)
-
-    fun String.toSqlColumnName(): String =
-        this.map {
-            if (it.isUpperCase()) "_${it.lowercase()}"
-            else it
-        }.joinToString("")
-
-    fun Any.toSqlValue(columnName: String): Any? =
-        when (columnName) {
-            "watchedAttributes", "contexts" -> {
-                val valueAsArrayList = this as ArrayList<String>
-                if (valueAsArrayList.isEmpty())
-                    null
-                else
-                    valueAsArrayList.joinToString(separator = ",")
-            }
-            "notificationTrigger" -> (this as ArrayList<String>).toTypedArray()
-            else -> this
-        }
 }

--- a/subscription-service/src/main/kotlin/com/egm/stellio/subscription/web/SubscriptionHandler.kt
+++ b/subscription-service/src/main/kotlin/com/egm/stellio/subscription/web/SubscriptionHandler.kt
@@ -30,7 +30,7 @@ import com.egm.stellio.shared.util.getSubFromSecurityContext
 import com.egm.stellio.shared.util.prepareGetSuccessResponseHeaders
 import com.egm.stellio.shared.web.BaseHandler
 import com.egm.stellio.subscription.model.Subscription
-import com.egm.stellio.subscription.model.serialize
+import com.egm.stellio.subscription.model.prepareForRendering
 import com.egm.stellio.subscription.service.SubscriptionService
 import com.egm.stellio.subscription.utils.ParsingUtils.parseSubscription
 import kotlinx.coroutines.reactive.awaitFirst
@@ -112,7 +112,7 @@ class SubscriptionHandler(
             applicationProperties.pagination.limitMax
         ).bind()
         val subscriptions = subscriptionService.getSubscriptions(paginationQuery.limit, paginationQuery.offset, sub)
-            .serialize(contexts, mediaType, includeSysAttrs)
+            .prepareForRendering(contexts, mediaType, includeSysAttrs)
         val subscriptionsCount = subscriptionService.getSubscriptionsCount(sub).bind()
 
         buildQueryResponse(
@@ -153,7 +153,7 @@ class SubscriptionHandler(
         val subscription = subscriptionService.getById(subscriptionId)
 
         prepareGetSuccessResponseHeaders(mediaType, contexts)
-            .body(subscription.serialize(contexts, mediaType, includeSysAttrs))
+            .body(subscription.prepareForRendering(contexts, mediaType, includeSysAttrs))
     }.fold(
         { it.toErrorResponse() },
         { it }

--- a/subscription-service/src/test/kotlin/com/egm/stellio/subscription/model/SubscriptionTest.kt
+++ b/subscription-service/src/test/kotlin/com/egm/stellio/subscription/model/SubscriptionTest.kt
@@ -117,10 +117,10 @@ class SubscriptionTest {
     }
 
     @Test
-    fun `it should serialize a subscription as JSON and add the status attribute`() {
+    fun `it should prepare a subscription as JSON and add the status attribute`() {
         val subscription = subscription.copy().expand(APIC_COMPOUND_CONTEXTS)
 
-        val serializedSub = subscription.serialize(NGSILD_TEST_CORE_CONTEXT, includeSysAttrs = false)
+        val serializedSub = subscription.prepareForRendering(NGSILD_TEST_CORE_CONTEXT, includeSysAttrs = false)
 
         val deserializedSub = deserializeObject(serializedSub)
 
@@ -129,10 +129,10 @@ class SubscriptionTest {
     }
 
     @Test
-    fun `it should serialize a subscription as JSON without createdAt and modifiedAt if not specified`() {
+    fun `it should prepare a subscription as JSON without createdAt and modifiedAt if not specified`() {
         val subscription = subscription.copy().expand(APIC_COMPOUND_CONTEXTS)
 
-        val serializedSub = subscription.serialize(NGSILD_TEST_CORE_CONTEXT, includeSysAttrs = false)
+        val serializedSub = subscription.prepareForRendering(NGSILD_TEST_CORE_CONTEXT, includeSysAttrs = false)
 
         val deserializedSub = deserializeObject(serializedSub)
 
@@ -141,10 +141,10 @@ class SubscriptionTest {
     }
 
     @Test
-    fun `it should serialize a subscription as JSON with createdAt and modifiedAt if specified`() {
+    fun `it should prepare a subscription as JSON with createdAt and modifiedAt if specified`() {
         val subscription = subscription.copy().expand(APIC_COMPOUND_CONTEXTS)
 
-        val serializedSub = subscription.serialize(NGSILD_TEST_CORE_CONTEXT, includeSysAttrs = true)
+        val serializedSub = subscription.prepareForRendering(NGSILD_TEST_CORE_CONTEXT, includeSysAttrs = true)
 
         val deserializedSub = deserializeObject(serializedSub)
 
@@ -152,10 +152,10 @@ class SubscriptionTest {
     }
 
     @Test
-    fun `it should serialize a subscription with a context if JSON-LD media type is asked`() {
+    fun `it should prepare a subscription with a context if JSON-LD media type is asked`() {
         val subscription = subscription.copy().expand(APIC_COMPOUND_CONTEXTS)
 
-        val serializedSub = subscription.serialize(NGSILD_TEST_CORE_CONTEXT, mediaType = JSON_LD_MEDIA_TYPE)
+        val serializedSub = subscription.prepareForRendering(NGSILD_TEST_CORE_CONTEXT, mediaType = JSON_LD_MEDIA_TYPE)
 
         val deserializedSub = deserializeObject(serializedSub)
 
@@ -163,10 +163,13 @@ class SubscriptionTest {
     }
 
     @Test
-    fun `it should serialize a subscription without context if JSON media type is asked`() {
+    fun `it should prepare a subscription without context if JSON media type is asked`() {
         val subscription = subscription.copy().expand(APIC_COMPOUND_CONTEXTS)
 
-        val serializedSub = subscription.serialize(NGSILD_TEST_CORE_CONTEXT, mediaType = MediaType.APPLICATION_JSON)
+        val serializedSub = subscription.prepareForRendering(
+            NGSILD_TEST_CORE_CONTEXT,
+            mediaType = MediaType.APPLICATION_JSON
+        )
 
         val deserializedSub = deserializeObject(serializedSub)
 
@@ -174,12 +177,15 @@ class SubscriptionTest {
     }
 
     @Test
-    fun `it should serialize a list of subscriptions as JSON-LD with sysAttrs`() {
+    fun `it should prepare a list of subscriptions as JSON-LD with sysAttrs`() {
         val subscription = subscription.copy()
         val otherSubscription = subscription.copy(id = "urn:ngsi-ld:Subscription:02".toUri())
 
         val serializedSubs =
-            listOf(subscription, otherSubscription).serialize(NGSILD_TEST_CORE_CONTEXTS, includeSysAttrs = true)
+            listOf(subscription, otherSubscription).prepareForRendering(
+                NGSILD_TEST_CORE_CONTEXTS,
+                includeSysAttrs = true
+            )
 
         val deserializedSubs = deserializeListOfObjects(serializedSubs)
 
@@ -192,12 +198,12 @@ class SubscriptionTest {
     }
 
     @Test
-    fun `it should serialize a list of subscriptions as JSON without sysAttrs`() {
+    fun `it should prepare a list of subscriptions as JSON without sysAttrs`() {
         val subscription = subscription.copy()
         val otherSubscription = subscription.copy(id = "urn:ngsi-ld:Subscription:02".toUri())
 
         val serializedSubs = listOf(subscription, otherSubscription)
-            .serialize(NGSILD_TEST_CORE_CONTEXTS, mediaType = MediaType.APPLICATION_JSON)
+            .prepareForRendering(NGSILD_TEST_CORE_CONTEXTS, mediaType = MediaType.APPLICATION_JSON)
 
         val deserializedSubs = deserializeListOfObjects(serializedSubs)
 


### PR DESCRIPTION
- fix a bug in DataTypes.toFinalRepresentation where first let was actually not applied
- more SQL related functions in ParsingUtils to DBConversionUtils
- remove direct uses of DataType.mapper (internal object)
- remove some useless functions to serialize / deserialize in ParsingUtils
