### PR TITLE
refactor(subscription): centralize SQL query logic and other minor code improvements

### DIFF
--- a/search-service/src/main/kotlin/com/egm/stellio/search/entity/service/EntityService.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/entity/service/EntityService.kt
@@ -51,6 +51,7 @@ import com.egm.stellio.shared.util.JsonUtils.serializeObject
 import com.egm.stellio.shared.util.entityAlreadyExistsMessage
 import com.egm.stellio.shared.util.getSubFromSecurityContext
 import com.egm.stellio.shared.util.ngsiLdDateTime
+import com.egm.stellio.shared.util.wrapToList
 import io.r2dbc.postgresql.codec.Json
 import org.slf4j.LoggerFactory
 import org.springframework.r2dbc.core.DatabaseClient
@@ -446,7 +447,7 @@ class EntityService(
             entityId,
             expandedAttribute,
             modifiedAt
-        ).bind().let { listOf(it) }
+        ).bind().wrapToList()
 
         handleSuccessOperationActions(entityId, originalEntity, operationResult, modifiedAt).bind()
 
@@ -496,7 +497,7 @@ class EntityService(
             ngsiLdAttribute,
             expandedAttribute,
             replacedAt
-        ).bind().let { listOf(it) }
+        ).bind().wrapToList()
 
         handleSuccessOperationActions(entityId, originalEntity, operationResult, replacedAt).bind()
 

--- a/shared/src/main/kotlin/com/egm/stellio/shared/util/ListUtils.kt
+++ b/shared/src/main/kotlin/com/egm/stellio/shared/util/ListUtils.kt
@@ -1,0 +1,3 @@
+package com.egm.stellio.shared.util
+
+inline fun <reified T> T.wrapToList(): List<T> = listOf(this)

--- a/subscription-service/src/main/kotlin/com/egm/stellio/subscription/model/NotificationParams.kt
+++ b/subscription-service/src/main/kotlin/com/egm/stellio/subscription/model/NotificationParams.kt
@@ -7,14 +7,14 @@ import java.time.ZonedDateTime
 
 data class NotificationParams(
     @JsonInclude(value = JsonInclude.Include.NON_EMPTY)
-    var attributes: List<ExpandedTerm>?,
+    val attributes: List<ExpandedTerm>?,
     @JsonInclude(value = JsonInclude.Include.NON_EMPTY)
     val pick: Set<String>? = null,
     @JsonInclude(value = JsonInclude.Include.NON_EMPTY)
     val omit: Set<String>? = null,
     val format: FormatType = FormatType.NORMALIZED,
     val endpoint: Endpoint,
-    var status: StatusType? = null,
+    val status: StatusType? = null,
     @JsonInclude(value = JsonInclude.Include.NON_DEFAULT)
     val timesSent: Int = 0,
     val lastNotification: ZonedDateTime? = null,

--- a/subscription-service/src/main/kotlin/com/egm/stellio/subscription/service/CoreAPIService.kt
+++ b/subscription-service/src/main/kotlin/com/egm/stellio/subscription/service/CoreAPIService.kt
@@ -65,7 +65,7 @@ class CoreAPIService(
         val params = StringBuilder()
 
         if (!notificationParams.attributes.isNullOrEmpty()) {
-            val attrsParam = notificationParams.attributes!!.joinToString(",") { it.encode() }
+            val attrsParam = notificationParams.attributes.joinToString(",") { it.encode() }
             params.append("&${QueryParameter.ATTRS.key}=$attrsParam")
         }
         if (!notificationParams.pick.isNullOrEmpty()) {

--- a/subscription-service/src/main/kotlin/com/egm/stellio/subscription/service/NotificationService.kt
+++ b/subscription-service/src/main/kotlin/com/egm/stellio/subscription/service/NotificationService.kt
@@ -25,6 +25,7 @@ import com.egm.stellio.shared.util.JsonLdUtils.compactEntity
 import com.egm.stellio.shared.util.JsonUtils.serializeObject
 import com.egm.stellio.shared.util.acceptToMediaType
 import com.egm.stellio.shared.util.getTenantFromContext
+import com.egm.stellio.shared.util.wrapToList
 import com.egm.stellio.shared.web.DEFAULT_TENANT_NAME
 import com.egm.stellio.shared.web.NGSILD_TENANT_HEADER
 import com.egm.stellio.subscription.model.Endpoint
@@ -99,7 +100,7 @@ class NotificationService(
                                 it.notification.sysAttrs,
                                 it.lang
                             )
-                        ).let { listOf(it) }
+                        ).wrapToList()
                 }
 
             val compactedEntitiesWithPreviousValues =

