### PR TITLE
Revert "fix: split migration for compressed table (#1779)"

### DIFF
--- a/docs/admin/upgrading_to_2.35.0.md
+++ b/docs/admin/upgrading_to_2.35.0.md
@@ -1,0 +1,28 @@
+# Upgrading to 2.35.0
+
+This note describes the necessary steps to upgrade to Stellio 2.35.0
+
+## Migration Issue for compressed temporal data setup
+
+> ** WARNING ** This only concerns setup that [enabled timescale compression](enabling_timescale_compression.md).
+
+
+Timescale does not support data type changes [on compressed data](https://github.com/timescale/docs/blob/latest/use-timescale/compression/modify-a-schema.md#schema-modifications)
+It means that to migrate to 2.35.0, you should first decompress 'attribute_instance' and 'attribute_instance_audit' tables. (which may take a lot of space)
+
+````sql
+WITH chunks AS (SELECT format('%I.%I', chunk_schema, chunk_name)::regclass AS chunk
+                FROM timescaledb_information.chunks
+                WHERE hypertable_name IN ( '{tenant_db}.attribute_instance','{tenant_db}.attribute_instance_audit')
+                  AND is_compressed = true)
+
+SELECT decompress_chunk(chunk)
+FROM chunks;
+````
+
+You can check that all the chunks have been correctly decompressed by running:
+
+```sql
+SELECT number_compressed_chunks
+FROM hypertable_compression_stats('{tenant_db}.attribute_instance');
+```

--- a/search-service/src/main/resources/db/migration/V0_54__temporal_value_as_jsonb.sql
+++ b/search-service/src/main/resources/db/migration/V0_54__temporal_value_as_jsonb.sql
@@ -1,42 +1,16 @@
--- change value type to jsonb in multiple steps to support compressed table
-
--- attribute_instance
 ALTER TABLE attribute_instance
-    ADD COLUMN json_value JSONB;
-
-UPDATE attribute_instance
-SET json_value = to_jsonb(value)
-WHERE value IS NOT NULL;
-
-
-ALTER TABLE attribute_instance
-    DROP COLUMN value;
-
-ALTER TABLE attribute_instance
-    RENAME COLUMN json_value TO value;
-
--- attribute_instance_audit
-ALTER TABLE attribute_instance_audit
-    ADD COLUMN json_value JSONB;
-
-
-UPDATE attribute_instance_audit
-SET json_value = to_jsonb(value)
-WHERE value IS NOT NULL;
+    ALTER COLUMN value TYPE JSONB
+        USING to_jsonb(value);
 
 ALTER TABLE attribute_instance_audit
-    DROP COLUMN value;
-
-ALTER TABLE attribute_instance_audit
-    RENAME COLUMN json_value TO value;
+    ALTER COLUMN value TYPE JSONB
+        USING to_jsonb(value);
 
 
 -- field who already had a json value
 UPDATE attribute_instance
 SET value = (value #>> '{}')::jsonb
-WHERE
-    value IS NOT NULL
-    AND payload #>> '{@type, 0}' in (
+WHERE payload #>> '{@type, 0}' in (
     'https://uri.etsi.org/ngsi-ld/LanguageProperty',
     'https://uri.etsi.org/ngsi-ld/JsonProperty',
     'https://uri.etsi.org/ngsi-ld/VocabProperty'
@@ -45,9 +19,7 @@ AND LEFT(value #>> '{}', 1) in ('{', '['); -- avoid transforming 'urn:ngsi-ld:nu
 
 UPDATE attribute_instance_audit
 SET value = (value #>> '{}')::jsonb
-WHERE
-    value IS NOT NULL
-    AND payload #>> '{@type, 0}' in (
+WHERE payload #>> '{@type, 0}' in (
     'https://uri.etsi.org/ngsi-ld/LanguageProperty',
     'https://uri.etsi.org/ngsi-ld/JsonProperty',
     'https://uri.etsi.org/ngsi-ld/VocabProperty'


### PR DESCRIPTION
The fixed worked but took more than double the place taken by the database which is not an acceptable behavior.