### PR TITLE
fix: csr entity info.type returned as String instead of String[]

### DIFF
--- a/search-service/src/main/kotlin/com/egm/stellio/search/csr/model/EntityInfo.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/csr/model/EntityInfo.kt
@@ -22,8 +22,12 @@ import java.util.regex.Pattern
 data class EntityInfo(
     val id: URI? = null,
     val idPattern: String? = null,
-    // no WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED because it is used for the database
-    @JsonFormat(with = [JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY])
+    @JsonFormat(
+        with = [
+            JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY,
+            JsonFormat.Feature.WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED
+        ]
+    )
     @JsonProperty("type")
     val types: List<String>
 ) {

--- a/search-service/src/main/kotlin/com/egm/stellio/search/csr/model/RegistrationInfoDB.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/csr/model/RegistrationInfoDB.kt
@@ -1,0 +1,31 @@
+package com.egm.stellio.search.csr.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import java.net.URI
+
+// used for instantiation in database
+data class RegistrationInfoDBWriter(
+    val entities: List<EntityInfoDB>? = null,
+    val propertyNames: List<String>? = null,
+    val relationshipNames: List<String>? = null
+) {
+    constructor(registrationInfo: RegistrationInfo) : this(
+        registrationInfo.entities?.map { EntityInfoDB(it) },
+        registrationInfo.propertyNames,
+        registrationInfo.relationshipNames
+    )
+}
+
+data class EntityInfoDB(
+    val id: URI? = null,
+    val idPattern: String? = null,
+    // types should always be a list in database
+    @JsonProperty("type")
+    val types: List<String>
+) {
+    constructor(info: EntityInfo) : this(
+        info.id,
+        info.idPattern,
+        info.types
+    )
+}


### PR DESCRIPTION
5.2.8 EntityInfo describe type as String or String[]