### PR TITLE
feat: switch back to jib for multi-arch Docker images

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,8 +68,7 @@ pipeline {
                 }
             }
             steps {
-                sh 'docker login'
-                sh './gradlew bootBuildImage --publishImage'
+                sh './gradlew jib -Djib.to.auth.username=$EGM_CI_DH_USR -Djib.to.auth.password=$EGM_CI_DH_PSW'
             }
         }
         /* Used when we want to publish images for a specific tag (e.g., FIWARE versions) */
@@ -80,10 +79,9 @@ pipeline {
                     if (currentTags.size() > 0 && currentTags[0].trim() != "") {
                         for (int i = 0; i < currentTags.size(); ++i) {
                             env.CURRENT_TAG = currentTags[i]
-                            sh 'docker login'
-                            sh './gradlew bootBuildImage --publishImage --tags=stellio/stellio-api-gateway:$CURRENT_TAG -p api-gateway'
-                            sh './gradlew bootBuildImage --publishImage --tags=stellio/stellio-search-service:$CURRENT_TAG -p search-service'
-                            sh './gradlew bootBuildImage --publishImage --tags=stellio/stellio-subscription-service:$CURRENT_TAG -p subscription-service'
+                            sh './gradlew jib -Djib.to.image=stellio/stellio-api-gateway:$CURRENT_TAG -Djib.to.auth.username=$EGM_CI_DH_USR -Djib.to.auth.password=$EGM_CI_DH_PSW -p api-gateway'
+                            sh './gradlew jib -Djib.to.image=stellio/stellio-search-service:$CURRENT_TAG -Djib.to.auth.username=$EGM_CI_DH_USR -Djib.to.auth.password=$EGM_CI_DH_PSW -p search-service'
+                            sh './gradlew jib -Djib.to.image=stellio/stellio-subscription-service:$CURRENT_TAG -Djib.to.auth.username=$EGM_CI_DH_USR -Djib.to.auth.password=$EGM_CI_DH_PSW -p subscription-service'
                         }
                     }
                 }

--- a/api-gateway/build.gradle.kts
+++ b/api-gateway/build.gradle.kts
@@ -1,4 +1,7 @@
+import com.google.cloud.tools.jib.gradle.PlatformParameters
+
 plugins {
+    id("com.google.cloud.tools.jib")
     id("org.springframework.boot")
 }
 
@@ -20,14 +23,9 @@ springBoot {
     }
 }
 
-tasks.bootBuildImage {
-    imageName = "stellio/stellio-api-gateway:${project.version}"
-    imagePlatform = "linux/amd64"
-
-    val buildpackEnvironment = project.ext["buildpackEnvironment"] as? Map<String, String> ?: emptyMap()
-    val buildpackRuntimeEnvironment = project.ext["buildpackRuntimeEnvironment"] as? Map<String, String> ?: emptyMap()
-    val buildpackOciLabels = project.ext["buildpackOciLabels"] as? Map<String, String> ?: emptyMap()
-    environment = buildpackEnvironment
-        .plus(buildpackRuntimeEnvironment)
-        .plus(buildpackOciLabels)
-}
+jib.from.image = project.ext["jibFromImage"].toString()
+jib.from.platforms.addAll(project.ext["jibFromPlatforms"] as List<PlatformParameters>)
+jib.to.image = "stellio/stellio-api-gateway:${project.version}"
+jib.container.ports = listOf("8080")
+jib.container.creationTime.set(project.ext["jibContainerCreationTime"].toString())
+jib.container.labels.putAll(project.ext["jibContainerLabels"] as Map<String, String>)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -151,6 +151,10 @@ subprojects {
         }
     }
 
