### PR TITLE
fix(core): extract of relationships incorrectly expects same relationships names for all entities

### DIFF
--- a/search-service/src/main/kotlin/com/egm/stellio/search/entity/service/LinkedEntityService.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/entity/service/LinkedEntityService.kt
@@ -51,8 +51,11 @@ class LinkedEntityService(
         entitiesQuery: EntitiesQuery,
         currentLevel: UInt
     ): Either<APIException, List<CompactedEntity>> = either {
+        if (currentLevel > entitiesQuery.linkedEntityQuery!!.joinLevel)
+            return compactedEntities.right()
+
         val linkedRelationships = compactedEntities.getRelationshipsNamesWithObjects()
-        if (currentLevel > entitiesQuery.linkedEntityQuery!!.joinLevel || linkedRelationships.isEmpty())
+        if (linkedRelationships.isEmpty())
             return compactedEntities.right()
 
         val relationshipsQuery = EntitiesQueryFromGet(

--- a/shared/src/main/kotlin/com/egm/stellio/shared/model/CompactedEntity.kt
+++ b/shared/src/main/kotlin/com/egm/stellio/shared/model/CompactedEntity.kt
@@ -62,7 +62,7 @@ fun CompactedEntity.getRelationshipsNamesWithObjects(): Map<String, Set<URI>> =
 fun List<CompactedEntity>.getRelationshipsNamesWithObjects(): Map<String, Set<URI>> =
     this.map { it.getRelationshipsNamesWithObjects() }.fold(emptyMap()) { acc, value ->
         (acc.keys + value.keys).associateWith {
-            (acc[it] ?: emptySet()).plus(value[it]!!)
+            (acc[it] ?: emptySet()).plus(value[it] ?: emptySet())
         }
     }
 

--- a/shared/src/test/kotlin/com/egm/stellio/shared/model/CompactedEntityLinkedTests.kt
+++ b/shared/src/test/kotlin/com/egm/stellio/shared/model/CompactedEntityLinkedTests.kt
@@ -120,7 +120,7 @@ class CompactedEntityLinkedTests {
                     "type": "Relationship",
                     "object": "urn:ngsi-ld:LinkedEntity:03"
                 },
-                "r2": {
+                "r3": {
                     "type": "Relationship",
                     "object": "urn:ngsi-ld:LinkedEntity:04"
                 }
@@ -130,11 +130,12 @@ class CompactedEntityLinkedTests {
         val relationships = compactedEntities.getRelationshipsNamesWithObjects()
 
         assertThat(relationships)
-            .hasSize(2)
+            .hasSize(3)
             .containsExactlyEntriesOf(
                 mapOf(
                     "r1" to setOf("urn:ngsi-ld:LinkedEntity:01".toUri(), "urn:ngsi-ld:LinkedEntity:03".toUri()),
-                    "r2" to setOf("urn:ngsi-ld:LinkedEntity:02".toUri(), "urn:ngsi-ld:LinkedEntity:04".toUri())
+                    "r2" to setOf("urn:ngsi-ld:LinkedEntity:02".toUri()),
+                    "r3" to setOf("urn:ngsi-ld:LinkedEntity:04".toUri())
                 )
             )
     }


### PR DESCRIPTION
- Fix incorrect association code that expected that the same relationships names exist in all entities
- Avoid useless call to `getRelationshipsNamesWithObjects` if `joinLevel` is reached
