### PR TITLE
revert multiple level subscription patch

### DIFF
--- a/subscription-service/build.gradle.kts
+++ b/subscription-service/build.gradle.kts
@@ -18,8 +18,6 @@ dependencies {
     implementation("org.springframework:spring-jdbc")
     implementation("org.flywaydb:flyway-core")
     implementation("org.postgresql:r2dbc-postgresql")
-    implementation("com.github.stellio-hub:json-merge:0.1.0")
-    implementation("org.json:json:20250517")
     implementation("com.jayway.jsonpath:json-path:2.9.0")
     implementation(project(":shared"))
     implementation("org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.5")

--- a/subscription-service/src/main/kotlin/com/egm/stellio/subscription/model/Subscription.kt
+++ b/subscription-service/src/main/kotlin/com/egm/stellio/subscription/model/Subscription.kt
@@ -34,7 +34,6 @@ import com.egm.stellio.subscription.model.NotificationTrigger.ATTRIBUTE_UPDATED
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException
-import com.savvasdalkitsis.jsonmerger.JsonMerger
 import org.springframework.data.annotation.Id
 import org.springframework.data.annotation.Transient
 import org.springframework.http.MediaType
@@ -262,10 +261,7 @@ data class Subscription(
         fragment: Map<String, Any>,
         contexts: List<String>
     ): Either<APIException, Subscription> = either {
-        val mergedSubscription = JsonMerger().merge(
-            serializeObject(this@Subscription),
-            serializeObject(fragment)
-        ).deserializeAsMap()
+        val mergedSubscription = convertTo<Map<String, Any>>(this@Subscription).plus(fragment)
         deserialize(mergedSubscription, contexts).bind()
             .copy(modifiedAt = ngsiLdDateTime())
     }


### PR DESCRIPTION
previous changes were not aligned with the specification.
Patch subscription use the 5.5.8 Partial Update Patch Behaviour who work only for one level.