### PR TITLE
fix(temporal): include deletedAt when present in temporal entity representation

### DIFF
--- a/search-service/src/main/kotlin/com/egm/stellio/search/entity/model/Entity.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/entity/model/Entity.kt
@@ -44,6 +44,9 @@ data class Entity(
 
         resultEntity[NGSILD_CREATED_AT_IRI] = buildNonReifiedTemporalValue(createdAt)
         resultEntity[NGSILD_MODIFIED_AT_IRI] = buildNonReifiedTemporalValue(modifiedAt)
+        deletedAt?.run {
+            resultEntity[NGSILD_DELETED_AT_IRI] = buildNonReifiedTemporalValue(deletedAt)
+        }
 
         return resultEntity
     }


### PR DESCRIPTION
When retrieving the temporal evolution of an entity, if `sysAttrs` is asked for, the `deletedAt` temporal property should be present at entity level if entity has been deleted (as said in 6.3.11: "In the case of temporal representations, also the system
generated temporal attribute deletedAt is included, if the NGSI-LD Element has been deleted.")