### PR TITLE
feat: implement a Kafka listener to receive telemetry data

### DIFF
--- a/docs/admin/architecture.md
+++ b/docs/admin/architecture.md
@@ -113,38 +113,6 @@ are JSON-LD compacted, but when sent by Stellio, they are JSON-LD expanded):
 }
 ```
 
-### Telemetry ingestion via Kafka
-
-For high-throughput IoT scenarios, attribute values can be pushed directly to Kafka without going through the HTTP API.
-This avoids the overhead of HTTP connection handling and offers an improved resilience.
-
-**Topic**: `cim.telemetry`
-
-**Constraints**:
-- The entity must already exist (provisioned once via HTTP).
-- Only `Property` values are supported; other attribute types must use the HTTP API.
-- No authentication — Kafka is a trusted, internal channel.
-
-**Message format** (the message key must be set to the `entityId`):
-
-```json
-{
-  "tenantName": "urn:ngsi-ld:tenant:stellio",
-  "entityId": "urn:ngsi-ld:Vehicle:A4567",
-  "attributeName": "https://vocab.egm.io/speed",
-  "datasetId": "urn:ngsi-ld:Dataset:GPS",
-  "value": 25.3,
-  "observedAt": "2026-01-01T00:00:00Z"
-}
-```
-
-On receipt, the search-service:
-- creates the attribute if it does not exist yet.
-- applies merge semantics (NGSI-LD §5.5.12), preserving existing attribute metadata, if it exists.
-
-An `ATTRIBUTE_CREATE` or `ATTRIBUTE_UPDATE` event is then published to `cim.entity._CatchAll` so subscriptions fire as
-normal.
-
 ### Mapping from Core API operations to `notificationTrigger` in subscriptions
 
 Starting from version 1.6.1 of the NGSI-LD specification, subscriptions support a new `notificationTrigger` member (see 5.2.12 for more details).

--- a/docs/admin/architecture.md
+++ b/docs/admin/architecture.md
@@ -113,6 +113,38 @@ are JSON-LD compacted, but when sent by Stellio, they are JSON-LD expanded):
 }
 ```
 
+### Telemetry ingestion via Kafka
+
+For high-throughput IoT scenarios, attribute values can be pushed directly to Kafka without going through the HTTP API.
+This avoids the overhead of HTTP connection handling and offers an improved resilience.
+
+**Topic**: `cim.telemetry`
+
+**Constraints**:
+- The entity must already exist (provisioned once via HTTP).
+- Only `Property` values are supported; other attribute types must use the HTTP API.
+- No authentication — Kafka is a trusted, internal channel.
+
+**Message format** (the message key must be set to the `entityId`):
+
+```json
+{
+  "tenantName": "urn:ngsi-ld:tenant:stellio",
+  "entityId": "urn:ngsi-ld:Vehicle:A4567",
+  "attributeName": "https://vocab.egm.io/speed",
+  "datasetId": "urn:ngsi-ld:Dataset:GPS",
+  "value": 25.3,
+  "observedAt": "2026-01-01T00:00:00Z"
+}
+```
+
+On receipt, the search-service:
+- creates the attribute if it does not exist yet.
+- applies merge semantics (NGSI-LD §5.5.12), preserving existing attribute metadata, if it exists.
+
+An `ATTRIBUTE_CREATE` or `ATTRIBUTE_UPDATE` event is then published to `cim.entity._CatchAll` so subscriptions fire as
+normal.
+
 ### Mapping from Core API operations to `notificationTrigger` in subscriptions
 
 Starting from version 1.6.1 of the NGSI-LD specification, subscriptions support a new `notificationTrigger` member (see 5.2.12 for more details).

