### PR TITLE
fix(temporal): inconsistencies in delete temporal attribute endpoint

### DIFF
--- a/search-service/src/main/kotlin/com/egm/stellio/search/entity/service/EntityAttributeService.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/entity/service/EntityAttributeService.kt
@@ -571,7 +571,8 @@ class EntityAttributeService(
         entityId: URI,
         attributeName: ExpandedTerm,
         datasetId: URI? = null,
-        anyAttributeInstance: Boolean = false
+        anyAttributeInstance: Boolean = false,
+        excludeDeleted: Boolean = true
     ): Either<APIException, Unit> {
         val datasetIdFilter =
             if (anyAttributeInstance) ""
@@ -589,7 +590,7 @@ class EntityAttributeService(
                     from temporal_entity_attribute 
                     where entity_id = :entity_id 
                     and attribute_name = :attribute_name
-                    and deleted_at is null
+                    ${if (excludeDeleted) " and deleted_at is null " else ""}
                     $datasetIdFilter
                 ) as attributeNameExists;
             """.trimIndent()

--- a/search-service/src/main/kotlin/com/egm/stellio/search/entity/service/EntityService.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/entity/service/EntityService.kt
@@ -722,7 +722,9 @@ class EntityService(
             entityAttributeService.checkEntityAndAttributeExistence(
                 entityId,
                 attributeName,
-                datasetId
+                datasetId,
+                anyAttributeInstance = deleteAll,
+                excludeDeleted = false
             ).bind()
             entityAttributeService.permanentlyDeleteAttribute(
                 entityId,

--- a/search-service/src/test/kotlin/com/egm/stellio/search/entity/service/EntityServiceTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/entity/service/EntityServiceTests.kt
@@ -611,7 +611,9 @@ class EntityServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     @Test
     fun `it should permanently delete an attribute`() = runTest {
         coEvery { authorizationService.userCanUpdateEntity(any()) } returns Unit.right()
-        coEvery { entityAttributeService.checkEntityAndAttributeExistence(any(), any(), any()) } returns Unit.right()
+        coEvery {
+            entityAttributeService.checkEntityAndAttributeExistence(any(), any(), any(), any(), any())
+        } returns Unit.right()
         coEvery { entityAttributeService.permanentlyDeleteAttribute(any(), any(), any(), any()) } returns Unit.right()
         coEvery { entityAttributeService.getAllForEntity(any()) } returns emptyList()
 
@@ -627,7 +629,7 @@ class EntityServiceTests : WithTimescaleContainer, WithKafkaContainer() {
         entityService.permanentlyDeleteAttribute(beehiveTestCId, INCOMING_IRI, null).shouldSucceed()
 
         coVerify {
-            entityAttributeService.checkEntityAndAttributeExistence(beehiveTestCId, INCOMING_IRI, null)
+            entityAttributeService.checkEntityAndAttributeExistence(beehiveTestCId, INCOMING_IRI, null, false, false)
             entityAttributeService.permanentlyDeleteAttribute(beehiveTestCId, INCOMING_IRI, null, false)
             entityAttributeService.getAllForEntity(beehiveTestCId)
         }
@@ -637,7 +639,7 @@ class EntityServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     fun `it should return a ResourceNotFound error if trying to permanently delete an unknown attribute`() = runTest {
         coEvery { authorizationService.userCanUpdateEntity(any()) } returns Unit.right()
         coEvery {
-            entityAttributeService.checkEntityAndAttributeExistence(any(), any(), any())
+            entityAttributeService.checkEntityAndAttributeExistence(any(), any(), any(), any(), any())
         } returns ResourceNotFoundException("Entity does not exist").left()
 
         loadAndPrepareSampleData("beehive.jsonld")
@@ -654,7 +656,7 @@ class EntityServiceTests : WithTimescaleContainer, WithKafkaContainer() {
         }
 
         coVerify {
-            entityAttributeService.checkEntityAndAttributeExistence(beehiveTestCId, OUTGOING_IRI, null)
+            entityAttributeService.checkEntityAndAttributeExistence(beehiveTestCId, OUTGOING_IRI, null, false, false)
         }
         coVerify(exactly = 0) {
             entityAttributeService.permanentlyDeleteAttribute(beehiveTestCId, OUTGOING_IRI, null, false)


### PR DESCRIPTION
- deleteAll flag was not handled when checking for existence
- it was not possible to permanently delete an attribute already deleted from current state
