### PR TITLE
feat(core): implement missing behaviours in handling of NGSI-LD Nulls

### DIFF
--- a/search-service/config/detekt/baseline.xml
+++ b/search-service/config/detekt/baseline.xml
@@ -6,6 +6,7 @@
     <ID>ClassNaming:V0_29__JsonLd_migration.kt$V0_29__JsonLd_migration : BaseJavaMigration</ID>
     <ID>ComplexCondition:EntitiesQueryUtils.kt$geoQuery == null &amp;&amp; q == null &amp;&amp; typeSelection.isNullOrEmpty() &amp;&amp; attrs.isEmpty() &amp;&amp; !local</ID>
     <ID>ComplexCondition:EntitiesQueryUtils.kt$typeSelection.isNullOrEmpty() &amp;&amp; keep.isEmpty() &amp;&amp; drop.isEmpty() &amp;&amp; q == null &amp;&amp; geoQuery == null &amp;&amp; !local</ID>
+    <ID>CyclomaticComplexMethod:AttributeUtils.kt$fun mergePatch( source: ExpandedAttributeInstance, update: ExpandedAttributeInstance ): Either&lt;APIException, Pair&lt;String, ExpandedAttributeInstance&gt;&gt;</ID>
     <ID>Filename:V0_29__JsonLd_migration.kt$db.migration.V0_29__JsonLd_migration.kt</ID>
     <ID>LongMethod:AttributeInstanceService.kt$AttributeInstanceService$@Transactional suspend fun create(attributeInstance: AttributeInstance): Either&lt;APIException, Unit&gt;</ID>
     <ID>LongMethod:ContextSourceRegistrationService.kt$ContextSourceRegistrationService$@Transactional suspend fun upsert( csr: ContextSourceRegistration ): Either&lt;APIException, Unit&gt;</ID>

--- a/search-service/src/main/kotlin/com/egm/stellio/search/entity/service/EntityAttributeService.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/entity/service/EntityAttributeService.kt
@@ -48,6 +48,7 @@ import com.egm.stellio.shared.model.JSONLD_NONE_KW
 import com.egm.stellio.shared.model.JSONLD_TYPE_KW
 import com.egm.stellio.shared.model.NGSILD_JSONPROPERTY_JSON
 import com.egm.stellio.shared.model.NGSILD_LANGUAGEPROPERTY_LANGUAGEMAP
+import com.egm.stellio.shared.model.NGSILD_NULL
 import com.egm.stellio.shared.model.NGSILD_OBSERVED_AT_IRI
 import com.egm.stellio.shared.model.NGSILD_PREFIX
 import com.egm.stellio.shared.model.NGSILD_RELATIONSHIP_OBJECT
@@ -68,6 +69,7 @@ import com.egm.stellio.shared.model.isAttributeOfType
 import com.egm.stellio.shared.model.toNgsiLdEntity
 import com.egm.stellio.shared.util.AuthContextModel
 import com.egm.stellio.shared.util.ErrorMessages.Entity.ATTRIBUTE_TYPE_MISMATCH_MESSAGE
+import com.egm.stellio.shared.util.ErrorMessages.Entity.NGSI_LD_NULL_NOT_ALLOWED_IN_DATASET_ID_MESSAGE
 import com.egm.stellio.shared.util.ErrorMessages.Entity.NGSI_LD_NULL_NOT_ALLOWED_MESSAGE
 import com.egm.stellio.shared.util.ErrorMessages.Entity.NOT_IMPLEMENTED_PARTIAL_ATTRIBUTE_MESSAGE
 import com.egm.stellio.shared.util.ErrorMessages.Entity.attributeWithDatasetIdNotFoundMessage
@@ -716,6 +718,9 @@ class EntityAttributeService(
         logger.debug("Partial updating attribute {} in entity {}", attributeName, entityId)
 
         val datasetId = attributeValues.getDatasetId()
+        ensure(datasetId.toString() != NGSILD_NULL) {
+            BadRequestDataException(NGSI_LD_NULL_NOT_ALLOWED_IN_DATASET_ID_MESSAGE)
+        }
         val currentAttribute = getForEntityAndAttribute(entityId, attributeName, datasetId).fold({ null }, { it })
         val attributeOperationResult =
             if (currentAttribute == null || currentAttribute.deletedAt != null) {

--- a/search-service/src/main/kotlin/com/egm/stellio/search/entity/service/EntityAttributeService.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/entity/service/EntityAttributeService.kt
@@ -68,6 +68,7 @@ import com.egm.stellio.shared.model.isAttributeOfType
 import com.egm.stellio.shared.model.toNgsiLdEntity
 import com.egm.stellio.shared.util.AuthContextModel
 import com.egm.stellio.shared.util.ErrorMessages.Entity.ATTRIBUTE_TYPE_MISMATCH_MESSAGE
+import com.egm.stellio.shared.util.ErrorMessages.Entity.NGSI_LD_NULL_NOT_ALLOWED_MESSAGE
 import com.egm.stellio.shared.util.ErrorMessages.Entity.NOT_IMPLEMENTED_PARTIAL_ATTRIBUTE_MESSAGE
 import com.egm.stellio.shared.util.ErrorMessages.Entity.attributeWithDatasetIdNotFoundMessage
 import com.egm.stellio.shared.util.ErrorMessages.Entity.entityNotFoundMessage
@@ -192,13 +193,16 @@ class EntityAttributeService(
                     attributeMetadata.datasetId
                 )!!
 
-                addOrReplaceAttribute(
-                    ngsiLdEntity.id,
-                    expandedAttributeName,
-                    attributeMetadata,
-                    createdAt,
-                    attributePayload
-                ).bind()
+                if (hasNgsiLdNullValue(attributePayload, attributeMetadata.type))
+                    BadRequestDataException(NGSI_LD_NULL_NOT_ALLOWED_MESSAGE).left().bind()
+                else
+                    addOrReplaceAttribute(
+                        ngsiLdEntity.id,
+                        expandedAttributeName,
+                        attributeMetadata,
+                        createdAt,
+                        attributePayload
+                    ).bind()
             }
     }
 
@@ -281,7 +285,7 @@ class EntityAttributeService(
             observedAt
         )
         val (jsonTargetObject, updatedAttributeInstance) =
-            mergePatch(attribute.payload.toExpandedAttributeInstance(), processedAttributePayload)
+            mergePatch(attribute.payload.toExpandedAttributeInstance(), processedAttributePayload).bind()
         val value = getValueFromPartialAttributePayload(attribute, updatedAttributeInstance).bind()
         update(attribute.id, processedAttributeMetadata.valueType, mergedAt, jsonTargetObject).bind()
 
@@ -641,7 +645,9 @@ class EntityAttributeService(
                 ngsiLdAttributeInstance.datasetId
             )!!
 
-            if (disallowOverwrite && currentAttribute != null && currentAttribute.deletedAt == null) {
+            if (hasNgsiLdNullValue(attributePayload, attributeMetadata.type)) {
+                BadRequestDataException(NGSI_LD_NULL_NOT_ALLOWED_MESSAGE).left().bind()
+            } else if (disallowOverwrite && currentAttribute != null && currentAttribute.deletedAt == null) {
                 FailedAttributeOperationResult(
                     ngsiLdAttribute.name,
                     ngsiLdAttributeInstance.datasetId,
@@ -751,7 +757,7 @@ class EntityAttributeService(
             }
         }
         val (jsonTargetObject, updatedAttributeInstance) =
-            partialUpdatePatch(attribute.payload.toExpandedAttributeInstance(), attributeValues)
+            partialUpdatePatch(attribute.payload.toExpandedAttributeInstance(), attributeValues).bind()
         val value = getValueFromPartialAttributePayload(attribute, updatedAttributeInstance).bind()
         val attributeValueType = guessAttributeValueType(attribute.attributeType, updatedAttributeInstance).bind()
         update(attribute.id, attributeValueType, modifiedAt, jsonTargetObject).bind()
@@ -834,7 +840,11 @@ class EntityAttributeService(
                 ngsiLdAttributeInstance.datasetId
             )!!
 
-            if (currentAttribute == null || currentAttribute.deletedAt != null)
+            val isNull = hasNgsiLdNullValue(attributePayload, attributeMetadata.type)
+
+            if (isNull && (currentAttribute == null || currentAttribute.deletedAt != null))
+                null
+            else if (currentAttribute == null || currentAttribute.deletedAt != null)
                 addOrReplaceAttribute(
                     entityUri,
                     ngsiLdAttribute.name,
@@ -849,7 +859,7 @@ class EntityAttributeService(
                         attributePayload
                     )
                 }.bind()
-            else if (hasNgsiLdNullValue(attributePayload, currentAttribute.attributeType))
+            else if (isNull)
                 deleteAttribute(
                     entityUri,
                     ngsiLdAttribute.name,
@@ -865,7 +875,7 @@ class EntityAttributeService(
                     observedAt,
                     attributePayload
                 ).bind()
-        }
+        }.filterNotNull()
     }.fold({ it.left() }, { it.right() })
 
     @Transactional
@@ -888,6 +898,8 @@ class EntityAttributeService(
                     OperationStatus.FAILED,
                     "Unknown attribute $attributeName with datasetId $datasetId in entity $entityId"
                 )