--- a/docs/user/kafka_telemetry_ingestion.md
+++ b/docs/user/kafka_telemetry_ingestion.md
@@ -1,0 +1,31 @@
+# Kafka telemetry ingestion
+
+For high-throughput IoT scenarios, attribute values can be pushed directly to Kafka without going through the HTTP API.
+This avoids the overhead of HTTP connection handling and offers an improved resilience.
+
+**Topic**: `cim.telemetry`
+
+**Constraints**:
+- The entity must already exist (provisioned once via HTTP).
+- Only `Property` values are supported; other attribute types must use the HTTP API.
+- No authentication — Kafka is a trusted, internal channel.
+
+**Message format** (the message key must be set to the `entityId`):
+
+```json
+{
+  "tenantName": "urn:ngsi-ld:tenant:stellio",
+  "entityId": "urn:ngsi-ld:Vehicle:A4567",
+  "attributeName": "https://vocab.egm.io/speed",
+  "datasetId": "urn:ngsi-ld:Dataset:GPS",
+  "value": 25.3,
+  "observedAt": "2026-01-01T00:00:00Z"
+}
+```
+
+On receipt, the search-service:
+- creates the attribute if it does not exist yet.
+- applies merge semantics (NGSI-LD §5.5.12), preserving existing attribute metadata, if it exists.
+
+An `ATTRIBUTE_CREATE` or `ATTRIBUTE_UPDATE` event is then published to `cim.entity._CatchAll` so subscriptions fire as
+normal.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,7 @@ nav:
       - Information model : 'user/information_model.md'
       - API Walkthrough: 'user/API_walkthrough.md'
       - NGSI-LD Query Language support: 'user/query_language.md'
+      - Kafka telemetry ingestion: 'user/kafka_telemetry_ingestion.md'
       - Authentication and authorization: 'user/authentication_and_authorization.md'
   - Installation & Administration Manual:
       - Architecture: 'admin/architecture.md'

--- a/search-service/src/main/kotlin/com/egm/stellio/search/entity/listener/TelemetryListener.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/entity/listener/TelemetryListener.kt
@@ -1,0 +1,82 @@
+package com.egm.stellio.search.entity.listener
+
+import com.egm.stellio.search.entity.model.TelemetryDataMessage
+import com.egm.stellio.search.entity.service.EntityService
+import com.egm.stellio.shared.model.JSONLD_TYPE_KW
+import com.egm.stellio.shared.model.JSONLD_VALUE_KW
+import com.egm.stellio.shared.model.NGSILD_DATASET_ID_IRI
+import com.egm.stellio.shared.model.NGSILD_OBSERVED_AT_IRI
+import com.egm.stellio.shared.model.NGSILD_PROPERTY_TYPE
+import com.egm.stellio.shared.model.NGSILD_PROPERTY_VALUE
+import com.egm.stellio.shared.util.JsonLdUtils.buildNonReifiedPropertyValue
+import com.egm.stellio.shared.util.JsonLdUtils.buildNonReifiedTemporalValue
+import com.egm.stellio.shared.util.JsonUtils
+import com.egm.stellio.shared.util.NGSILD_TENANT_HEADER
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.reactor.mono
+import org.slf4j.LoggerFactory
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.stereotype.Component
+
+@Component
+class TelemetryListener(
+    private val entityService: EntityService
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+    private val coroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+
+    @KafkaListener(topics = ["cim.telemetry"], groupId = "search-telemetry")
+    fun processTelemetry(content: String) {
+        coroutineScope.launch {
+            handleTelemetryMessage(content)
+        }
+    }
+
+    internal suspend fun handleTelemetryMessage(content: String) {
+        val message = runCatching {
+            JsonUtils.deserializeAs<TelemetryDataMessage>(content)
+        }.getOrElse {
+            logger.warn("Failed to deserialize telemetry message: ${it.message}")
+            return
+        }
+
+        val attributeFragment = buildMap {
+            put(JSONLD_TYPE_KW, listOf(NGSILD_PROPERTY_TYPE.uri))
+            put(NGSILD_PROPERTY_VALUE, listOf(mapOf(JSONLD_VALUE_KW to message.value)))
+            put(NGSILD_OBSERVED_AT_IRI, buildNonReifiedTemporalValue(message.observedAt))
+            message.datasetId?.let { put(NGSILD_DATASET_ID_IRI, buildNonReifiedPropertyValue(it.toString())) }
+        }
+
+        mono {
+            entityService.mergeAttribute(
+                message.entityId,
+                message.attributeName,
+                attributeFragment,
+                message.observedAt
+            )
+        }.contextWrite {
+            it.put(NGSILD_TENANT_HEADER, message.tenantName)
+        }.subscribe { result ->
+            result.fold(
+                {
+                    logger.warn(
+                        "Failed to ingest attribute {} for entity {}: {}",
+                        message.attributeName,
+                        message.entityId,
+                        it.message
+                    )
+                },
+                {
+                    logger.debug(
+                        "Ingested attribute {} for entity {}",
+                        message.attributeName,
+                        message.entityId
+                    )
+                }
+            )
+        }
+    }
+}