--- a/subscription-service/src/main/kotlin/com/egm/stellio/subscription/service/SubscriptionService.kt
+++ b/subscription-service/src/main/kotlin/com/egm/stellio/subscription/service/SubscriptionService.kt
@@ -67,6 +67,19 @@ class SubscriptionService(
     private val r2dbcEntityTemplate: R2dbcEntityTemplate
 ) {
 
+    private val subscriptionBaseQuery = """
+        SELECT subscription.id as sub_id, subscription.type as sub_type, subscription_name, created_at,
+            modified_at, description, watched_attributes, notification_trigger, time_interval, q, notif_attributes,
+            notif_format, endpoint_uri, endpoint_accept, endpoint_receiver_info, endpoint_notifier_info, status, 
+            times_sent, is_active, last_notification, last_failure, last_success, entity_selector.id as entity_id, 
+            id_pattern, entity_selector.type_selection as type_selection, georel, geometry, coordinates, 
+            pgis_geometry, geoproperty, scope_q, expires_at, contexts, throttling, sys_attrs, lang, 
+            datasetId, jsonld_context, join_type, join_level, show_changes, pick, omit, cooldown, timeout
+        FROM subscription 
+        LEFT JOIN entity_selector on subscription.id = entity_selector.subscription_id
+        LEFT JOIN geometry_query on subscription.id = geometry_query.subscription_id
+    """.trimIndent()
+
     @Transactional
     suspend fun upsert(subscription: Subscription, sub: Sub): Either<APIException, Unit> = either {
         val endpoint = subscription.notification.endpoint
@@ -206,16 +219,7 @@ class SubscriptionService(
     suspend fun getById(id: URI): Subscription {
         val selectStatement =
             """
-            SELECT subscription.id as sub_id, subscription.type as sub_type, subscription_name, created_at,
-                modified_at, description, watched_attributes, notification_trigger, time_interval, q, notif_attributes,
-                notif_format, endpoint_uri, endpoint_accept, endpoint_receiver_info, endpoint_notifier_info, status, 
-                times_sent, is_active, last_notification, last_failure, last_success, entity_selector.id as entity_id, 
-                id_pattern, entity_selector.type_selection as type_selection, georel, geometry, coordinates, 
-                pgis_geometry, geoproperty, scope_q, expires_at, contexts, throttling, sys_attrs, lang, 
-                datasetId, jsonld_context, join_type, join_level, show_changes, pick, omit, cooldown, timeout
-            FROM subscription 
-            LEFT JOIN entity_selector ON entity_selector.subscription_id = :id
-            LEFT JOIN geometry_query ON geometry_query.subscription_id = :id 
+            $subscriptionBaseQuery
             WHERE subscription.id = :id
             """.trimIndent()
 
@@ -287,16 +291,7 @@ class SubscriptionService(
     suspend fun getSubscriptions(limit: Int, offset: Int, sub: Sub): List<Subscription> {
         val selectStatement =
             """
-            SELECT subscription.id as sub_id, subscription.type as sub_type, subscription_name, created_at, 
-                modified_At, description, watched_attributes, notification_trigger, time_interval, q, notif_attributes, 
-                notif_format, endpoint_uri, endpoint_accept, endpoint_receiver_info, endpoint_notifier_info, status, 
-                times_sent, is_active, last_notification, last_failure, last_success, entity_selector.id as entity_id,
-                id_pattern, entity_selector.type_selection as type_selection, georel, geometry, coordinates, 
-                pgis_geometry, geoproperty, scope_q, expires_at, contexts, throttling, sys_attrs, lang, 
-                datasetId, jsonld_context, join_type, join_level, show_changes, pick, omit, cooldown, timeout
-            FROM subscription 
-            LEFT JOIN entity_selector ON entity_selector.subscription_id = subscription.id
-            LEFT JOIN geometry_query ON geometry_query.subscription_id = subscription.id
+            $subscriptionBaseQuery
             WHERE subscription.id in (
                 SELECT subscription.id as sub_id
                 from subscription
@@ -331,15 +326,7 @@ class SubscriptionService(
     ): List<Subscription> {
         val selectStatement =
             """
-            SELECT subscription.id as sub_id, subscription.type as sub_type, subscription_name, description, q,
-                   entity_selector.id as entity_id, entity_selector.id_pattern as id_pattern, 
-                   entity_selector.type_selection as type_selection, georel, geometry, coordinates, pgis_geometry,
-                   geoproperty, scope_q, notif_attributes, notif_format, endpoint_uri, endpoint_accept, times_sent, 
-                   endpoint_receiver_info, endpoint_notifier_info, contexts, throttling, sys_attrs, lang, 
-                   datasetId, jsonld_context, join_type, join_level, show_changes, pick, omit, cooldown, timeout
-            FROM subscription 
-            LEFT JOIN entity_selector on subscription.id = entity_selector.subscription_id
-            LEFT JOIN geometry_query on subscription.id = geometry_query.subscription_id
+            $subscriptionBaseQuery
             WHERE is_active
             AND ( expires_at is null OR expires_at >= :date )
             AND time_interval IS NULL
@@ -363,7 +350,7 @@ class SubscriptionService(
             """.trimIndent()
         return databaseClient.sql(selectStatement)
             .bind("date", ngsiLdDateTime())
-            .allToMappedList { rowToMinimalMatchSubscription(it) }
+            .allToMappedList { rowToSubscription(it) }
             .mergeEntitySelectorsOnSubscriptions()
     }
 
@@ -501,47 +488,6 @@ class SubscriptionService(
         )
     }
 
-    private val rowToMinimalMatchSubscription: ((Map<String, Any>) -> Subscription) = { row ->
-        Subscription(
-            id = toUri(row["sub_id"]),
-            type = row["sub_type"] as String,
-            subscriptionName = row["subscription_name"] as? String,
-            description = row["description"] as? String,
-            q = row["q"] as? String,
-            scopeQ = row["scope_q"] as? String,
-            entities = rowToEntityInfo(row)?.let { setOf(it) },
-            geoQ = rowToGeoQ(row),
-            notification = NotificationParams(
-                attributes = (row["notif_attributes"] as? String)?.split(","),
-                pick = toNullableSet(row["pick"]),
-                omit = toNullableSet(row["omit"]),
-                format = toEnum(row["notif_format"]!!),
-                endpoint = Endpoint(
-                    uri = toUri(row["endpoint_uri"]),
-                    accept = toEnum(row["endpoint_accept"]!!),
-                    cooldown = toNullableInt(row["cooldown"]),
-                    receiverInfo = deserialize(toJsonString(row["endpoint_receiver_info"])),
-                    notifierInfo = deserialize(toJsonString(row["endpoint_notifier_info"])),
-                    timeout = toNullableInt(row["timeout"])
-                ),
-                status = null,
-                timesSent = row["times_sent"] as Int,
-                lastNotification = null,
-                lastFailure = null,
-                lastSuccess = null,
-                sysAttrs = row["sys_attrs"] as Boolean,
-                join = toOptionalEnum<JoinType>(row["join_type"]),
-                joinLevel = row["join_level"] as? Int,
-                showChanges = row["show_changes"] as Boolean
-            ),
-            contexts = toList(row["contexts"]!!),
-            throttling = toNullableInt(row["throttling"]),
-            lang = row["lang"] as? String,
-            datasetId = toNullableList(row["datasetId"]),
-            jsonldContext = toNullableUri(row["jsonld_context"])
-        )
-    }
-
     private val rowToGeoQ: ((Map<String, Any>) -> GeoQ?) = { row ->
         row["georel"]?.let {
             GeoQ(
@@ -567,16 +513,7 @@ class SubscriptionService(
     suspend fun getRecurringSubscriptionsToNotify(): List<Subscription> {
         val selectStatement =
             """
-            SELECT subscription.id as sub_id, subscription.type as sub_type, subscription_name, created_at,
-                modified_At, expires_at, description, watched_attributes, notification_trigger, time_interval, q, 
-                scope_q, notif_attributes, notif_format, endpoint_uri, endpoint_accept, endpoint_receiver_info,
-                endpoint_notifier_info, status, times_sent, last_notification, last_failure, last_success, is_active, 
-                entity_selector.id as entity_id, id_pattern, entity_selector.type_selection as type_selection, georel,
-                geometry, coordinates, pgis_geometry, geoproperty, contexts, throttling, sys_attrs, lang, 
-                datasetId, jsonld_context, join_type, join_level, show_changes, pick, omit, cooldown, timeout
-            FROM subscription
-            LEFT JOIN entity_selector ON entity_selector.subscription_id = subscription.id
-            LEFT JOIN geometry_query ON geometry_query.subscription_id = subscription.id
+            $subscriptionBaseQuery
             WHERE time_interval IS NOT NULL
             AND (last_notification IS NULL 
                 OR ((EXTRACT(EPOCH FROM last_notification) + time_interval) < EXTRACT(EPOCH FROM :currentDate))


### PR DESCRIPTION
- Introduce `subscriptionBaseQuery` to simplify and reuse SQL queries.
- Replace repeated SQL query statements with `subscriptionBaseQuery`.
- Introduce `wrapToList` utility function for streamlined list creation.
- Update `NotificationParams` to use immutable properties for better safety.
