### PR TITLE
fix: simplified temporal representation of a deleted languageMap

### DIFF
--- a/search-service/src/main/kotlin/com/egm/stellio/search/entity/model/Attribute.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/entity/model/Attribute.kt
@@ -1,9 +1,7 @@
 package com.egm.stellio.search.entity.model
 
 import com.egm.stellio.shared.model.ExpandedTerm
-import com.egm.stellio.shared.model.JSONLD_LANGUAGE_KW
 import com.egm.stellio.shared.model.JSONLD_NONE_KW
-import com.egm.stellio.shared.model.JSONLD_VALUE_KW
 import com.egm.stellio.shared.model.NGSILD_DATASET_ID_IRI
 import com.egm.stellio.shared.model.NGSILD_GEOPROPERTY_TYPE
 import com.egm.stellio.shared.model.NGSILD_GEOPROPERTY_VALUE
@@ -31,7 +29,6 @@ import com.egm.stellio.shared.model.NGSILD_VOCABPROPERTY_VOCAB
 import com.egm.stellio.shared.model.NGSILD_VOCABPROPERTY_VOCABS
 import com.egm.stellio.shared.model.NGSILD_VOCABPROPERTY_VOCAB_TERM
 import com.egm.stellio.shared.util.JsonLdUtils.buildNonReifiedPropertyValue
-import com.egm.stellio.shared.util.JsonUtils.serializeObject
 import io.r2dbc.postgresql.codec.Json
 import org.springframework.data.annotation.Id
 import java.net.URI
@@ -144,13 +141,6 @@ data class Attribute(
                         NGSILD_DATASET_ID_IRI to buildNonReifiedPropertyValue(datasetId.toString())
                     )
                 else nullAttrRepresentation
-            }
-
-        fun toNullValue(): String =
-            when (this) {
-                Property, GeoProperty, JsonProperty, VocabProperty, Relationship -> NGSILD_NULL
-                LanguageProperty ->
-                    serializeObject(listOf(mapOf(JSONLD_VALUE_KW to NGSILD_NULL, JSONLD_LANGUAGE_KW to JSONLD_NONE_KW)))
             }
     }
 }

--- a/search-service/src/main/kotlin/com/egm/stellio/search/entity/service/EntityAttributeService.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/entity/service/EntityAttributeService.kt
@@ -48,6 +48,7 @@ import com.egm.stellio.shared.model.JSONLD_NONE_KW
 import com.egm.stellio.shared.model.JSONLD_TYPE_KW
 import com.egm.stellio.shared.model.NGSILD_JSONPROPERTY_JSON
 import com.egm.stellio.shared.model.NGSILD_LANGUAGEPROPERTY_LANGUAGEMAP
+import com.egm.stellio.shared.model.NGSILD_NULL
 import com.egm.stellio.shared.model.NGSILD_OBSERVED_AT_IRI
 import com.egm.stellio.shared.model.NGSILD_PREFIX
 import com.egm.stellio.shared.model.NGSILD_RELATIONSHIP_OBJECT
@@ -369,7 +370,7 @@ class EntityAttributeService(
         attributesToDeleteWithPayload.forEach { (attribute, expandedAttributePayload) ->
             attributeInstanceService.addDeletedAttributeInstance(
                 attributeUuid = attribute.id,
-                value = attribute.attributeType.toNullValue().asJsonB(),
+                value = NGSILD_NULL.asJsonB(),
                 deletedAt = deletedAt,
                 attributeValues = expandedAttributePayload
             ).bind()


### PR DESCRIPTION
I am not sure why this existed in the first place. But it was the reason behind the issue in the simplified temporal representation of a deleted languageMap. (All languageMap related test of the test suite still pass)

Note: the value parameter of addDeletedAttributeInstance could be removed entirely.