--- a/search-service/src/main/kotlin/com/egm/stellio/search/entity/model/TelemetryDataMessage.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/entity/model/TelemetryDataMessage.kt
@@ -1,0 +1,15 @@
+package com.egm.stellio.search.entity.model
+
+import com.egm.stellio.shared.model.ExpandedTerm
+import com.egm.stellio.shared.web.DEFAULT_TENANT_NAME
+import java.net.URI
+import java.time.ZonedDateTime
+
+data class TelemetryDataMessage(
+    val tenantName: String = DEFAULT_TENANT_NAME,
+    val entityId: URI,
+    val attributeName: ExpandedTerm,
+    val datasetId: URI? = null,
+    val value: Any,
+    val observedAt: ZonedDateTime
+)

--- a/search-service/src/main/kotlin/com/egm/stellio/search/entity/service/EntityService.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/entity/service/EntityService.kt
@@ -39,6 +39,7 @@ import com.egm.stellio.shared.model.APIException
 import com.egm.stellio.shared.model.AlreadyExistsException
 import com.egm.stellio.shared.model.EXPANDED_ENTITY_SPECIFIC_MEMBERS
 import com.egm.stellio.shared.model.ExpandedAttribute
+import com.egm.stellio.shared.model.ExpandedAttributeInstance
 import com.egm.stellio.shared.model.ExpandedAttributeInstances
 import com.egm.stellio.shared.model.ExpandedAttributes
 import com.egm.stellio.shared.model.ExpandedEntity
@@ -457,6 +458,34 @@ class EntityService(
         handleSuccessOperationActions(entityId, originalEntity, operationResult, modifiedAt).bind()
 
         UpdateResult(operationResult)
+    }
+
+    @Transactional
+    suspend fun mergeAttribute(
+        entityId: URI,
+        expandedAttributeName: ExpandedTerm,
+        attributeFragment: ExpandedAttributeInstance,
+        observedAt: ZonedDateTime
+    ): Either<APIException, List<SucceededAttributeOperationResult>> = either {
+        val mergedAt = ngsiLdDateTime()
+        val originalEntity = entityQueryService.retrieve(entityId).bind().toExpandedEntity()
+        val expandedAttributes: ExpandedAttributes = mapOf(expandedAttributeName to listOf(attributeFragment))
+        val ngsiLdAttributes = expandedAttributes.toNgsiLdAttributes().bind()
+
+        val operationResult = entityAttributeService.mergeAttributes(
+            entityId,
+            ngsiLdAttributes,
+            expandedAttributes,
+            mergedAt,
+            observedAt
+        ).bind()
+
+        if (operationResult.isNotEmpty()) {
+            val updatedEntity = updateState(entityId, mergedAt, entityAttributeService.getAllForEntity(entityId)).bind()
+            entityEventService.publishAttributeChangeEvents(null, originalEntity, updatedEntity, operationResult)
+        }
+
+        operationResult
     }
 
     @Transactional

