### PR TITLE
fix(subscription): remove storage of default value for timeout

### DIFF
--- a/subscription-service/src/main/kotlin/com/egm/stellio/subscription/model/Endpoint.kt
+++ b/subscription-service/src/main/kotlin/com/egm/stellio/subscription/model/Endpoint.kt
@@ -11,7 +11,7 @@ data class Endpoint(
     val cooldown: Int? = null,
     val notifierInfo: List<EndpointInfo>? = null,
     val receiverInfo: List<EndpointInfo>? = null,
-    val timeout: Int = DEFAULT_TIMEOUT
+    val timeout: Int? = null
 ) {
 
     enum class AcceptType(val accept: String) {
@@ -28,7 +28,7 @@ data class Endpoint(
     companion object {
 
         // set a default timeout of 30 seconds when none specified
-        const val DEFAULT_TIMEOUT = 30000
+        const val DEFAULT_TIMEOUT = 30000L
 
         const val MQTT_SCHEME = "mqtt"
         const val MQTTS_SCHEME = "mqtts"
@@ -41,5 +41,9 @@ data class Endpoint(
                 DataTypes.convertToList(input)
             else null
         }
+    }
+
+    fun computeTimeout(): Long {
+        return timeout?.toLong() ?: DEFAULT_TIMEOUT
     }
 }

--- a/subscription-service/src/main/kotlin/com/egm/stellio/subscription/model/Subscription.kt
+++ b/subscription-service/src/main/kotlin/com/egm/stellio/subscription/model/Subscription.kt
@@ -221,7 +221,7 @@ data class Subscription(
         else Unit.right()
 
     private fun checkTimeoutGreaterThanZero(): Either<APIException, Unit> =
-        if (notification.endpoint.timeout < 1)
+        if (notification.endpoint.timeout != null && notification.endpoint.timeout < 1)
             BadRequestDataException("The value of 'timeout' must be greater than zero (int)").left()
         else Unit.right()
 

--- a/subscription-service/src/main/kotlin/com/egm/stellio/subscription/service/NotificationService.kt
+++ b/subscription-service/src/main/kotlin/com/egm/stellio/subscription/service/NotificationService.kt
@@ -261,7 +261,7 @@ class NotificationService(
                         .httpRequest {
                             val clientRequest = it.getNativeRequest<HttpClientRequest>()
                             clientRequest.responseTimeout(
-                                Duration.ofMillis(subscription.notification.endpoint.timeout.toLong())
+                                Duration.ofMillis(subscription.notification.endpoint.computeTimeout())
                             )
                         }
                         .headers { it.setAll(headerMap) }

--- a/subscription-service/src/main/kotlin/com/egm/stellio/subscription/service/SubscriptionService.kt
+++ b/subscription-service/src/main/kotlin/com/egm/stellio/subscription/service/SubscriptionService.kt
@@ -480,7 +480,7 @@ class SubscriptionService(
                     cooldown = toNullableInt(row["cooldown"]),
                     receiverInfo = deserialize(toJsonString(row["endpoint_receiver_info"])),
                     notifierInfo = deserialize(toJsonString(row["endpoint_notifier_info"])),
-                    timeout = toInt(row["timeout"])
+                    timeout = toNullableInt(row["timeout"])
                 ),
                 status = toOptionalEnum<NotificationParams.StatusType>(row["status"]),
                 timesSent = row["times_sent"] as Int,
@@ -522,7 +522,7 @@ class SubscriptionService(
                     cooldown = toNullableInt(row["cooldown"]),
                     receiverInfo = deserialize(toJsonString(row["endpoint_receiver_info"])),
                     notifierInfo = deserialize(toJsonString(row["endpoint_notifier_info"])),
-                    timeout = toInt(row["timeout"])
+                    timeout = toNullableInt(row["timeout"])
                 ),
                 status = null,
                 timesSent = row["times_sent"] as Int,

--- a/subscription-service/src/main/kotlin/com/egm/stellio/subscription/service/mqtt/MqttNotificationService.kt
+++ b/subscription-service/src/main/kotlin/com/egm/stellio/subscription/service/mqtt/MqttNotificationService.kt
@@ -59,7 +59,7 @@ class MqttNotificationService(
 
         try {
             val mqttVersion = notifierInfo[Mqtt.Version.KEY]
-            val timeout = subscription.notification.endpoint.timeout
+            val timeout = subscription.notification.endpoint.computeTimeout()
             when (mqttVersion) {
                 Mqtt.Version.V3 -> callMqttV3(data, timeout)
                 Mqtt.Version.V5 -> callMqttV5(data, timeout)
@@ -76,13 +76,13 @@ class MqttNotificationService(
         }
     }
 
-    internal suspend fun callMqttV3(data: MqttNotificationData, timeout: Int) {
+    internal suspend fun callMqttV3(data: MqttNotificationData, timeout: Long) {
         val mqttClient = connectMqttv3(data.connection)
         val message = MqttMessage(
             serializeObject(data.message).toByteArray()
         )
         message.qos = data.qos
-        mqttClient.timeToWait = timeout.toLong()
+        mqttClient.timeToWait = timeout
         mqttClient.publish(data.topic, message)
         mqttClient.disconnect()
     }
@@ -104,7 +104,7 @@ class MqttNotificationService(
         return mqttClient
     }
 
-    internal suspend fun callMqttV5(data: MqttNotificationData, timeout: Int) {
+    internal suspend fun callMqttV5(data: MqttNotificationData, timeout: Long) {
         val mqttClient = connectMqttv5(data.connection, timeout)
         val message = org.eclipse.paho.mqttv5.common.MqttMessage(serializeObject(data.message).toByteArray())
         message.qos = data.qos
@@ -114,7 +114,7 @@ class MqttNotificationService(
         mqttClient.close()
     }
 
-    internal suspend fun connectMqttv5(data: MqttConnectionData, timeout: Int): MqttAsyncClient {
+    internal suspend fun connectMqttv5(data: MqttConnectionData, timeout: Long): MqttAsyncClient {
         val persistence = org.eclipse.paho.mqttv5.client.persist.MemoryPersistence()
         val mqttClient = MqttAsyncClient(data.brokerUrl, data.clientId, persistence)
         val connOpts = MqttConnectionOptions().apply {
@@ -125,7 +125,7 @@ class MqttNotificationService(
             if (!data.password.isNullOrBlank()) {
                 password = data.password.toByteArray()
             }
-            connectionTimeout = Duration.ofMillis(timeout.toLong()).toSeconds().toInt()
+            connectionTimeout = Duration.ofMillis(timeout).toSeconds().toInt()
         }
 
         val token: IMqttToken = mqttClient.connect(connOpts)


### PR DESCRIPTION
If stored in DB, it is part of the subscription when it is retrieved and thus breaks the conformance test suite (the default value is not user provided and the specification imposes nothing about this).