+    tasks.withType<com.google.cloud.tools.jib.gradle.BuildImageTask>().configureEach {
+        notCompatibleWithConfigurationCache("Jib does not support configuration cache")
+    }
+
     project.ext.set("jibFromImage", "eclipse-temurin:21-jre")
     project.ext.set(
         "jibFromPlatforms",

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,15 @@
+import com.google.cloud.tools.jib.gradle.PlatformParameters
 import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
 import io.spring.gradle.dependencymanagement.dsl.DependencyManagementExtension
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
-
+buildscript {
+    dependencies {
+        classpath("com.google.cloud.tools:jib-layer-filter-extension-gradle:0.3.0")
+    }
+}
 
 extra["springCloudVersion"] = "2025.1.0"
 
@@ -19,7 +24,7 @@ plugins {
     id("org.graalvm.buildtools.native") version "1.0.0"
     kotlin("jvm") version "2.3.10" apply false
     kotlin("plugin.spring") version "2.3.10" apply false
-
+    id("com.google.cloud.tools.jib") version "3.5.3" apply false
     id("io.gitlab.arturbosch.detekt") version "1.23.8" apply false
     id("org.sonarqube") version "7.2.3.7755"
     jacoco
@@ -146,36 +151,37 @@ subprojects {
         }
     }
 
-    // Docker configuration for the Spring Boot bootBuildImage task
-    ext.set(
-        "buildpackEnvironment",
-        mapOf(
-            "BP_JVM_VERSION" to "21.*",
-            "BP_NATIVE_IMAGE" to "false"
+    project.ext.set("jibFromImage", "eclipse-temurin:21-jre")
+    project.ext.set(
+        "jibFromPlatforms",
+        listOf(
+            PlatformParameters().apply {
+                os = "linux"
+                architecture = "arm64"
+            },
+            PlatformParameters().apply {
+                os = "linux"
+                architecture = "amd64"
+            }
         )
     )
-    ext.set(
-        "buildpackRuntimeEnvironment",
+    project.ext.set("jibContainerCreationTime", "USE_CURRENT_TIMESTAMP")
+    project.ext.set(
+        "jibContainerLabels",
         mapOf(
-            "BPE_DELIM_JAVA_TOOL_OPTIONS" to " ",
-            "BPE_APPEND_JAVA_TOOL_OPTIONS" to "-XX:MaxDirectMemorySize=256M "
-        )
-    )
-    // See https://github.com/opencontainers/image-spec/blob/main/annotations.md for predefined keys
-    ext.set(
-        "buildpackOciLabels",
-        mapOf(
-            "BP_OCI_AUTHORS" to "https://stellio.io",
-            "BP_OCI_DOCUMENTATION" to "https://stellio.readthedocs.io/",
-            "BP_OCI_VENDOR" to "EGM",
-            "BP_OCI_LICENSES" to "Apache-2.0",
-            "BP_OCI_TITLE" to "Stellio context broker",
-            "BP_OCI_DESCRIPTION" to
+            "maintainer" to "EGM",
+            "org.opencontainers.image.authors" to "EGM",
+            "org.opencontainers.image.documentation" to "https://stellio.readthedocs.io/",
+            "org.opencontainers.image.vendor" to "EGM",
+            "org.opencontainers.image.licenses" to "Apache-2.0",
+            "org.opencontainers.image.title" to "Stellio context broker",
+            "org.opencontainers.image.description" to
                 """
                     Stellio is an NGSI-LD compliant context broker developed by EGM. 
                     NGSI-LD is an Open API and data model specification for context management published by ETSI.
                 """.trimIndent(),
-            "BP_OCI_SOURCE" to "https://github.com/stellio-hub/stellio-context-broker"
+            "org.opencontainers.image.source" to "https://github.com/stellio-hub/stellio-context-broker",
+            "com.java.version" to "${JavaVersion.VERSION_21}"
         )
     )
 }

--- a/search-service/build.gradle.kts
+++ b/search-service/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.google.cloud.tools.jib.gradle.PlatformParameters
+
 configurations {
     compileOnly {
         extendsFrom(configurations.annotationProcessor.get())
@@ -5,6 +7,7 @@ configurations {
 }
 
 plugins {
+    id("com.google.cloud.tools.jib")
     id("org.springframework.boot")
 }
 
@@ -43,14 +46,9 @@ tasks.bootRun {
     environment("SPRING_PROFILES_ACTIVE", "dev")
 }
 
-tasks.bootBuildImage {
-    imageName = "stellio/stellio-search-service:${project.version}"
-    imagePlatform = "linux/amd64"
-
-    val buildpackEnvironment = project.ext["buildpackEnvironment"] as? Map<String, String> ?: emptyMap()
-    val buildpackRuntimeEnvironment = project.ext["buildpackRuntimeEnvironment"] as? Map<String, String> ?: emptyMap()
-    val buildpackOciLabels = project.ext["buildpackOciLabels"] as? Map<String, String> ?: emptyMap()
-    environment = buildpackEnvironment
-        .plus(buildpackRuntimeEnvironment)
-        .plus(buildpackOciLabels)
-}
+jib.from.image = project.ext["jibFromImage"].toString()
+jib.from.platforms.addAll(project.ext["jibFromPlatforms"] as List<PlatformParameters>)
+jib.to.image = "stellio/stellio-search-service:${project.version}"
+jib.container.ports = listOf("8083")
+jib.container.creationTime.set(project.ext["jibContainerCreationTime"].toString())
+jib.container.labels.putAll(project.ext["jibContainerLabels"] as Map<String, String>)

--- a/subscription-service/build.gradle.kts
+++ b/subscription-service/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.google.cloud.tools.jib.gradle.PlatformParameters
+
 configurations {
     compileOnly {
         extendsFrom(configurations.annotationProcessor.get())
@@ -5,6 +7,7 @@ configurations {
 }
 
 plugins {
+    id("com.google.cloud.tools.jib")
     id("org.springframework.boot")
 }
 
@@ -42,14 +45,9 @@ tasks.bootRun {
     environment("SPRING_PROFILES_ACTIVE", "dev")
 }
 
-tasks.bootBuildImage {
-    imageName = "stellio/stellio-subscription-service:${project.version}"
-    imagePlatform = "linux/amd64"
-
-    val buildpackEnvironment = project.ext["buildpackEnvironment"] as? Map<String, String> ?: emptyMap()
-    val buildpackRuntimeEnvironment = project.ext["buildpackRuntimeEnvironment"] as? Map<String, String> ?: emptyMap()
-    val buildpackOciLabels = project.ext["buildpackOciLabels"] as? Map<String, String> ?: emptyMap()
-    environment = buildpackEnvironment
-        .plus(buildpackRuntimeEnvironment)
-        .plus(buildpackOciLabels)
-}
+jib.from.image = project.ext["jibFromImage"].toString()
+jib.from.platforms.addAll(project.ext["jibFromPlatforms"] as List<PlatformParameters>)
+jib.to.image = "stellio/stellio-subscription-service:${project.version}"
+jib.container.ports = listOf("8084")
+jib.container.creationTime.set(project.ext["jibContainerCreationTime"].toString())
+jib.container.labels.putAll(project.ext["jibContainerLabels"] as Map<String, String>)


### PR DESCRIPTION
It appears it is quite complex to create multi-arch Docker images with cloud native buildpacks and to integrate this in a Gradle build process (creation of two distinct images, creation of a manifest, deletion of the two previously created images).

So, reverting to the previous way of creation multi-arch Docker images with Jib. It is currently excluded from the Gradle's configuration cache as that fails the build with such error (waiting for the plugin to be adapted):

```
- Task `:api-gateway:jib` of type `com.google.cloud.tools.jib.gradle.BuildImageTask`: cannot serialize object of type 'org.gradle.api.internal.project.DefaultProject', a subtype of 'org.gradle.api.Project', as these are not supported with the configuration cache.
  See https://docs.gradle.org/9.4.1/userguide/configuration_cache_requirements.html#config_cache:requirements:disallowed_types
- Task `:api-gateway:jib` of type `com.google.cloud.tools.jib.gradle.BuildImageTask`: invocation of 'Task.project' at execution time is unsupported with the configuration cache.
  See https://docs.gradle.org/9.4.1/userguide/configuration_cache_requirements.html#config_cache:requirements:use_project_during_execution
```