--- a/search-service/src/test/kotlin/com/egm/stellio/search/entity/listener/TelemetryListenerTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/entity/listener/TelemetryListenerTests.kt
@@ -1,0 +1,89 @@
+package com.egm.stellio.search.entity.listener
+
+import arrow.core.right
+import com.egm.stellio.search.entity.model.OperationStatus
+import com.egm.stellio.search.entity.model.SucceededAttributeOperationResult
+import com.egm.stellio.search.entity.service.EntityService
+import com.egm.stellio.shared.util.INCOMING_IRI
+import com.egm.stellio.shared.util.JsonUtils.serializeObject
+import com.egm.stellio.shared.util.ngsiLdDateTime
+import com.egm.stellio.shared.util.toUri
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.coEvery
+import io.mockk.coVerify
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import java.net.URI
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, classes = [TelemetryListener::class])
+@ActiveProfiles("test")
+class TelemetryListenerTests {
+
+    @MockkBean(relaxed = true)
+    private lateinit var entityService: EntityService
+
+    @Autowired
+    private lateinit var telemetryListener: TelemetryListener
+
+    private val entityId = "urn:ngsi-ld:BeeHive:01".toUri()
+
+    private fun buildTelemetryMessage(
+        entityId: String = "urn:ngsi-ld:BeeHive:01",
+        attributeName: String = INCOMING_IRI,
+        datasetId: URI? = null,
+        value: Any = 42.0
+    ): String = serializeObject(
+        mapOf(
+            "entityId" to entityId,
+            "attributeName" to attributeName,
+            "value" to value,
+            "observedAt" to ngsiLdDateTime().toString()
+        ).let {
+            if (datasetId != null)
+                it.plus("datasetId" to datasetId.toString())
+            else it
+        }
+    )
+
+    @Test
+    fun `it should ingest a valid telemetry message`() = runTest {
+        coEvery {
+            entityService.mergeAttribute(any(), any(), any(), any())
+        } returns listOf(
+            SucceededAttributeOperationResult(INCOMING_IRI, null, OperationStatus.UPDATED, emptyMap())
+        ).right()
+
+        telemetryListener.handleTelemetryMessage(buildTelemetryMessage())
+
+        coVerify(timeout = 1000L) {
+            entityService.mergeAttribute(eq(entityId), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `it should ingest a valid telemetry message having a datasetId`() = runTest {
+        coEvery {
+            entityService.mergeAttribute(any(), any(), any(), any())
+        } returns listOf(
+            SucceededAttributeOperationResult(INCOMING_IRI, null, OperationStatus.UPDATED, emptyMap())
+        ).right()
+
+        telemetryListener.handleTelemetryMessage(buildTelemetryMessage(datasetId = URI("urn:ngsi-ld:Dataset:01")))
+
+        coVerify(timeout = 1000L) {
+            entityService.mergeAttribute(eq(entityId), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `it should not call ingestAttribute when message is malformed JSON`() = runTest {
+        telemetryListener.handleTelemetryMessage("not valid json{")
+
+        coVerify(exactly = 0) {
+            entityService.mergeAttribute(any(), any(), any(), any())
+        }
+    }
+}

--- a/search-service/src/test/kotlin/com/egm/stellio/search/entity/service/EntityServiceTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/entity/service/EntityServiceTests.kt
@@ -683,6 +683,59 @@ class EntityServiceTests : WithTimescaleContainer, WithKafkaContainer() {
         }
     }
 
+    @Test
+    fun `mergeAttribute should return an error when the entity does not exist`() = runTest {
+        entityService.mergeAttribute(
+            entity01Uri,
+            INCOMING_IRI,
+            mapOf(JSONLD_TYPE_KW to listOf("https://uri.etsi.org/ngsi-ld/Property")),
+            now
+        ).shouldFail {
+            assertInstanceOf(ResourceNotFoundException::class.java, it)
+        }
+
+        coVerify(exactly = 0) {
+            entityAttributeService.mergeAttributes(any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `mergeAttribute should merge the attribute when entity exists`() = runTest {
+        coEvery {
+            entityAttributeService.mergeAttributes(any(), any(), any(), any(), any())
+        } returns listOf(
+            SucceededAttributeOperationResult(INCOMING_IRI, null, OperationStatus.UPDATED, emptyMap())
+        ).right()
+        coEvery { entityAttributeService.getAllForEntity(any()) } returns emptyList()
+
+        loadMinimalEntity(entity01Uri, setOf(BEEHIVE_IRI))
+            .sampleDataToNgsiLdEntity()
+            .map { entityService.createEntityPayload(it.second, it.first, now) }
+
+        val expandedAttributes = expandAttributes(
+            loadSampleData("fragments/beehive_mergeAttribute.json"),
+            APIC_COMPOUND_CONTEXTS
+        )
+
+        entityService.mergeAttribute(
+            entity01Uri,
+            INCOMING_IRI,
+            expandedAttributes[INCOMING_IRI]!![0],
+            now
+        ).shouldSucceed()
+
+        coVerify {
+            entityAttributeService.mergeAttributes(
+                eq(entity01Uri),
+                any(),
+                any(),
+                any(),
+                eq(now)
+            )
+            entityAttributeService.getAllForEntity(eq(entity01Uri))
+        }
+    }
+
     private fun buildTypeQuery(typeIri: String) = EntitiesQueryFromGet(
         typeSelection = typeIri,
         paginationQuery = PaginationQuery(limit = 100, offset = 0),


### PR DESCRIPTION
- Introduces TelemetryDataMessage as the message contract
- Adds TelemetryListener that consumes messages from the `cim.telemetry` Kafka topic
- Adds EntityService.mergeAttribute — a lightweight entry point that builds an expanded attribute fragment, delegates to the existing mergeAttributes pipeline, and publishes an event on `cim.entity._CatchAll`
- Updates the architecture documentation with the topic contract and field reference