+            } else if (hasNgsiLdNullValue(expandedAttribute.second.first(), attributeMetadata.type)) {
+                BadRequestDataException(NGSI_LD_NULL_NOT_ALLOWED_MESSAGE).left().bind()
             } else {
                 addOrReplaceAttribute(
                     entityId,

--- a/search-service/src/main/kotlin/com/egm/stellio/search/entity/util/AttributeUtils.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/entity/util/AttributeUtils.kt
@@ -272,7 +272,7 @@ fun mergePatch(
             isNgsiLdNullDatasetId(attrName, attrValue) ->
                 raise(BadRequestDataException(NGSI_LD_NULL_NOT_ALLOWED_IN_DATASET_ID_MESSAGE))
             attrName == NGSILD_LANGUAGEPROPERTY_LANGUAGEMAP ->
-                target[attrName] = mergeLanguageMap(source, attrValue as List<Map<String, String>>)
+                target[attrName] = mergeLanguageMap(source, attrValue as ExpandedLanguageMapValue)
             isNgsiLdNullSubAttribute(attrValue) || isNgsiLdNullValue(attrValue) ->
                 target.remove(attrName)
             !source.containsKey(attrName) ->

--- a/search-service/src/main/kotlin/com/egm/stellio/search/entity/util/AttributeUtils.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/entity/util/AttributeUtils.kt
@@ -13,6 +13,7 @@ import com.egm.stellio.search.entity.model.AttributeMetadata
 import com.egm.stellio.shared.model.APIException
 import com.egm.stellio.shared.model.BadRequestDataException
 import com.egm.stellio.shared.model.ExpandedAttributeInstance
+import com.egm.stellio.shared.model.ExpandedTerm
 import com.egm.stellio.shared.model.JSONLD_ID_KW
 import com.egm.stellio.shared.model.JSONLD_LANGUAGE_KW
 import com.egm.stellio.shared.model.JSONLD_TYPE_KW
@@ -21,7 +22,6 @@ import com.egm.stellio.shared.model.NGSILD_DATASET_ID_IRI
 import com.egm.stellio.shared.model.NGSILD_JSONPROPERTY_JSON
 import com.egm.stellio.shared.model.NGSILD_LANGUAGEPROPERTY_LANGUAGEMAP
 import com.egm.stellio.shared.model.NGSILD_NULL
-import com.egm.stellio.shared.model.NGSILD_PREFIX
 import com.egm.stellio.shared.model.NGSILD_PROPERTY_VALUE
 import com.egm.stellio.shared.model.NGSILD_VOCABPROPERTY_VOCAB
 import com.egm.stellio.shared.model.NgsiLdAttributeInstance
@@ -166,27 +166,27 @@ fun guessRelationshipValueType(
             Pair(Attribute.AttributeValueType.ARRAY, Triple(objectId.ids.asJsonB(), null, null))
     }
 
-private fun isNgsiLdNullSubAttribute(attrValue: Any): Boolean {
-    val instance = (attrValue as? List<*>)?.firstOrNull() as? ExpandedAttributeInstance ?: return false
+private fun isNgsiLdNullSubAttribute(attrValue: List<Any>): Boolean {
+    val instance = attrValue.firstOrNull() as? ExpandedAttributeInstance ?: return false
     val typeUri = (instance[JSONLD_TYPE_KW] as? List<*>)?.firstOrNull() as? String ?: return false
-    val attributeType = AttributeType.entries.find { typeUri == "$NGSILD_PREFIX${it.name}" } ?: return false
+    val attributeType = AttributeType.entries.find { typeUri == it.toExpandedName() } ?: return false
     return hasNgsiLdNullValue(instance, attributeType)
 }
 
-private fun isNgsiLdNullId(attrValue: Any): Boolean =
-    ((attrValue as? List<*>)?.firstOrNull() as? Map<*, *>)?.get(JSONLD_ID_KW) == NGSILD_NULL
+private fun isNgsiLdNullDatasetId(attrName: ExpandedTerm, attrValue: List<Any>): Boolean =
+    attrName == NGSILD_DATASET_ID_IRI &&
+        (attrValue.firstOrNull() as? Map<*, *>)?.get(JSONLD_ID_KW) == NGSILD_NULL
 
-private fun isNgsiLdNullValue(attrValue: Any): Boolean =
-    ((attrValue as? List<*>)?.firstOrNull() as? Map<*, *>)?.get(JSONLD_VALUE_KW) == NGSILD_NULL
+private fun isNgsiLdNullValue(attrValue: List<Any>): Boolean =
+    (attrValue.firstOrNull() as? Map<*, *>)?.get(JSONLD_VALUE_KW) == NGSILD_NULL
 
 private fun mergeLanguageMap(
     source: ExpandedAttributeInstance,
-    attrName: String,
-    attrValue: List<Any>
+    updatedLanguageMap: List<Map<String, String>>
 ): List<Any> {
-    val sourceLangEntries = source[attrName] as List<Map<String, String>>
+    val sourceLangEntries = source[NGSILD_LANGUAGEPROPERTY_LANGUAGEMAP] as List<Map<String, String>>
     val targetLangEntries = sourceLangEntries.toMutableList()
-    (attrValue as List<Map<String, String>>).forEach { langEntry ->
+    updatedLanguageMap.forEach { langEntry ->
         targetLangEntries.removeIf { it[JSONLD_LANGUAGE_KW] == langEntry[JSONLD_LANGUAGE_KW] }
         if (langEntry[JSONLD_VALUE_KW] != NGSILD_NULL)
             targetLangEntries.add(langEntry)
@@ -202,21 +202,22 @@ private fun mergeLanguageMap(
  * - Property with object value: expanded as nested JSON-LD with IRI keys — null keys are top-level entries whose
  *   single expanded value is `[{"@value": "urn:ngsi-ld:null"}]`
  */
-private fun applyNgsiLdNullRemoval(merged: Map<String, Any>, update: Any): Map<String, Any> {
-    val updateMap = update as? Map<*, *> ?: return merged
-
-    val jsonContent = updateMap[JSONLD_VALUE_KW] as? Map<String, Any>
+private fun applyNgsiLdNullRemoval(merged: Map<String, Any>, update: Map<String, Any>): Map<String, Any> {
+    val jsonContent = update[JSONLD_VALUE_KW] as? Map<String, Any>
     if (jsonContent != null) {
         val nullKeys = jsonContent.filter { (_, v) -> v == NGSILD_NULL }.keys
         val mergedContent = merged[JSONLD_VALUE_KW] as? Map<String, Any>
+
         return if (nullKeys.isEmpty() || mergedContent == null) merged
         else merged + (JSONLD_VALUE_KW to mergedContent.filterKeys { it !in nullKeys })
-    }
+    } else {
+        val nullKeys = update.filter { (_, v) ->
+            (v as? List<*>)?.singleOrNull()?.let { it as? Map<*, *> }?.get(JSONLD_VALUE_KW) == NGSILD_NULL
+        }.keys
 
-    val nullKeys = updateMap.filter { (_, v) ->
-        (v as? List<*>)?.singleOrNull()?.let { it as? Map<*, *> }?.get(JSONLD_VALUE_KW) == NGSILD_NULL
-    }.keys
-    return if (nullKeys.isEmpty()) merged else merged.filterKeys { it !in nullKeys }
+        return if (nullKeys.isEmpty()) merged
+        else merged.filterKeys { it !in nullKeys }
+    }
 }
 
 /**
@@ -245,7 +246,7 @@ fun partialUpdatePatch(
     val target = source.toMutableMap()
     update.forEach { (attrName, attrValue) ->
         when {
-            attrName == NGSILD_DATASET_ID_IRI && isNgsiLdNullId(attrValue) ->
+            isNgsiLdNullDatasetId(attrName, attrValue) ->
                 raise(BadRequestDataException(NGSI_LD_NULL_NOT_ALLOWED_IN_DATASET_ID_MESSAGE))
             isNgsiLdNullSubAttribute(attrValue) || isNgsiLdNullValue(attrValue) ->
                 target.remove(attrName)
@@ -262,10 +263,10 @@ fun mergePatch(
     val target = source.toMutableMap()
     update.forEach { (attrName, attrValue) ->
         when {
-            attrName == NGSILD_DATASET_ID_IRI && isNgsiLdNullId(attrValue) ->
+            isNgsiLdNullDatasetId(attrName, attrValue) ->
                 raise(BadRequestDataException(NGSI_LD_NULL_NOT_ALLOWED_IN_DATASET_ID_MESSAGE))
-            listOf(NGSILD_LANGUAGEPROPERTY_LANGUAGEMAP).contains(attrName) ->
-                target[attrName] = mergeLanguageMap(source, attrName, attrValue)
+            attrName == NGSILD_LANGUAGEPROPERTY_LANGUAGEMAP ->
+                target[attrName] = mergeLanguageMap(source, attrValue as List<Map<String, String>>)
             isNgsiLdNullSubAttribute(attrValue) || isNgsiLdNullValue(attrValue) ->
                 target.remove(attrName)
             !source.containsKey(attrName) ->
@@ -286,7 +287,7 @@ fun mergePatch(
                     ).deserializeAsMap()
                     target[attrName] = listOf(
                         if (attrName == NGSILD_JSONPROPERTY_JSON || attrName == NGSILD_PROPERTY_VALUE)
-                            applyNgsiLdNullRemoval(mergedElement, attrValue[0])
+                            applyNgsiLdNullRemoval(mergedElement, attrValue[0] as Map<String, Any>)
                         else
                             mergedElement
                     )

--- a/search-service/src/main/kotlin/com/egm/stellio/search/entity/util/AttributeUtils.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/entity/util/AttributeUtils.kt
@@ -13,10 +13,15 @@ import com.egm.stellio.search.entity.model.AttributeMetadata
 import com.egm.stellio.shared.model.APIException
 import com.egm.stellio.shared.model.BadRequestDataException
 import com.egm.stellio.shared.model.ExpandedAttributeInstance
+import com.egm.stellio.shared.model.JSONLD_ID_KW
 import com.egm.stellio.shared.model.JSONLD_LANGUAGE_KW
+import com.egm.stellio.shared.model.JSONLD_TYPE_KW
+import com.egm.stellio.shared.model.JSONLD_VALUE_KW
+import com.egm.stellio.shared.model.NGSILD_DATASET_ID_IRI
 import com.egm.stellio.shared.model.NGSILD_JSONPROPERTY_JSON
 import com.egm.stellio.shared.model.NGSILD_LANGUAGEPROPERTY_LANGUAGEMAP
 import com.egm.stellio.shared.model.NGSILD_NULL
+import com.egm.stellio.shared.model.NGSILD_PREFIX
 import com.egm.stellio.shared.model.NGSILD_PROPERTY_VALUE
 import com.egm.stellio.shared.model.NGSILD_VOCABPROPERTY_VOCAB
 import com.egm.stellio.shared.model.NgsiLdAttributeInstance
@@ -33,6 +38,8 @@ import com.egm.stellio.shared.model.getMemberValue
 import com.egm.stellio.shared.model.getPropertyValue
 import com.egm.stellio.shared.model.getRelationshipId
 import com.egm.stellio.shared.model.getRelationshipObjects
+import com.egm.stellio.shared.util.ErrorMessages.Entity.NGSI_LD_NULL_NOT_ALLOWED_IN_DATASET_ID_MEMBER
+import com.egm.stellio.shared.util.ErrorMessages.Entity.NGSI_LD_NULL_NOT_ALLOWED_IN_TYPE_MEMBER
 import com.egm.stellio.shared.util.ErrorMessages.Entity.attributeCannotGetValueMessage
 import com.egm.stellio.shared.util.JsonLdUtils
 import com.egm.stellio.shared.util.JsonUtils
@@ -160,6 +167,62 @@ fun guessRelationshipValueType(
             Pair(Attribute.AttributeValueType.ARRAY, Triple(objectId.ids.asJsonB(), null, null))
     }
 
+private fun isNgsiLdNullType(attrValue: Any): Boolean =
+    (attrValue as? List<*>)?.contains(NGSILD_NULL) == true
+
+private fun isNgsiLdNullSubAttribute(attrValue: Any): Boolean {
+    val instance = (attrValue as? List<*>)?.firstOrNull() as? ExpandedAttributeInstance ?: return false
+    val typeUri = (instance[JSONLD_TYPE_KW] as? List<*>)?.firstOrNull() as? String ?: return false
+    val attributeType = AttributeType.entries.find { typeUri == "$NGSILD_PREFIX${it.name}" } ?: return false
+    return hasNgsiLdNullValue(instance, attributeType)
+}
+
+private fun isNgsiLdNullId(attrValue: Any): Boolean =
+    ((attrValue as? List<*>)?.firstOrNull() as? Map<*, *>)?.get(JSONLD_ID_KW) == NGSILD_NULL
+
+private fun isNgsiLdNullValue(attrValue: Any): Boolean =
+    ((attrValue as? List<*>)?.firstOrNull() as? Map<*, *>)?.get(JSONLD_VALUE_KW) == NGSILD_NULL
+
+private fun mergeLanguageMap(
+    source: ExpandedAttributeInstance,
+    attrName: String,
+    attrValue: List<Any>
+): List<Any> {
+    val sourceLangEntries = source[attrName] as List<Map<String, String>>
+    val targetLangEntries = sourceLangEntries.toMutableList()
+    (attrValue as List<Map<String, String>>).forEach { langEntry ->
+        targetLangEntries.removeIf { it[JSONLD_LANGUAGE_KW] == langEntry[JSONLD_LANGUAGE_KW] }
+        if (langEntry[JSONLD_VALUE_KW] != NGSILD_NULL)
+            targetLangEntries.add(langEntry)
+    }
+    return targetLangEntries
+}
+
+/**
+ * Removes from the merged map any keys that have an NGSI-LD Null value in the update.
+ *
+ * Two representations are handled:
+ * - JsonProperty: value is `{"@value": {...raw JSON...}, "@type": "@json"}` — null keys are inside the @value map
+ * - Property with object value: expanded as nested JSON-LD with IRI keys — null keys are top-level entries whose
+ *   single expanded value is `[{"@value": "urn:ngsi-ld:null"}]`
+ */
+private fun applyNgsiLdNullRemoval(merged: Map<String, Any>, update: Any): Map<String, Any> {
+    val updateMap = update as? Map<*, *> ?: return merged
+
+    val jsonContent = updateMap[JSONLD_VALUE_KW] as? Map<String, Any>
+    if (jsonContent != null) {
+        val nullKeys = jsonContent.filter { (_, v) -> v == NGSILD_NULL }.keys
+        val mergedContent = merged[JSONLD_VALUE_KW] as? Map<String, Any>
+        return if (nullKeys.isEmpty() || mergedContent == null) merged
+        else merged + (JSONLD_VALUE_KW to mergedContent.filterKeys { it !in nullKeys })
+    }
+
+    val nullKeys = updateMap.filter { (_, v) ->
+        (v as? List<*>)?.singleOrNull()?.let { it as? Map<*, *> }?.get(JSONLD_VALUE_KW) == NGSILD_NULL
+    }.keys
+    return if (nullKeys.isEmpty()) merged else merged.filterKeys { it !in nullKeys }
+}
+
 /**
  * Returns whether the expanded attribute instance holds a NGSI-LD Null value
  */
@@ -182,54 +245,63 @@ fun Json.toExpandedAttributeInstance(): ExpandedAttributeInstance =
 fun partialUpdatePatch(
     source: ExpandedAttributeInstance,
     update: ExpandedAttributeInstance
-): Pair<String, ExpandedAttributeInstance> {
-    val target = source.plus(update)
-    return Pair(JsonUtils.serializeObject(target), target)
+): Either<APIException, Pair<String, ExpandedAttributeInstance>> = either {
+    val target = source.toMutableMap()
+    update.forEach { (attrName, attrValue) ->
+        when {
+            attrName == JSONLD_TYPE_KW && isNgsiLdNullType(attrValue) ->
+                raise(BadRequestDataException(NGSI_LD_NULL_NOT_ALLOWED_IN_TYPE_MEMBER))
+            attrName == NGSILD_DATASET_ID_IRI && isNgsiLdNullId(attrValue) ->
+                raise(BadRequestDataException(NGSI_LD_NULL_NOT_ALLOWED_IN_DATASET_ID_MEMBER))
+            isNgsiLdNullSubAttribute(attrValue) || isNgsiLdNullValue(attrValue) ->
+                target.remove(attrName)
+            else -> target[attrName] = attrValue
+        }
+    }
+    Pair(JsonUtils.serializeObject(target), target)
 }
 
 fun mergePatch(
     source: ExpandedAttributeInstance,
     update: ExpandedAttributeInstance
-): Pair<String, ExpandedAttributeInstance> {
+): Either<APIException, Pair<String, ExpandedAttributeInstance>> = either {
     val target = source.toMutableMap()
     update.forEach { (attrName, attrValue) ->
-        if (!source.containsKey(attrName)) {
-            target[attrName] = attrValue
-        } else if (
+        when {
+            attrName == JSONLD_TYPE_KW && isNgsiLdNullType(attrValue) ->
+                raise(BadRequestDataException(NGSI_LD_NULL_NOT_ALLOWED_IN_TYPE_MEMBER))
+            attrName == NGSILD_DATASET_ID_IRI && isNgsiLdNullId(attrValue) ->
+                raise(BadRequestDataException(NGSI_LD_NULL_NOT_ALLOWED_IN_DATASET_ID_MEMBER))
+            listOf(NGSILD_LANGUAGEPROPERTY_LANGUAGEMAP).contains(attrName) ->
+                target[attrName] = mergeLanguageMap(source, attrName, attrValue)
+            isNgsiLdNullSubAttribute(attrValue) || isNgsiLdNullValue(attrValue) ->
+                target.remove(attrName)
+            !source.containsKey(attrName) ->
+                target[attrName] = attrValue
             listOf(
                 NGSILD_JSONPROPERTY_JSON,
                 NGSILD_VOCABPROPERTY_VOCAB,
                 NGSILD_PROPERTY_VALUE
-            ).contains(attrName)
-        ) {
-            if (attrValue.size > 1) {
-                // a Property holding an array of value or a JsonPropery holding an array of JSON objects
-                // cannot be safely merged patch, so copy the whole value from the update
-                target[attrName] = attrValue
-            } else {
-                target[attrName] = listOf(
-                    JsonMerger().merge(
+            ).contains(attrName) -> {
+                if (attrValue.size > 1) {
+                    // a Property holding an array of value or a JsonProperty holding an array of JSON objects
+                    // cannot be safely merged patch, so copy the whole value from the update
+                    target[attrName] = attrValue
+                } else {
+                    val mergedElement = JsonMerger().merge(
                         JsonUtils.serializeObject(source[attrName]!![0]),
                         JsonUtils.serializeObject(attrValue[0])
                     ).deserializeAsMap()
-                )
-            }
-        } else if (listOf(NGSILD_LANGUAGEPROPERTY_LANGUAGEMAP).contains(attrName)) {
-            val sourceLangEntries = source[attrName] as List<Map<String, String>>
-            val targetLangEntries = sourceLangEntries.toMutableList()
-            (attrValue as List<Map<String, String>>).forEach { langEntry ->
-                // remove any previously existing entry for this language
-                targetLangEntries.removeIf {
-                    it[JSONLD_LANGUAGE_KW] == langEntry[JSONLD_LANGUAGE_KW]
+                    target[attrName] = listOf(
+                        if (attrName == NGSILD_JSONPROPERTY_JSON || attrName == NGSILD_PROPERTY_VALUE)
+                            applyNgsiLdNullRemoval(mergedElement, attrValue[0])
+                        else
+                            mergedElement
+                    )
                 }
-                targetLangEntries.add(langEntry)
             }
-
-            target[attrName] = targetLangEntries
-        } else {
-            target[attrName] = attrValue
+            else -> target[attrName] = attrValue
         }
     }
-
-    return Pair(JsonUtils.serializeObject(target), target)
+    Pair(JsonUtils.serializeObject(target), target)
 }

--- a/search-service/src/main/kotlin/com/egm/stellio/search/entity/util/AttributeUtils.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/entity/util/AttributeUtils.kt
@@ -13,6 +13,7 @@ import com.egm.stellio.search.entity.model.AttributeMetadata
 import com.egm.stellio.shared.model.APIException
 import com.egm.stellio.shared.model.BadRequestDataException
 import com.egm.stellio.shared.model.ExpandedAttributeInstance
+import com.egm.stellio.shared.model.ExpandedLanguageMapValue
 import com.egm.stellio.shared.model.ExpandedTerm
 import com.egm.stellio.shared.model.JSONLD_ID_KW
 import com.egm.stellio.shared.model.JSONLD_LANGUAGE_KW
@@ -182,11 +183,11 @@ private fun isNgsiLdNullValue(attrValue: List<Any>): Boolean =
 
 private fun mergeLanguageMap(
     source: ExpandedAttributeInstance,
-    updatedLanguageMap: List<Map<String, String>>
+    updateLanguageMap: ExpandedLanguageMapValue
 ): List<Any> {
-    val sourceLangEntries = source[NGSILD_LANGUAGEPROPERTY_LANGUAGEMAP] as List<Map<String, String>>
+    val sourceLangEntries = source[NGSILD_LANGUAGEPROPERTY_LANGUAGEMAP] as ExpandedLanguageMapValue
     val targetLangEntries = sourceLangEntries.toMutableList()
-    updatedLanguageMap.forEach { langEntry ->
+    updateLanguageMap.forEach { langEntry ->
         targetLangEntries.removeIf { it[JSONLD_LANGUAGE_KW] == langEntry[JSONLD_LANGUAGE_KW] }
         if (langEntry[JSONLD_VALUE_KW] != NGSILD_NULL)
             targetLangEntries.add(langEntry)
@@ -202,23 +203,28 @@ private fun mergeLanguageMap(
  * - Property with object value: expanded as nested JSON-LD with IRI keys — null keys are top-level entries whose
  *   single expanded value is `[{"@value": "urn:ngsi-ld:null"}]`
  */
-private fun applyNgsiLdNullRemoval(merged: Map<String, Any>, update: Map<String, Any>): Map<String, Any> {
-    val jsonContent = update[JSONLD_VALUE_KW] as? Map<String, Any>
-    if (jsonContent != null) {
+private fun applyNgsiLdNullRemoval(
+    attrName: String,
+    merged: Map<String, Any>,
+    update: Map<String, Any>
+): Map<String, Any> =
+    if (attrName == NGSILD_JSONPROPERTY_JSON) {
+        val jsonContent = update[JSONLD_VALUE_KW] as Map<String, Any>
         val nullKeys = jsonContent.filter { (_, v) -> v == NGSILD_NULL }.keys
         val mergedContent = merged[JSONLD_VALUE_KW] as? Map<String, Any>
 
-        return if (nullKeys.isEmpty() || mergedContent == null) merged
+        if (nullKeys.isEmpty() || mergedContent == null) merged
         else merged + (JSONLD_VALUE_KW to mergedContent.filterKeys { it !in nullKeys })
-    } else {
+    }
+    // else branch covers Properties with object value
+    else {
         val nullKeys = update.filter { (_, v) ->
             (v as? List<*>)?.singleOrNull()?.let { it as? Map<*, *> }?.get(JSONLD_VALUE_KW) == NGSILD_NULL
         }.keys
 
-        return if (nullKeys.isEmpty()) merged
+        if (nullKeys.isEmpty()) merged
         else merged.filterKeys { it !in nullKeys }
     }
-}
 
 /**
  * Returns whether the expanded attribute instance holds a NGSI-LD Null value
@@ -277,8 +283,8 @@ fun mergePatch(
                 NGSILD_PROPERTY_VALUE
             ).contains(attrName) -> {
                 if (attrValue.size > 1) {
-                    // a Property holding an array of value or a JsonProperty holding an array of JSON objects
-                    // cannot be safely merged patch, so copy the whole value from the update
+                    // a Property or VocabProperty holding an array of values or a JsonProperty holding an array of
+                    // JSON objects cannot be safely merged patch, so copy the whole value from the update
                     target[attrName] = attrValue
                 } else {
                     val mergedElement = JsonMerger().merge(
@@ -287,7 +293,7 @@ fun mergePatch(
                     ).deserializeAsMap()
                     target[attrName] = listOf(
                         if (attrName == NGSILD_JSONPROPERTY_JSON || attrName == NGSILD_PROPERTY_VALUE)
-                            applyNgsiLdNullRemoval(mergedElement, attrValue[0] as Map<String, Any>)
+                            applyNgsiLdNullRemoval(attrName, mergedElement, attrValue[0] as ExpandedAttributeInstance)
                         else
                             mergedElement
                     )

--- a/search-service/src/main/kotlin/com/egm/stellio/search/entity/util/AttributeUtils.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/entity/util/AttributeUtils.kt
@@ -38,8 +38,7 @@ import com.egm.stellio.shared.model.getMemberValue
 import com.egm.stellio.shared.model.getPropertyValue
 import com.egm.stellio.shared.model.getRelationshipId
 import com.egm.stellio.shared.model.getRelationshipObjects
-import com.egm.stellio.shared.util.ErrorMessages.Entity.NGSI_LD_NULL_NOT_ALLOWED_IN_DATASET_ID_MEMBER
-import com.egm.stellio.shared.util.ErrorMessages.Entity.NGSI_LD_NULL_NOT_ALLOWED_IN_TYPE_MEMBER
+import com.egm.stellio.shared.util.ErrorMessages.Entity.NGSI_LD_NULL_NOT_ALLOWED_IN_DATASET_ID_MESSAGE
 import com.egm.stellio.shared.util.ErrorMessages.Entity.attributeCannotGetValueMessage
 import com.egm.stellio.shared.util.JsonLdUtils
 import com.egm.stellio.shared.util.JsonUtils
@@ -167,9 +166,6 @@ fun guessRelationshipValueType(
             Pair(Attribute.AttributeValueType.ARRAY, Triple(objectId.ids.asJsonB(), null, null))
     }
 
-private fun isNgsiLdNullType(attrValue: Any): Boolean =
-    (attrValue as? List<*>)?.contains(NGSILD_NULL) == true
-
 private fun isNgsiLdNullSubAttribute(attrValue: Any): Boolean {
     val instance = (attrValue as? List<*>)?.firstOrNull() as? ExpandedAttributeInstance ?: return false
     val typeUri = (instance[JSONLD_TYPE_KW] as? List<*>)?.firstOrNull() as? String ?: return false
@@ -249,10 +245,8 @@ fun partialUpdatePatch(
     val target = source.toMutableMap()
     update.forEach { (attrName, attrValue) ->
         when {
-            attrName == JSONLD_TYPE_KW && isNgsiLdNullType(attrValue) ->
-                raise(BadRequestDataException(NGSI_LD_NULL_NOT_ALLOWED_IN_TYPE_MEMBER))
             attrName == NGSILD_DATASET_ID_IRI && isNgsiLdNullId(attrValue) ->
-                raise(BadRequestDataException(NGSI_LD_NULL_NOT_ALLOWED_IN_DATASET_ID_MEMBER))
+                raise(BadRequestDataException(NGSI_LD_NULL_NOT_ALLOWED_IN_DATASET_ID_MESSAGE))
             isNgsiLdNullSubAttribute(attrValue) || isNgsiLdNullValue(attrValue) ->
                 target.remove(attrName)
             else -> target[attrName] = attrValue
@@ -268,10 +262,8 @@ fun mergePatch(
     val target = source.toMutableMap()
     update.forEach { (attrName, attrValue) ->
         when {
-            attrName == JSONLD_TYPE_KW && isNgsiLdNullType(attrValue) ->
-                raise(BadRequestDataException(NGSI_LD_NULL_NOT_ALLOWED_IN_TYPE_MEMBER))
             attrName == NGSILD_DATASET_ID_IRI && isNgsiLdNullId(attrValue) ->
-                raise(BadRequestDataException(NGSI_LD_NULL_NOT_ALLOWED_IN_DATASET_ID_MEMBER))
+                raise(BadRequestDataException(NGSI_LD_NULL_NOT_ALLOWED_IN_DATASET_ID_MESSAGE))
             listOf(NGSILD_LANGUAGEPROPERTY_LANGUAGEMAP).contains(attrName) ->
                 target[attrName] = mergeLanguageMap(source, attrName, attrValue)
             isNgsiLdNullSubAttribute(attrValue) || isNgsiLdNullValue(attrValue) ->

--- a/search-service/src/test/kotlin/com/egm/stellio/search/entity/service/EntityAttributeServiceTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/entity/service/EntityAttributeServiceTests.kt
@@ -16,6 +16,7 @@ import com.egm.stellio.search.support.WithTimescaleContainer
 import com.egm.stellio.search.temporal.model.AttributeInstance
 import com.egm.stellio.search.temporal.service.AttributeInstanceService
 import com.egm.stellio.shared.WithMockCustomUser
+import com.egm.stellio.shared.model.BadRequestDataException
 import com.egm.stellio.shared.model.NGSILD_DEFAULT_VOCAB
 import com.egm.stellio.shared.model.NGSILD_NULL
 import com.egm.stellio.shared.model.ResourceNotFoundException
@@ -23,6 +24,7 @@ import com.egm.stellio.shared.model.toNgsiLdAttribute
 import com.egm.stellio.shared.model.toNgsiLdAttributes
 import com.egm.stellio.shared.util.APIC_COMPOUND_CONTEXTS
 import com.egm.stellio.shared.util.BEEHIVE_IRI
+import com.egm.stellio.shared.util.ErrorMessages.Entity.NGSI_LD_NULL_NOT_ALLOWED_MESSAGE
 import com.egm.stellio.shared.util.INCOMING_IRI
 import com.egm.stellio.shared.util.JsonLdUtils
 import com.egm.stellio.shared.util.JsonLdUtils.expandAttribute
@@ -309,6 +311,50 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
 
         val attributes = entityAttributeService.getAllForEntity("urn:ngsi-ld:BeeHive:TESTC".toUri())
         assertTrue(attributes.isEmpty())
+    }
+
+    @Test
+    fun `it should raise a BadRequestData error when creating property with a NGSI-LD Null value`() = runTest {
+        coEvery { attributeInstanceService.create(any()) } returns Unit.right()
+
+        val entityWithNullAttribute = """
+            {
+                "id": "urn:ngsi-ld:BeeHive:TESTC",
+                "type": "BeeHive",
+                "incoming": {
+                    "type": "Property",
+                    "value": "urn:ngsi-ld:null"
+                }
+            }
+        """.trimIndent()
+
+        entityAttributeService.createAttributes(entityWithNullAttribute, APIC_COMPOUND_CONTEXTS)
+            .shouldFail { exception ->
+                assertInstanceOf(BadRequestDataException::class.java, exception)
+                assertEquals(NGSI_LD_NULL_NOT_ALLOWED_MESSAGE, exception.message)
+            }
+    }
+
+    @Test
+    fun `it should raise a BadRequestData error when creating relationship with a NGSI-LD Null value`() = runTest {
+        coEvery { attributeInstanceService.create(any()) } returns Unit.right()
+
+        val entityWithNullAttribute = """
+            {
+                "id": "urn:ngsi-ld:BeeHive:TESTC",
+                "type": "BeeHive",
+                "incoming": {
+                    "type": "Relationship",
+                    "object": "urn:ngsi-ld:null"
+                }
+            }
+        """.trimIndent()
+
+        entityAttributeService.createAttributes(entityWithNullAttribute, APIC_COMPOUND_CONTEXTS)
+            .shouldFail { exception ->
+                assertInstanceOf(BadRequestDataException::class.java, exception)
+                assertEquals(NGSI_LD_NULL_NOT_ALLOWED_MESSAGE, exception.message)
+            }
     }
 
     @Test
@@ -870,6 +916,65 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
         ).shouldSucceedWith { operationResult ->
             assertInstanceOf(FailedAttributeOperationResult::class.java, operationResult)
             assertEquals(INCOMING_IRI, operationResult.attributeName)
+        }
+    }
+
+    @Test
+    fun `it should raise a BadRequestData error when replacing an attribute with a NGSI-LD Null value`() = runTest {
+        val rawEntity = loadSampleData()
+
+        coEvery { attributeInstanceService.create(any()) } returns Unit.right()
+
+        entityAttributeService.createAttributes(rawEntity, APIC_COMPOUND_CONTEXTS).shouldSucceed()
+
+        val nullAttribute = """
+            {
+                "type": "Property",
+                "value": "urn:ngsi-ld:null"
+            }
+        """.trimIndent()
+        val expandedAttribute = expandAttribute(INCOMING_IRI, nullAttribute, APIC_COMPOUND_CONTEXTS)
+        val ngsiLdAttribute = expandedAttribute.toNgsiLdAttribute().shouldSucceedAndResult()
+
+        entityAttributeService.replaceAttribute(
+            beehiveTestCId,
+            ngsiLdAttribute,
+            expandedAttribute,
+            ngsiLdDateTime()
+        ).shouldFail { exception ->
+            assertInstanceOf(BadRequestDataException::class.java, exception)
+            assertEquals(NGSI_LD_NULL_NOT_ALLOWED_MESSAGE, exception.message)
+        }
+    }
+
+    @Test
+    fun `it should raise a BadRequestData error when appending an attribute with a NGSI-LD Null value`() = runTest {
+        val rawEntity = loadSampleData()
+
+        coEvery { attributeInstanceService.create(any()) } returns Unit.right()
+
+        entityAttributeService.createAttributes(rawEntity, APIC_COMPOUND_CONTEXTS).shouldSucceed()
+
+        val nullAttribute = """
+            {
+                "incoming": {
+                    "type": "Property",
+                    "value": "urn:ngsi-ld:null"
+                }
+            }
+        """.trimIndent()
+        val expandedAttributes = JsonLdUtils.expandAttributes(nullAttribute, APIC_COMPOUND_CONTEXTS)
+        val ngsiLdAttributes = expandedAttributes.toMap().toNgsiLdAttributes().shouldSucceedAndResult()
+
+        entityAttributeService.appendAttributes(
+            beehiveTestCId,
+            ngsiLdAttributes,
+            expandedAttributes,
+            false,
+            ngsiLdDateTime()
+        ).shouldFail { exception ->
+            assertInstanceOf(BadRequestDataException::class.java, exception)
+            assertEquals(NGSI_LD_NULL_NOT_ALLOWED_MESSAGE, exception.message)
         }
     }
 

--- a/search-service/src/test/kotlin/com/egm/stellio/search/entity/service/EntityServiceTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/entity/service/EntityServiceTests.kt
@@ -17,6 +17,7 @@ import com.egm.stellio.search.support.gimmeSucceededAttributeOperationResult
 import com.egm.stellio.shared.WithMockCustomUser
 import com.egm.stellio.shared.model.AccessDeniedException
 import com.egm.stellio.shared.model.AlreadyExistsException
+import com.egm.stellio.shared.model.BadRequestDataException
 import com.egm.stellio.shared.model.CompactedAttributeInstances
 import com.egm.stellio.shared.model.JSONLD_ID_KW
 import com.egm.stellio.shared.model.JSONLD_TYPE_KW
@@ -28,6 +29,7 @@ import com.egm.stellio.shared.model.NGSILD_VALUE_TERM
 import com.egm.stellio.shared.model.ResourceNotFoundException
 import com.egm.stellio.shared.queryparameter.PaginationQuery
 import com.egm.stellio.shared.util.APIARY_IRI
+import com.egm.stellio.shared.util.APIC_COMPOUND_CONTEXT
 import com.egm.stellio.shared.util.APIC_COMPOUND_CONTEXTS
 import com.egm.stellio.shared.util.BEEHIVE_IRI
 import com.egm.stellio.shared.util.INCOMING_IRI
@@ -182,6 +184,26 @@ class EntityServiceTests : WithTimescaleContainer, WithKafkaContainer() {
             ngsiLdEntity,
             jsonLdEntity
         ).shouldFail { assertInstanceOf(AlreadyExistsException::class.java, it) }
+    }
+
+    @Test
+    fun `it should not create an entity if it contains an NGSI-LD Null value`() = runTest {
+        val (jsonLdEntity, ngsiLdEntity) = """
+            {
+                "id": "urn:ngsi-ld:Entity:01",
+                "type": "BeeHive",
+                "nullProp": {
+                    "type": "Property",
+                    "value": "urn:ngsi-ld:null"
+                },
+                "@context": "$APIC_COMPOUND_CONTEXT"
+            }
+        """.trimIndent().sampleDataToNgsiLdEntity().shouldSucceedAndResult()
+
+        entityService.createEntity(
+            ngsiLdEntity,
+            jsonLdEntity
+        ).shouldFail { assertInstanceOf(BadRequestDataException::class.java, it) }
     }
 
     @Test

--- a/search-service/src/test/kotlin/com/egm/stellio/search/entity/util/AttributeUtilsTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/entity/util/AttributeUtilsTests.kt
@@ -3,8 +3,7 @@ package com.egm.stellio.search.entity.util
 import com.egm.stellio.search.entity.model.Attribute
 import com.egm.stellio.search.entity.model.Attribute.AttributeType
 import com.egm.stellio.shared.model.BadRequestDataException
-import com.egm.stellio.shared.util.ErrorMessages.Entity.NGSI_LD_NULL_NOT_ALLOWED_IN_DATASET_ID_MEMBER
-import com.egm.stellio.shared.util.ErrorMessages.Entity.NGSI_LD_NULL_NOT_ALLOWED_IN_TYPE_MEMBER
+import com.egm.stellio.shared.util.ErrorMessages.Entity.NGSI_LD_NULL_NOT_ALLOWED_IN_DATASET_ID_MESSAGE
 import com.egm.stellio.shared.util.JsonLdUtils.expandAttribute
 import com.egm.stellio.shared.util.NGSILD_TEST_CORE_CONTEXTS
 import com.egm.stellio.shared.util.ngsiLdDateTime
@@ -265,39 +264,6 @@ class AttributeUtilsTests {
     }
 
     @Test
-    fun `partialUpdatePatch should raise a BadRequestData error when the type member value is NGSI-LD Null`() =
-        runTest {
-            val source = expandAttribute(
-                """
-                {
-                    "attribute": {
-                        "type": "Property",
-                        "value": 12.0
-                    }
-                }
-                """.trimIndent(),
-                NGSILD_TEST_CORE_CONTEXTS
-            ).second[0]
-
-            val update = expandAttribute(
-                """
-                {
-                    "attribute": {
-                        "type": "urn:ngsi-ld:null",
-                        "value": 12.0
-                    }
-                }
-                """.trimIndent(),
-                NGSILD_TEST_CORE_CONTEXTS
-            ).second[0]
-
-            partialUpdatePatch(source, update).shouldFail {
-                assertInstanceOf(BadRequestDataException::class.java, it)
-                assertEquals(NGSI_LD_NULL_NOT_ALLOWED_IN_TYPE_MEMBER, it.message)
-            }
-        }
-
-    @Test
     fun `partialUpdatePatch should raise a BadRequestData error when the datasetId member value is NGSI-LD Null`() =
         runTest {
             val source = expandAttribute(
@@ -327,7 +293,7 @@ class AttributeUtilsTests {
 
             partialUpdatePatch(source, update).shouldFail {
                 assertInstanceOf(BadRequestDataException::class.java, it)
-                assertEquals(NGSI_LD_NULL_NOT_ALLOWED_IN_DATASET_ID_MEMBER, it.message)
+                assertEquals(NGSI_LD_NULL_NOT_ALLOWED_IN_DATASET_ID_MESSAGE, it.message)
             }
         }
 
@@ -360,39 +326,7 @@ class AttributeUtilsTests {
 
         mergePatch(source, update).shouldFail {
             assertInstanceOf(BadRequestDataException::class.java, it)
-            assertEquals(NGSI_LD_NULL_NOT_ALLOWED_IN_DATASET_ID_MEMBER, it.message)
-        }
-    }
-
-    @Test
-    fun `mergePatch should raise a BadRequestData error when the type member value is NGSI-LD Null`() = runTest {
-        val source = expandAttribute(
-            """
-                {
-                    "attribute": {
-                        "type": "Property",
-                        "value": 12.0
-                    }
-                }
-            """.trimIndent(),
-            NGSILD_TEST_CORE_CONTEXTS
-        ).second[0]
-
-        val update = expandAttribute(
-            """
-                {
-                    "attribute": {
-                        "type": "urn:ngsi-ld:null",
-                        "value": 12.0
-                    }
-                }
-            """.trimIndent(),
-            NGSILD_TEST_CORE_CONTEXTS
-        ).second[0]
-
-        mergePatch(source, update).shouldFail {
-            assertInstanceOf(BadRequestDataException::class.java, it)
-            assertEquals(NGSI_LD_NULL_NOT_ALLOWED_IN_TYPE_MEMBER, it.message)
+            assertEquals(NGSI_LD_NULL_NOT_ALLOWED_IN_DATASET_ID_MESSAGE, it.message)
         }
     }
 }

--- a/search-service/src/test/kotlin/com/egm/stellio/search/entity/util/AttributeUtilsTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/entity/util/AttributeUtilsTests.kt
@@ -2,12 +2,17 @@ package com.egm.stellio.search.entity.util
 
 import com.egm.stellio.search.entity.model.Attribute
 import com.egm.stellio.search.entity.model.Attribute.AttributeType
+import com.egm.stellio.shared.model.BadRequestDataException
+import com.egm.stellio.shared.util.ErrorMessages.Entity.NGSI_LD_NULL_NOT_ALLOWED_IN_DATASET_ID_MEMBER
+import com.egm.stellio.shared.util.ErrorMessages.Entity.NGSI_LD_NULL_NOT_ALLOWED_IN_TYPE_MEMBER
 import com.egm.stellio.shared.util.JsonLdUtils.expandAttribute
 import com.egm.stellio.shared.util.NGSILD_TEST_CORE_CONTEXTS
 import com.egm.stellio.shared.util.ngsiLdDateTime
+import com.egm.stellio.shared.util.shouldFail
 import com.egm.stellio.shared.util.shouldSucceedAndResult
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.springframework.test.context.ActiveProfiles
@@ -257,5 +262,137 @@ class AttributeUtilsTests {
         ).second[0]
 
         assertTrue(hasNgsiLdNullValue(expandedProperty, AttributeType.Relationship))
+    }
+
+    @Test
+    fun `partialUpdatePatch should raise a BadRequestData error when the type member value is NGSI-LD Null`() =
+        runTest {
+            val source = expandAttribute(
+                """
+                {
+                    "attribute": {
+                        "type": "Property",
+                        "value": 12.0
+                    }
+                }
+                """.trimIndent(),
+                NGSILD_TEST_CORE_CONTEXTS
+            ).second[0]
+
+            val update = expandAttribute(
+                """
+                {
+                    "attribute": {
+                        "type": "urn:ngsi-ld:null",
+                        "value": 12.0
+                    }
+                }
+                """.trimIndent(),
+                NGSILD_TEST_CORE_CONTEXTS
+            ).second[0]
+
+            partialUpdatePatch(source, update).shouldFail {
+                assertInstanceOf(BadRequestDataException::class.java, it)
+                assertEquals(NGSI_LD_NULL_NOT_ALLOWED_IN_TYPE_MEMBER, it.message)
+            }
+        }
+
+    @Test
+    fun `partialUpdatePatch should raise a BadRequestData error when the datasetId member value is NGSI-LD Null`() =
+        runTest {
+            val source = expandAttribute(
+                """
+                {
+                    "attribute": {
+                        "type": "Property",
+                        "value": 12.0
+                    }
+                }
+                """.trimIndent(),
+                NGSILD_TEST_CORE_CONTEXTS
+            ).second[0]
+
+            val update = expandAttribute(
+                """
+                {
+                    "attribute": {
+                        "type": "Property",
+                        "value": 12.0,
+                        "datasetId": "urn:ngsi-ld:null"
+                    }
+                }
+                """.trimIndent(),
+                NGSILD_TEST_CORE_CONTEXTS
+            ).second[0]
+
+            partialUpdatePatch(source, update).shouldFail {
+                assertInstanceOf(BadRequestDataException::class.java, it)
+                assertEquals(NGSI_LD_NULL_NOT_ALLOWED_IN_DATASET_ID_MEMBER, it.message)
+            }
+        }
+
+    @Test
+    fun `mergePatch should raise a BadRequestData error when the datasetId member value is NGSI-LD Null`() = runTest {
+        val source = expandAttribute(
+            """
+                {
+                    "attribute": {
+                        "type": "Property",
+                        "value": 12.0
+                    }
+                }
+            """.trimIndent(),
+            NGSILD_TEST_CORE_CONTEXTS
+        ).second[0]
+
+        val update = expandAttribute(
+            """
+                {
+                    "attribute": {
+                        "type": "Property",
+                        "value": 12.0,
+                        "datasetId": "urn:ngsi-ld:null"
+                    }
+                }
+            """.trimIndent(),
+            NGSILD_TEST_CORE_CONTEXTS
+        ).second[0]
+
+        mergePatch(source, update).shouldFail {
+            assertInstanceOf(BadRequestDataException::class.java, it)
+            assertEquals(NGSI_LD_NULL_NOT_ALLOWED_IN_DATASET_ID_MEMBER, it.message)
+        }
+    }
+
+    @Test
+    fun `mergePatch should raise a BadRequestData error when the type member value is NGSI-LD Null`() = runTest {
+        val source = expandAttribute(
+            """
+                {
+                    "attribute": {
+                        "type": "Property",
+                        "value": 12.0
+                    }
+                }
+            """.trimIndent(),
+            NGSILD_TEST_CORE_CONTEXTS
+        ).second[0]
+
+        val update = expandAttribute(
+            """
+                {
+                    "attribute": {
+                        "type": "urn:ngsi-ld:null",
+                        "value": 12.0
+                    }
+                }
+            """.trimIndent(),
+            NGSILD_TEST_CORE_CONTEXTS
+        ).second[0]
+
+        mergePatch(source, update).shouldFail {
+            assertInstanceOf(BadRequestDataException::class.java, it)
+            assertEquals(NGSI_LD_NULL_NOT_ALLOWED_IN_TYPE_MEMBER, it.message)
+        }
     }
 }

--- a/search-service/src/test/kotlin/com/egm/stellio/search/entity/util/PatchAttributeTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/entity/util/PatchAttributeTests.kt
@@ -4,6 +4,7 @@ import com.egm.stellio.shared.util.JsonLdUtils.expandAttribute
 import com.egm.stellio.shared.util.JsonUtils.serializeObject
 import com.egm.stellio.shared.util.NGSILD_TEST_CORE_CONTEXTS
 import com.egm.stellio.shared.util.assertJsonPayloadsAreEqual
+import com.egm.stellio.shared.util.shouldSucceedAndResult
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
@@ -106,6 +107,68 @@ class PatchAttributeTests {
                         "attribute": {
                             "type": "VocabProperty",
                             "vocab": "egm"
+                        }
+                    }
+                    """.trimIndent()
+                ),
+                Arguments.of(
+                    """
+                    {
+                        "attribute": {
+                            "type": "Property",
+                            "value": 12.5,
+                            "subAttribute": {
+                                "type": "Property",
+                                "value": "someValue"
+                            }
+                        }
+                    }
+                    """.trimIndent(),
+                    """
+                    {
+                        "attribute": {
+                            "type": "Property",
+                            "value": 12.5,
+                            "subAttribute": {
+                                "type": "Property",
+                                "value": "urn:ngsi-ld:null"
+                            }
+                        }
+                    }
+                    """.trimIndent(),
+                    """
+                    {
+                        "attribute": {
+                            "type": "Property",
+                            "value": 12.5
+                        }
+                    }
+                    """.trimIndent()
+                ),
+                Arguments.of(
+                    """
+                    {
+                        "attribute": {
+                            "type": "Property",
+                            "value": 12.5,
+                            "unitCode": "GRM"
+                        }
+                    }
+                    """.trimIndent(),
+                    """
+                    {
+                        "attribute": {
+                            "type": "Property",
+                            "value": 12.5,
+                            "unitCode": "urn:ngsi-ld:null"
+                        }
+                    }
+                    """.trimIndent(),
+                    """
+                    {
+                        "attribute": {
+                            "type": "Property",
+                            "value": 12.5
                         }
                     }
                     """.trimIndent()
@@ -265,6 +328,58 @@ class PatchAttributeTests {
                 Arguments.of(
                     """
                     {
+                        "attribute": {
+                            "type": "LanguageProperty",
+                            "languageMap": { "en": "train", "fr": "train", "@none": "locomotive" }
+                        }
+                    }
+                    """.trimIndent(),
+                    """
+                    {
+                        "attribute": {
+                            "type": "LanguageProperty",
+                            "languageMap": { "@none": "urn:ngsi-ld:null", "fr": "TGV" }
+                        }
+                    }
+                    """.trimIndent(),
+                    """
+                    {
+                        "attribute": {
+                            "type": "LanguageProperty",
+                            "languageMap": { "en": "train", "fr": "TGV" }
+                        }
+                    }
+                    """.trimIndent()
+                ),
+                Arguments.of(
+                    """
+                    {
+                        "attribute": {
+                            "type": "LanguageProperty",
+                            "languageMap": { "en": "train", "fr": "train", "es": "tren" }
+                        }
+                    }
+                    """.trimIndent(),
+                    """
+                    {
+                        "attribute": {
+                            "type": "LanguageProperty",
+                            "languageMap": { "en": "urn:ngsi-ld:null", "fr": "TGV" }
+                        }
+                    }
+                    """.trimIndent(),
+                    """
+                    {
+                        "attribute": {
+                            "type": "LanguageProperty",
+                            "languageMap": { "es": "tren", "fr": "TGV" }
+                        }
+                    }
+                    """.trimIndent()
+                ),
+                Arguments.of(
+                    """
+                    {
                         "incoming": {
                             "type": "JsonProperty",
                             "json": { "a": 1, "b": "thing" }
@@ -313,6 +428,266 @@ class PatchAttributeTests {
                         }
                     }
                     """.trimIndent()
+                ),
+                Arguments.of(
+                    """
+                    {
+                        "attribute": {
+                            "type": "Property",
+                            "value": 12.5,
+                            "subAttribute": {
+                                "type": "Property",
+                                "value": "someValue"
+                            }
+                        }
+                    }
+                    """.trimIndent(),
+                    """
+                    {
+                        "attribute": {
+                            "type": "Property",
+                            "value": 12.5,
+                            "subAttribute": {
+                                "type": "Property",
+                                "value": "urn:ngsi-ld:null"
+                            }
+                        }
+                    }
+                    """.trimIndent(),
+                    """
+                    {
+                        "attribute": {
+                            "type": "Property",
+                            "value": 12.5
+                        }
+                    }
+                    """.trimIndent()
+                ),
+                Arguments.of(
+                    """
+                    {
+                        "attribute": {
+                            "type": "Property",
+                            "value": 12.5,
+                            "subAttribute": {
+                                "type": "Property",
+                                "value": "someValue"
+                            }
+                        }
+                    }
+                    """.trimIndent(),
+                    """
+                    {
+                        "attribute": {
+                            "type": "Property",
+                            "value": 12.5,
+                            "subAttribute": "urn:ngsi-ld:null"
+                        }
+                    }
+                    """.trimIndent(),
+                    """
+                    {
+                        "attribute": {
+                            "type": "Property",
+                            "value": 12.5
+                        }
+                    }
+                    """.trimIndent()
+                ),
+                Arguments.of(
+                    """
+                    {
+                        "attribute": {
+                            "type": "Property",
+                            "value": 12.5,
+                            "subRelationship": {
+                                "type": "Relationship",
+                                "object": "urn:ngsi-ld:Entity:01"
+                            }
+                        }
+                    }
+                    """.trimIndent(),
+                    """
+                    {
+                        "attribute": {
+                            "type": "Property",
+                            "value": 12.5,
+                            "subRelationship": {
+                                "type": "Relationship",
+                                "object": "urn:ngsi-ld:null"
+                            }
+                        }
+                    }
+                    """.trimIndent(),
+                    """
+                    {
+                        "attribute": {
+                            "type": "Property",
+                            "value": 12.5
+                        }
+                    }
+                    """.trimIndent()
+                ),
+                Arguments.of(
+                    """
+                    {
+                        "attribute": {
+                            "type": "Property",
+                            "value": 12.5
+                        }
+                    }
+                    """.trimIndent(),
+                    """
+                    {
+                        "attribute": {
+                            "type": "Property",
+                            "value": 12.5,
+                            "subAttribute": {
+                                "type": "Property",
+                                "value": "urn:ngsi-ld:null"
+                            }
+                        }
+                    }
+                    """.trimIndent(),
+                    """
+                    {
+                        "attribute": {
+                            "type": "Property",
+                            "value": 12.5
+                        }
+                    }
+                    """.trimIndent()
+                ),
+                Arguments.of(
+                    """
+                    {
+                        "attribute": {
+                            "type": "Property",
+                            "value": 12.5,
+                            "subLangProp": {
+                                "type": "LanguageProperty",
+                                "languageMap": { "fr": "train", "es": "tren" }
+                            }
+                        }
+                    }
+                    """.trimIndent(),
+                    """
+                    {
+                        "attribute": {
+                            "type": "Property",
+                            "subLangProp": {
+                                "type": "LanguageProperty",
+                                "languageMap": { "@none": "urn:ngsi-ld:null" }
+                            }
+                        }
+                    }
+                    """.trimIndent(),
+                    """
+                    {
+                        "attribute": {
+                            "type": "Property",
+                            "value": 12.5
+                        }
+                    }
+                    """.trimIndent()
+                ),
+                Arguments.of(
+                    """
+                    {
+                        "attribute": {
+                            "type": "Property",
+                            "value": 12.5,
+                            "unitCode": "someUnit"
+                        }
+                    }
+                    """.trimIndent(),
+                    """
+                    {
+                        "attribute": {
+                            "type": "Property",
+                            "value": 12.5,
+                            "unitCode": "urn:ngsi-ld:null"
+                        }
+                    }
+                    """.trimIndent(),
+                    """
+                    {
+                        "attribute": {
+                            "type": "Property",
+                            "value": 12.5
+                        }
+                    }
+                    """.trimIndent()
+                ),
+                Arguments.of(
+                    """
+                    {
+                        "address": {
+                            "type": "Property",
+                            "value": {
+                                "street": "Straße des 17. Juni",
+                                "city": "Berlin",
+                                "country": "Germany"
+                            }
+                        }
+                    }
+                    """.trimIndent(),
+                    """
+                    {
+                        "address": {
+                            "type": "Property",
+                            "value": {
+                                "street": "Pariser Platz",
+                                "country": "urn:ngsi-ld:null"
+                            }
+                        }
+                    }
+                    """.trimIndent(),
+                    """
+                    {
+                        "address": {
+                            "type": "Property",
+                            "value": {
+                                "street": "Pariser Platz",
+                                "city": "Berlin"
+                            }
+                        }
+                    }
+                    """.trimIndent()
+                ),
+                Arguments.of(
+                    """
+                    {
+                        "jsonProperty": {
+                            "type": "JsonProperty",
+                            "json": {
+                                "key1": "value1",
+                                "key2": "value2"
+                            }
+                        }
+                    }
+                    """.trimIndent(),
+                    """
+                    {
+                        "jsonProperty": {
+                            "type": "JsonProperty",
+                            "json": {
+                                "key1": "urn:ngsi-ld:null",
+                                "key2": "newValue2"
+                            }
+                        }
+                    }
+                    """.trimIndent(),
+                    """
+                    {
+                        "jsonProperty": {
+                            "type": "JsonProperty",
+                            "json": {
+                                "key2": "newValue2"
+                            }
+                        }
+                    }
+                    """.trimIndent()
                 )
             )
         }
@@ -328,7 +703,7 @@ class PatchAttributeTests {
         val (mergeResult, _) = partialUpdatePatch(
             expandAttribute(source, NGSILD_TEST_CORE_CONTEXTS).second[0],
             expandAttribute(target, NGSILD_TEST_CORE_CONTEXTS).second[0]
-        )
+        ).shouldSucceedAndResult()
 
         assertJsonPayloadsAreEqual(
             serializeObject(expandAttribute(expected, NGSILD_TEST_CORE_CONTEXTS).second[0]),
@@ -346,7 +721,7 @@ class PatchAttributeTests {
         val (mergeResult, _) = mergePatch(
             expandAttribute(source, NGSILD_TEST_CORE_CONTEXTS).second[0],
             expandAttribute(target, NGSILD_TEST_CORE_CONTEXTS).second[0]
-        )
+        ).shouldSucceedAndResult()
 
         assertJsonPayloadsAreEqual(
             serializeObject(expandAttribute(expected, NGSILD_TEST_CORE_CONTEXTS).second[0]),

--- a/search-service/src/test/kotlin/com/egm/stellio/search/entity/util/PatchAttributeTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/entity/util/PatchAttributeTests.kt
@@ -433,6 +433,32 @@ class PatchAttributeTests {
                     """
                     {
                         "attribute": {
+                            "type": "VocabProperty",
+                            "vocab": ["stellio"]
+                        }
+                    }
+                    """.trimIndent(),
+                    """
+                    {
+                        "attribute": {
+                            "type": "VocabProperty",
+                            "vocab": ["egm", "nantes"]
+                        }
+                    }
+                    """.trimIndent(),
+                    """
+                    {
+                        "attribute": {
+                            "type": "VocabProperty",
+                            "vocab": ["egm", "nantes"]
+                        }
+                    }
+                    """.trimIndent()
+                ),
+                Arguments.of(
+                    """
+                    {
+                        "attribute": {
                             "type": "Property",
                             "value": 12.5,
                             "subAttribute": {

--- a/shared/src/main/kotlin/com/egm/stellio/shared/model/ExpandedMembers.kt
+++ b/shared/src/main/kotlin/com/egm/stellio/shared/model/ExpandedMembers.kt
@@ -26,6 +26,7 @@ typealias ExpandedAttribute = Pair<ExpandedTerm, ExpandedAttributeInstances>
 typealias ExpandedAttributeInstances = List<ExpandedAttributeInstance>
 typealias ExpandedAttributeInstance = Map<String, List<Any>>
 typealias ExpandedNonReifiedPropertyValue = List<Map<String, Any>>
+typealias ExpandedLanguageMapValue = List<Map<String, String>>
 
 fun ExpandedAttributes.addCoreMembers(
     entityId: URI,

--- a/shared/src/main/kotlin/com/egm/stellio/shared/model/NgsiLdEntity.kt
+++ b/shared/src/main/kotlin/com/egm/stellio/shared/model/NgsiLdEntity.kt
@@ -387,7 +387,7 @@ class NgsiLdJsonPropertyInstance private constructor(
 }
 
 class NgsiLdLanguagePropertyInstance private constructor(
-    val languageMap: List<Map<String, String>>,
+    val languageMap: ExpandedLanguageMapValue,
     observedAt: ZonedDateTime?,
     datasetId: URI?,
     attributes: List<NgsiLdAttribute>
@@ -414,7 +414,7 @@ class NgsiLdLanguagePropertyInstance private constructor(
             val attributes = parseAttributes(rawAttributes).bind()
 
             NgsiLdLanguagePropertyInstance(
-                languageMap as List<Map<String, String>>,
+                languageMap as ExpandedLanguageMapValue,
                 observedAt,
                 datasetId,
                 attributes

--- a/shared/src/main/kotlin/com/egm/stellio/shared/model/NgsiLdEntity.kt
+++ b/shared/src/main/kotlin/com/egm/stellio/shared/model/NgsiLdEntity.kt
@@ -14,6 +14,7 @@ import com.egm.stellio.shared.util.ErrorMessages.Entity.attributeInconsistentIns
 import com.egm.stellio.shared.util.ErrorMessages.Entity.attributeInvalidOrNotImplementedTypeMessage
 import com.egm.stellio.shared.util.ErrorMessages.Entity.attributeMultipleDefaultInstancesMessage
 import com.egm.stellio.shared.util.ErrorMessages.Entity.attributeMultipleInstancesSameDatasetIdMessage
+import com.egm.stellio.shared.util.ErrorMessages.Entity.attributeWithNullDatasetIdMessage
 import com.egm.stellio.shared.util.ErrorMessages.Entity.geoPropertyMissingValueMessage
 import com.egm.stellio.shared.util.ErrorMessages.Entity.jsonPropertyInvalidJsonMessage
 import com.egm.stellio.shared.util.ErrorMessages.Entity.jsonPropertyMissingJsonMessage
@@ -90,6 +91,7 @@ class NgsiLdProperty private constructor(
 
             checkAttributeDefaultInstance(name, ngsiLdPropertyInstances).bind()
             checkAttributeDuplicateDatasetId(name, ngsiLdPropertyInstances).bind()
+            checkAttributeNullDatasetId(name, ngsiLdPropertyInstances).bind()
 
             NgsiLdProperty(name, ngsiLdPropertyInstances)
         }
@@ -115,6 +117,7 @@ class NgsiLdRelationship private constructor(
 
             checkAttributeDefaultInstance(name, ngsiLdRelationshipInstances).bind()
             checkAttributeDuplicateDatasetId(name, ngsiLdRelationshipInstances).bind()
+            checkAttributeNullDatasetId(name, ngsiLdRelationshipInstances).bind()
 
             NgsiLdRelationship(name, ngsiLdRelationshipInstances)
         }
@@ -140,6 +143,7 @@ class NgsiLdGeoProperty private constructor(
 
             checkAttributeDefaultInstance(name, ngsiLdGeoPropertyInstances).bind()
             checkAttributeDuplicateDatasetId(name, ngsiLdGeoPropertyInstances).bind()
+            checkAttributeNullDatasetId(name, ngsiLdGeoPropertyInstances).bind()
 
             NgsiLdGeoProperty(name, ngsiLdGeoPropertyInstances)
         }
@@ -165,6 +169,7 @@ class NgsiLdJsonProperty private constructor(
 
             checkAttributeDefaultInstance(name, ngsiLdJsonPropertyInstances).bind()
             checkAttributeDuplicateDatasetId(name, ngsiLdJsonPropertyInstances).bind()
+            checkAttributeNullDatasetId(name, ngsiLdJsonPropertyInstances).bind()
 
             NgsiLdJsonProperty(name, ngsiLdJsonPropertyInstances)
         }
@@ -190,6 +195,7 @@ class NgsiLdLanguageProperty private constructor(
 
             checkAttributeDefaultInstance(name, ngsiLdLanguagePropertyInstances).bind()
             checkAttributeDuplicateDatasetId(name, ngsiLdLanguagePropertyInstances).bind()
+            checkAttributeNullDatasetId(name, ngsiLdLanguagePropertyInstances).bind()
 
             NgsiLdLanguageProperty(name, ngsiLdLanguagePropertyInstances)
         }
@@ -215,6 +221,7 @@ class NgsiLdVocabProperty private constructor(
 
             checkAttributeDefaultInstance(name, ngsiLdVocabPropertyInstances).bind()
             checkAttributeDuplicateDatasetId(name, ngsiLdVocabPropertyInstances).bind()
+            checkAttributeNullDatasetId(name, ngsiLdVocabPropertyInstances).bind()
 
             NgsiLdVocabProperty(name, ngsiLdVocabPropertyInstances)
         }
@@ -555,6 +562,15 @@ fun checkAttributeDuplicateDatasetId(
     }
     ensure(datasetIds.toSet().count() == datasetIds.count()) {
         BadRequestDataException(attributeMultipleInstancesSameDatasetIdMessage(name))
+    }
+}
+
+fun checkAttributeNullDatasetId(
+    name: String,
+    instances: List<NgsiLdAttributeInstance>
+): Either<APIException, Unit> = either {
+    ensure(instances.count { it.datasetId?.toString() == NGSILD_NULL } == 0) {
+        BadRequestDataException(attributeWithNullDatasetIdMessage(name))
     }
 }
 

--- a/shared/src/main/kotlin/com/egm/stellio/shared/util/ErrorMessages.kt
+++ b/shared/src/main/kotlin/com/egm/stellio/shared/util/ErrorMessages.kt
@@ -126,6 +126,12 @@ object ErrorMessages {
         const val ENTITY_MISSING_TYPE_PROPERTY_MESSAGE = "The provided NGSI-LD entity does not contain a type property"
         const val ENTITY_MISSING_ID_PROPERTY_MESSAGE = "The provided NGSI-LD entity does not contain an id property"
 
+        const val NGSI_LD_NULL_NOT_ALLOWED_MESSAGE = "NGSI-LD Null is not allowed in this operation"
+        const val NGSI_LD_NULL_NOT_ALLOWED_IN_DATASET_ID_MEMBER =
+            "NGSI-LD Null is not allowed as the value of the datasetId member"
+        const val NGSI_LD_NULL_NOT_ALLOWED_IN_TYPE_MEMBER =
+            "NGSI-LD Null is not allowed as the value of the type member"
+
         fun entityOrAttrsNotFoundMessage(entityId: URI, attrs: Set<String>) =
             "Entity $entityId does not exist or has none of the requested attributes: $attrs"
         fun attributeNotFoundMessage(attrId: String, entityId: URI) =

--- a/shared/src/main/kotlin/com/egm/stellio/shared/util/ErrorMessages.kt
+++ b/shared/src/main/kotlin/com/egm/stellio/shared/util/ErrorMessages.kt
@@ -127,10 +127,10 @@ object ErrorMessages {
         const val ENTITY_MISSING_ID_PROPERTY_MESSAGE = "The provided NGSI-LD entity does not contain an id property"
 
         const val NGSI_LD_NULL_NOT_ALLOWED_MESSAGE = "NGSI-LD Null is not allowed in this operation"
-        const val NGSI_LD_NULL_NOT_ALLOWED_IN_DATASET_ID_MEMBER =
+        const val NGSI_LD_NULL_NOT_ALLOWED_IN_DATASET_ID_MESSAGE =
             "NGSI-LD Null is not allowed as the value of the datasetId member"
-        const val NGSI_LD_NULL_NOT_ALLOWED_IN_TYPE_MEMBER =
-            "NGSI-LD Null is not allowed as the value of the type member"
+        fun attributeWithNullDatasetIdMessage(attributeName: String) =
+            "Attribute $attributeName has an invalid NGSI-LD Null value for the datasetId member"
 
         fun entityOrAttrsNotFoundMessage(entityId: URI, attrs: Set<String>) =
             "Entity $entityId does not exist or has none of the requested attributes: $attrs"

--- a/shared/src/test/kotlin/com/egm/stellio/shared/model/NgsiLdEntityTests.kt
+++ b/shared/src/test/kotlin/com/egm/stellio/shared/model/NgsiLdEntityTests.kt
@@ -93,6 +93,32 @@ class NgsiLdEntityTests {
     }
 
     @Test
+    fun `it should not parse an entity with a datasetId having an NGSI-LD Null value`() = runTest {
+        val rawEntity =
+            """
+            {
+                "id": "urn:ngsi-ld:Device:01234",
+                "type": "Device",
+                "deviceState": {
+                    "type": "Property",
+                    "value": 23,
+                    "datasetId": "urn:ngsi-ld:null"
+                }
+            }
+            """.trimIndent()
+
+        expandJsonLdEntity(rawEntity, NGSILD_TEST_CORE_CONTEXTS).toNgsiLdEntity().shouldFail {
+            assertInstanceOf(BadRequestDataException::class.java, it)
+            assertEquals(
+                """
+                    Attribute ${NGSILD_DEFAULT_VOCAB}deviceState has an invalid NGSI-LD Null value for the datasetId member
+                """.trimIndent(),
+                it.message
+            )
+        }
+    }
+
+    @Test
     fun `it should parse an entity with a minimal property`() = runTest {
         val rawEntity =
             """


### PR DESCRIPTION
Per ETSI GS CIM 009 §4.5.18, §5.5.8, and §5.5.12:

- reject `urn:ngsi-ld:null` in create, append, and replace operations (`BadRequestData`)
- reject `urn:ngsi-ld:null` in `datasetId` member for merge patch and partial attribute update
- remove sub-attributes whose value is `urn:ngsi-ld:null` in merge patch (5.5.12)
- remove sub-attributes whose value is `urn:ngsi-ld:null` in partial attribute update (5.5.8)
- merge `LanguageProperty` languageMap entries and remove `@none` language via `urn:ngsi-ld:null` (§4.5.18)
- remove keys from `Property` object values and `JsonProperty` json objects via `urn:ngsi-ld:null` (§5.5.12 example 2)

Limitations:
- Removing an `observedAt` in a merge+patch operation is not possible since the value is transformed in a ZonedDateTime before applying the merge (and Stellio then returns a 400 if `observedAt` is `urn:ngsi-ld:null`). Allowing this use-case implies many changes and is thus postponed until it is strongly needed. 