### PR TITLE
fix: incorrect structure of logback configuration files

### DIFF
--- a/api-gateway/src/main/resources/logback-spring.xml
+++ b/api-gateway/src/main/resources/logback-spring.xml
@@ -12,32 +12,38 @@
         </encoder>
     </appender>
 
-    <appender name="gelf" class="de.siegmar.logbackgelf.GelfTcpAppender">
-        <graylogHost>${graylogHost}</graylogHost>
-        <graylogPort>${graylogPort}</graylogPort>
-        <encoder class="de.siegmar.logbackgelf.GelfEncoder">
-            <includeLevelName>true</includeLevelName>
-            <staticField>app_name:api-gateway</staticField>
-            <staticField>platform:${graylogSource}</staticField>
-        </encoder>
-    </appender>
-
-    <!-- Use AsyncAppender to prevent slowdowns -->
-    <appender name="async_gelf" class="ch.qos.logback.classic.AsyncAppender">
-        <!-- do not block the queue if Graylog is unavailable -->
-        <neverBlock>true</neverBlock>
-        <appender-ref ref="gelf" />
-    </appender>
-
     <logger name="com.egm.stellio" level="DEBUG"/>
     <logger name="org.springframework.cloud.gateway" level="INFO" />
     <logger name="org.zalando.logbook" level="TRACE" />
 
-    <root level="INFO">
-        <appender-ref ref="console" />
-        <springProfile name="gelflogs">
+    <springProfile name="!gelflogs">
+        <root level="INFO">
+            <appender-ref ref="console" />
+        </root>
+    </springProfile>
+
+    <springProfile name="gelflogs">
+        <appender name="gelf" class="de.siegmar.logbackgelf.GelfTcpAppender">
+            <graylogHost>${graylogHost}</graylogHost>
+            <graylogPort>${graylogPort}</graylogPort>
+            <encoder class="de.siegmar.logbackgelf.GelfEncoder">
+                <includeLevelName>true</includeLevelName>
+                <staticField>app_name:api-gateway</staticField>
+                <staticField>platform:${graylogSource}</staticField>
+            </encoder>
+        </appender>
+
+        <!-- Use AsyncAppender to prevent slowdowns -->
+        <appender name="async_gelf" class="ch.qos.logback.classic.AsyncAppender">
+            <!-- do not block the queue if Graylog is unavailable -->
+            <neverBlock>true</neverBlock>
+            <appender-ref ref="gelf" />
+        </appender>
+
+        <root level="INFO">
+            <appender-ref ref="console" />
             <appender-ref ref="async_gelf" />
-        </springProfile>
-    </root>
+        </root>
+    </springProfile>
 
 </configuration>

--- a/search-service/src/main/resources/logback-spring.xml
+++ b/search-service/src/main/resources/logback-spring.xml
@@ -12,33 +12,39 @@
         </encoder>
     </appender>
 
-    <appender name="gelf" class="de.siegmar.logbackgelf.GelfTcpAppender">
-        <graylogHost>${graylogHost}</graylogHost>
-        <graylogPort>${graylogPort}</graylogPort>
-        <encoder class="de.siegmar.logbackgelf.GelfEncoder">
-            <includeLevelName>true</includeLevelName>
-            <staticField>app_name:search-service</staticField>
-            <staticField>platform:${graylogSource}</staticField>
-        </encoder>
-    </appender>
-
-    <!-- Use AsyncAppender to prevent slowdowns -->
-    <appender name="async_gelf" class="ch.qos.logback.classic.AsyncAppender">
-        <!-- do not block the queue if Graylog is unavailable -->
-        <neverBlock>true</neverBlock>
-        <appender-ref ref="gelf" />
-    </appender>
-
     <logger name="com.egm.stellio" level="DEBUG"/>
     <logger name="org.flywaydb" level="DEBUG"/>
     <logger name="org.apache.kafka" level="WARN"/>
     <logger name="db.migration" level="DEBUG" />
 
-    <root level="INFO">
-        <appender-ref ref="console" />
-        <springProfile name="gelflogs">
+    <springProfile name="!gelflogs">
+        <root level="INFO">
+            <appender-ref ref="console" />
+        </root>
+    </springProfile>
+
+    <springProfile name="gelflogs">
+        <appender name="gelf" class="de.siegmar.logbackgelf.GelfTcpAppender">
+            <graylogHost>${graylogHost}</graylogHost>
+            <graylogPort>${graylogPort}</graylogPort>
+            <encoder class="de.siegmar.logbackgelf.GelfEncoder">
+                <includeLevelName>true</includeLevelName>
+                <staticField>app_name:search-service</staticField>
+                <staticField>platform:${graylogSource}</staticField>
+            </encoder>
+        </appender>
+
+        <!-- Use AsyncAppender to prevent slowdowns -->
+        <appender name="async_gelf" class="ch.qos.logback.classic.AsyncAppender">
+            <!-- do not block the queue if Graylog is unavailable -->
+            <neverBlock>true</neverBlock>
+            <appender-ref ref="gelf" />
+        </appender>
+
+        <root level="INFO">
+            <appender-ref ref="console" />
             <appender-ref ref="async_gelf" />
-        </springProfile>
-    </root>
+        </root>
+    </springProfile>
 
 </configuration>

--- a/subscription-service/src/main/resources/logback-spring.xml
+++ b/subscription-service/src/main/resources/logback-spring.xml
@@ -12,32 +12,38 @@
         </encoder>
     </appender>
 
-    <appender name="gelf" class="de.siegmar.logbackgelf.GelfTcpAppender">
-        <graylogHost>${graylogHost}</graylogHost>
-        <graylogPort>${graylogPort}</graylogPort>
-        <encoder class="de.siegmar.logbackgelf.GelfEncoder">
-            <includeLevelName>true</includeLevelName>
-            <staticField>app_name:subscription-service</staticField>
-            <staticField>platform:${graylogSource}</staticField>
-        </encoder>
-    </appender>
-
-    <!-- Use AsyncAppender to prevent slowdowns -->
-    <appender name="async_gelf" class="ch.qos.logback.classic.AsyncAppender">
-        <!-- do not block the queue if Graylog is unavailable -->
-        <neverBlock>true</neverBlock>
-        <appender-ref ref="gelf" />
-    </appender>
-
     <logger name="com.egm.stellio" level="DEBUG"/>
     <logger name="org.flywaydb" level="DEBUG"/>
     <logger name="org.apache.kafka" level="WARN"/>
 
-    <root level="INFO">
-        <appender-ref ref="console" />
-        <springProfile name="gelflogs">
+    <springProfile name="!gelflogs">
+        <root level="INFO">
+            <appender-ref ref="console" />
+        </root>
+    </springProfile>
+
+    <springProfile name="gelflogs">
+        <appender name="gelf" class="de.siegmar.logbackgelf.GelfTcpAppender">
+            <graylogHost>${graylogHost}</graylogHost>
+            <graylogPort>${graylogPort}</graylogPort>
+            <encoder class="de.siegmar.logbackgelf.GelfEncoder">
+                <includeLevelName>true</includeLevelName>
+                <staticField>app_name:subscription-service</staticField>
+                <staticField>platform:${graylogSource}</staticField>
+            </encoder>
+        </appender>
+
+        <!-- Use AsyncAppender to prevent slowdowns -->
+        <appender name="async_gelf" class="ch.qos.logback.classic.AsyncAppender">
+            <!-- do not block the queue if Graylog is unavailable -->
+            <neverBlock>true</neverBlock>
+            <appender-ref ref="gelf" />
+        </appender>
+
+        <root level="INFO">
             <appender-ref ref="async_gelf" />
-        </springProfile>
-    </root>
+            <appender-ref ref="console" />
+        </root>
+    </springProfile>
 
 </configuration>


### PR DESCRIPTION
- see warnings when starting a service:

```
14:45:10,619 |-WARN in org.springframework.boot.logging.logback.SpringProfileIfNestedWithinSecondPhaseElementSanityChecker@2fa60eb1 - <springProfile> elements cannot be nested within an <appender>, <logger> or <root> element
14:45:10,620 |-WARN in org.springframework.boot.logging.logback.SpringProfileIfNestedWithinSecondPhaseElementSanityChecker@2fa60eb1 - Element <root> at line 37 contains a nested <springProfile> element at line 39
```
