### PR TITLE
refactor: homogenize test naming to function- and operation-prefixed conventions

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -8,8 +8,24 @@
 
 ## Test naming
 
-- Unit tests: `[function] should [expected behavior] when [condition]`
-- Integration tests: `[function] should [test scenario]`
+Two conventions, chosen by the tier of the test. Never use the subject-less `it should …`
+form, and never abbreviate negation as `shouldn't` — always write `should not`.
+
+- **Unit / service / util tests** — name after the function under test:
+  `<functionName> should <expected behavior> [when <condition>]`
+  - Example: `mergeTemporalEntities should merge instances when datasetIds match`
+  - The prefix is the literal Kotlin function being exercised (camelCase), so tests are greppable
+    from the production symbol.
+- **Controller / integration tests** — name after the HTTP operation under test:
+  `<HTTP verb> <path> should <result>`
+  - Example: `GET /entities/{id} should return 200 when the entity exists`
+  - Use the spec-defined verb and route template; describe the observable HTTP outcome.
+
+Banned forms (migrate on sight):
+- `it should …` / `it shouldn't …` — subject-less BDD style; replace with the function- or
+  endpoint-prefixed form above.
+- `shoud` — recurring typo for `should`.
+- Names with no `should` at all — restate the expected behavior with `should`.
 
 ## Coverage
 

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -8,24 +8,22 @@
 
 ## Test naming
 
-Two conventions, chosen by the tier of the test. Never use the subject-less `it should …`
-form, and never abbreviate negation as `shouldn't` — always write `should not`.
+Two conventions, chosen by the tier of the test. Never use the subject-less `it should …` form.
 
 - **Unit / service / util tests** — name after the function under test:
   `<functionName> should <expected behavior> [when <condition>]`
   - Example: `mergeTemporalEntities should merge instances when datasetIds match`
   - The prefix is the literal Kotlin function being exercised (camelCase), so tests are greppable
     from the production symbol.
-- **Controller / integration tests** — name after the HTTP operation under test:
-  `<HTTP verb> <path> should <result>`
-  - Example: `GET /entities/{id} should return 200 when the entity exists`
-  - Use the spec-defined verb and route template; describe the observable HTTP outcome.
+- **Controller / integration tests** — name after the HTTP operation under test: `<operation> should <result>`
+  - Example: `create entity should return a 400 if entity does not have an type`
+  - Use the name of the operation; describe the observable HTTP outcome.
 
 Banned forms (migrate on sight):
 - `it should …` / `it shouldn't …` — subject-less BDD style; replace with the function- or
   endpoint-prefixed form above.
-- `shoud` — recurring typo for `should`.
 - Names with no `should` at all — restate the expected behavior with `should`.
+- Never abbreviate negation as `shouldn't` — always write `should not`.
 
 ## Coverage
 

--- a/search-service/config/detekt/baseline.xml
+++ b/search-service/config/detekt/baseline.xml
@@ -10,10 +10,10 @@
     <ID>LongMethod:AttributeInstanceService.kt$AttributeInstanceService$@Transactional suspend fun create(attributeInstance: AttributeInstance): Either&lt;APIException, Unit&gt;</ID>
     <ID>LongMethod:ContextSourceRegistrationService.kt$ContextSourceRegistrationService$@Transactional suspend fun upsert( csr: ContextSourceRegistration ): Either&lt;APIException, Unit&gt;</ID>
     <ID>LongMethod:EntitiesQueryUtils.kt$fun composeEntitiesQueryFromPost( defaultPagination: ApplicationProperties.Pagination, query: Query, queryParams: MultiValueMap&lt;String, String&gt;, contexts: List&lt;String&gt; ): Either&lt;APIException, EntitiesQueryFromPost&gt;</ID>
-    <ID>LongMethod:EntitiesQueryUtilsTests.kt$EntitiesQueryUtilsTests$@Test fun `it should parse a valid complete Query datatype`()</ID>
+    <ID>LongMethod:EntitiesQueryUtilsTests.kt$EntitiesQueryUtilsTests$@Test fun `composeEntitiesQueryFromPostRequest should parse a valid complete Query datatype`()</ID>
     <ID>LongMethod:EntityEventService.kt$EntityEventService$private fun publishAttributeChangeEvent( sub: String?, tenantName: String, originalEntity: ExpandedEntity, updatedEntity: ExpandedEntity, attributeOperationResult: SucceededAttributeOperationResult )</ID>
-    <ID>LongMethod:EntityEventServiceTests.kt$EntityEventServiceTests$@Test fun `it should publish ATTRIBUTE_UPDATE events if a multi-attribute is replaced`()</ID>
-    <ID>LongMethod:LinkedEntityServiceTests.kt$LinkedEntityServiceTests$@Test fun `it should inline entities up to the asked 2nd level`()</ID>
+    <ID>LongMethod:EntityEventServiceTests.kt$EntityEventServiceTests$@Test fun `publishAttributeChangeEvents should publish ATTRIBUTE_UPDATE events on multi-attribute replace`()</ID>
+    <ID>LongMethod:LinkedEntityServiceTests.kt$LinkedEntityServiceTests$@Test fun `processLinkedEntities should inline entities up to the asked 2nd level`()</ID>
     <ID>LongMethod:PatchAttributeTests.kt$PatchAttributeTests.Companion$@JvmStatic fun mergePatchProvider(): Stream&lt;Arguments&gt;</ID>
     <ID>LongMethod:PatchAttributeTests.kt$PatchAttributeTests.Companion$@JvmStatic fun partialUpdatePatchProvider(): Stream&lt;Arguments&gt;</ID>
     <ID>LongMethod:PermissionHandlerTests.kt$PermissionHandlerTests$@Test fun `query Permissions with details=true should return entire entity and subject information`()</ID>

--- a/search-service/src/test/kotlin/com/egm/stellio/search/authorization/permission/model/ActionTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/authorization/permission/model/ActionTests.kt
@@ -19,7 +19,7 @@ class ActionTests {
     )
 
     @Test
-    fun `it should return a 400 if the payload contains a multi-instance property`() = runTest {
+    fun `getSpecificAccessPolicy should return a 400 if the payload contains a multi-instance property`() = runTest {
         val requestPayload =
             """
             [{
@@ -46,7 +46,7 @@ class ActionTests {
     }
 
     @Test
-    fun `it should ignore properties that are not part of the payload when setting a specific access policy`() =
+    fun `getSpecificAccessPolicy should ignore properties not part of the payload`() =
         runTest {
             val requestPayload =
                 """
@@ -67,7 +67,7 @@ class ActionTests {
         }
 
     @Test
-    fun `it should accept AUTH_READ as a specific access policy`() =
+    fun `getSpecificAccessPolicy should accept AUTH_READ as a specific access policy`() =
         runTest {
             val requestPayload =
                 """
@@ -87,7 +87,7 @@ class ActionTests {
         }
 
     @Test
-    fun `it should return a 400 if the value is not one of the supported`() = runTest {
+    fun `getSpecificAccessPolicy should return a 400 if the value is not one of the supported`() = runTest {
         val requestPayload =
             """
             {
@@ -112,7 +112,7 @@ class ActionTests {
     }
 
     @Test
-    fun `it should return a 400 if the provided attribute is a relationship`() = runTest {
+    fun `getSpecificAccessPolicy should return a 400 if the provided attribute is a relationship`() = runTest {
         val requestPayload =
             """
             {

--- a/search-service/src/test/kotlin/com/egm/stellio/search/authorization/permission/service/AuthorizationServiceTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/authorization/permission/service/AuthorizationServiceTests.kt
@@ -16,7 +16,7 @@ class AuthorizationServiceTests {
     private val entityUri = "urn:ngsi-ld:Entity:01".toUri()
 
     @Test
-    fun `it should authorize access to read`() = runTest {
+    fun `userCanReadEntity should authorize access to read`() = runTest {
         authorizationService.userCanReadEntity(entityUri)
             .mapLeft {
                 fail("it should not have failed")

--- a/search-service/src/test/kotlin/com/egm/stellio/search/authorization/permission/service/EnabledAuthorizationServiceTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/authorization/permission/service/EnabledAuthorizationServiceTests.kt
@@ -59,7 +59,7 @@ class EnabledAuthorizationServiceTests {
     private val entityId02 = "urn:ngsi-ld:Beehive:02".toUri()
 
     @Test
-    fun `it should return false if user has no global role`() = runTest {
+    fun `userHasOneOfGivenRoles should return false when user has no global role`() = runTest {
         coEvery { subjectReferentialService.getCurrentSubjectClaims() } returns listOf(subjectUuid).right()
 
         enabledAuthorizationService.userHasOneOfGivenRoles(CREATION_ROLES)
@@ -69,7 +69,7 @@ class EnabledAuthorizationServiceTests {
     }
 
     @Test
-    fun `it should return true if user has one of the required roles`() = runTest {
+    fun `userHasOneOfGivenRoles should return true when user has one of the required roles`() = runTest {
         coEvery { subjectReferentialService.getCurrentSubjectClaims() } returns
             listOf(subjectUuid, STELLIO_CREATOR.key).right()
 
@@ -98,7 +98,7 @@ class EnabledAuthorizationServiceTests {
     }
 
     @Test
-    fun `it should allow an user that has the right to read an entity`() = runTest {
+    fun `userCanReadEntity should allow a user that has the right to read an entity`() = runTest {
         coEvery { permissionService.checkHasPermissionOnEntity(any(), any()) } returns true.right()
 
         enabledAuthorizationService.userCanReadEntity(entityId01)
@@ -113,7 +113,7 @@ class EnabledAuthorizationServiceTests {
     }
 
     @Test
-    fun `it should return an access denied if user cannot update the given entity`() = runTest {
+    fun `userCanUpdateEntity should return an access denied when user cannot update the entity`() = runTest {
         coEvery { permissionService.checkHasPermissionOnEntity(any(), any()) } returns false.right()
 
         enabledAuthorizationService.userCanUpdateEntity(entityId01)
@@ -131,7 +131,7 @@ class EnabledAuthorizationServiceTests {
     }
 
     @Test
-    fun `it should allow an user that has the right to update an entity`() = runTest {
+    fun `userCanUpdateEntity should allow a user that has the right to update an entity`() = runTest {
         coEvery { permissionService.checkHasPermissionOnEntity(any(), any()) } returns true.right()
 
         enabledAuthorizationService.userCanUpdateEntity(entityId01)
@@ -146,7 +146,7 @@ class EnabledAuthorizationServiceTests {
     }
 
     @Test
-    fun `it should return an access denied if user cannot admin the given entity`() = runTest {
+    fun `userCanAdminEntity should return an access denied when user cannot admin the entity`() = runTest {
         coEvery { permissionService.checkHasPermissionOnEntity(any(), any()) } returns false.right()
 
         enabledAuthorizationService.userCanAdminEntity(entityId01)
@@ -164,7 +164,7 @@ class EnabledAuthorizationServiceTests {
     }
 
     @Test
-    fun `it should allow an user that has the right to admin an entity`() = runTest {
+    fun `userCanAdminEntity should allow a user that has the right to admin an entity`() = runTest {
         coEvery { permissionService.checkHasPermissionOnEntity(any(), any()) } returns true.right()
 
         enabledAuthorizationService.userCanAdminEntity(entityId01)
@@ -180,7 +180,7 @@ class EnabledAuthorizationServiceTests {
 
     @Test
     @WithMockCustomUser(sub = USER_UUID, name = "Mock User")
-    fun `it should create owner link for a set of entities`() = runTest {
+    fun `createEntitiesOwnerRights should create owner link for a set of entities`() = runTest {
         coEvery { permissionService.create(any()) } returns Unit.right()
 
         enabledAuthorizationService.createEntitiesOwnerRights(listOf(entityId01, entityId02))
@@ -206,7 +206,7 @@ class EnabledAuthorizationServiceTests {
 
     @Test
     @WithMockCustomUser(sub = USER_UUID, name = "Mock User")
-    fun `it should only create ownership on non existing scopes`() = runTest {
+    fun `createScopesOwnerRights should only create ownership on non existing scopes`() = runTest {
         val scopeA = "/A"
         val scopeB = "/B"
 
@@ -239,7 +239,7 @@ class EnabledAuthorizationServiceTests {
     }
 
     @Test
-    fun `it should return a null filter is user has the stellio-admin role`() = runTest {
+    fun `getAccessRightWithClauseAndFilter should return a null filter for the stellio-admin role`() = runTest {
         coEvery {
             subjectReferentialService.getCurrentSubjectClaims()
         } returns listOf(subjectUuid, STELLIO_ADMIN.key).right()
@@ -250,7 +250,7 @@ class EnabledAuthorizationServiceTests {
     }
 
     @Test
-    fun `it should return a valid entity filter if user does not have the stellio-admin role`() = runTest {
+    fun `getAccessRightWithClauseAndFilter should return a filter for a non-admin user`() = runTest {
         coEvery {
             subjectReferentialService.getCurrentSubjectClaims()
         } returns listOf(subjectUuid, groupUuid).right()

--- a/search-service/src/test/kotlin/com/egm/stellio/search/authorization/permission/web/PermissionHandlerTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/authorization/permission/web/PermissionHandlerTests.kt
@@ -366,7 +366,7 @@ class PermissionHandlerTests {
     }
 
     @Test
-    fun `query Permissions instantiate filter based on query parameters`() = runTest {
+    fun `query Permissions should instantiate the filter based on query parameters`() = runTest {
         val permission = gimmeRawPermission()
 
         coEvery {

--- a/search-service/src/test/kotlin/com/egm/stellio/search/authorization/subject/listener/IAMListenerTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/authorization/subject/listener/IAMListenerTests.kt
@@ -44,7 +44,7 @@ class IAMListenerTests {
     private val entityId = "urn:ngsi-ld:BeeHive:TESTC".toUri()
 
     @Test
-    fun `it should handle a create event for an user`() = runTest {
+    fun `dispatchIamMessage should handle a create event for an user`() = runTest {
         val subjectCreateEvent = loadSampleData("events/authorization/UserCreateEvent.json")
 
         coEvery { subjectReferentialService.create(any()) } returns Unit.right()
@@ -67,7 +67,7 @@ class IAMListenerTests {
     }
 
     @Test
-    fun `it should handle a create event with unknwon properties for an user`() = runTest {
+    fun `dispatchIamMessage should handle a create event with unknwon properties for an user`() = runTest {
         val subjectCreateEvent = loadSampleData("events/authorization/UserCreateEventUnknownProperties.json")
 
         coEvery { subjectReferentialService.create(any()) } returns Unit.right()
@@ -90,7 +90,7 @@ class IAMListenerTests {
     }
 
     @Test
-    fun `it should handle a create event with the default tenant for an user`() = runTest {
+    fun `dispatchIamMessage should handle a create event with the default tenant for an user`() = runTest {
         val subjectCreateEvent = loadSampleData("events/authorization/UserCreateEventWithDefaultTenant.json")
 
         coEvery { subjectReferentialService.create(any()) } returns Unit.right()
@@ -113,7 +113,7 @@ class IAMListenerTests {
     }
 
     @Test
-    fun `it should handle a create event for a group`() = runTest {
+    fun `dispatchIamMessage should handle a create event for a group`() = runTest {
         val subjectCreateEvent = loadSampleData("events/authorization/GroupCreateEvent.json")
 
         coEvery { subjectReferentialService.create(any()) } returns Unit.right()
@@ -136,7 +136,7 @@ class IAMListenerTests {
     }
 
     @Test
-    fun `it should handle a create event for a subject with a default role`() = runTest {
+    fun `dispatchIamMessage should handle a create event for a subject with a default role`() = runTest {
         val subjectCreateEvent = loadSampleData("events/authorization/UserCreateEventDefaultRole.json")
 
         coEvery { subjectReferentialService.create(any()) } returns Unit.right()
@@ -155,7 +155,7 @@ class IAMListenerTests {
     }
 
     @Test
-    fun `it should handle a delete event for a subject`() = runTest {
+    fun `dispatchIamMessage should handle a delete event for a subject`() = runTest {
         val subjectDeleteEvent = loadSampleData("events/authorization/UserDeleteEvent.json")
 
         coEvery { subjectReferentialService.delete(any()) } returns Unit.right()
@@ -172,7 +172,7 @@ class IAMListenerTests {
     }
 
     @Test
-    fun `it should handle an append event adding a stellio-admin role for a group`() = runTest {
+    fun `dispatchIamMessage should handle an append event adding a stellio-admin role for a group`() = runTest {
         val roleAppendEvent = loadSampleData("events/authorization/RealmRoleAppendEventOneRole.json")
 
         coEvery { subjectReferentialService.setGlobalRoles(any(), any()) } returns Unit.right()
@@ -190,7 +190,7 @@ class IAMListenerTests {
     }
 
     @Test
-    fun `it should handle an append event adding a stellio-admin role for a client`() = runTest {
+    fun `dispatchIamMessage should handle an append event adding a stellio-admin role for a client`() = runTest {
         val roleAppendEvent = loadSampleData("events/authorization/RealmRoleAppendToClient.json")
 
         coEvery { subjectReferentialService.setGlobalRoles(any(), any()) } returns Unit.right()
@@ -208,7 +208,7 @@ class IAMListenerTests {
     }
 
     @Test
-    fun `it should handle an append event adding a stellio-admin role within two roles`() = runTest {
+    fun `dispatchIamMessage should handle an append event adding a stellio-admin role within two roles`() = runTest {
         val roleAppendEvent = loadSampleData("events/authorization/RealmRoleAppendEventTwoRoles.json")
 
         coEvery { subjectReferentialService.setGlobalRoles(any(), any()) } returns Unit.right()
@@ -226,7 +226,7 @@ class IAMListenerTests {
     }
 
     @Test
-    fun `it should handle an append event removing a stellio-admin role for a group`() = runTest {
+    fun `dispatchIamMessage should handle an append event removing a stellio-admin role for a group`() = runTest {
         val roleAppendEvent = loadSampleData("events/authorization/RealmRoleAppendEventNoRole.json")
 
         coEvery { subjectReferentialService.resetGlobalRoles(any()) } returns Unit.right()
@@ -243,7 +243,7 @@ class IAMListenerTests {
     }
 
     @Test
-    fun `it should handle an append event adding an user to a group`() = runTest {
+    fun `dispatchIamMessage should handle an append event adding an user to a group`() = runTest {
         val roleAppendEvent = loadSampleData("events/authorization/GroupMembershipAppendEvent.json")
 
         coEvery { subjectReferentialService.addGroupMembershipToUser(any(), any()) } returns Unit.right()
@@ -263,7 +263,7 @@ class IAMListenerTests {
     }
 
     @Test
-    fun `it should handle a delete event removing an user from a group`() = runTest {
+    fun `dispatchIamMessage should handle a delete event removing an user from a group`() = runTest {
         val roleAppendEvent = loadSampleData("events/authorization/GroupMembershipDeleteEvent.json")
 
         coEvery { subjectReferentialService.removeGroupMembershipToUser(any(), any()) } returns Unit.right()
@@ -283,7 +283,7 @@ class IAMListenerTests {
     }
 
     @Test
-    fun `it should handle a replace event changing the name of a group`() = runTest {
+    fun `dispatchIamMessage should handle a replace event changing the name of a group`() = runTest {
         val roleAppendEvent = loadSampleData("events/authorization/GroupUpdateEvent.json")
 
         coEvery { subjectReferentialService.updateSubjectInfo(any(), any()) } returns Unit.right()
@@ -301,7 +301,7 @@ class IAMListenerTests {
     }
 
     @Test
-    fun `it should handle a replace event changing the given name of an user`() = runTest {
+    fun `dispatchIamMessage should handle a replace event changing the given name of an user`() = runTest {
         val roleAppendEvent = loadSampleData("events/authorization/UserUpdateEvent.json")
 
         coEvery { subjectReferentialService.updateSubjectInfo(any(), any()) } returns Unit.right()
@@ -319,7 +319,7 @@ class IAMListenerTests {
     }
 
     @Test
-    fun `it should handle a replace event changing the clientId of a client`() = runTest {
+    fun `dispatchIamMessage should handle a replace event changing the clientId of a client`() = runTest {
         val clientIdReplaceEvent = loadSampleData("events/authorization/ClientIdAppendToClient.json")
 
         coEvery { subjectReferentialService.updateSubjectInfo(any(), any()) } returns Unit.right()
@@ -337,7 +337,7 @@ class IAMListenerTests {
     }
 
     @Test
-    fun `it should delete all entities owned by a user if user is deleted`() = runTest {
+    fun `dispatchIamMessage should delete all entities owned by a user if user is deleted`() = runTest {
         val subjectDeleteEvent = loadSampleData("events/authorization/UserDeleteEvent.json")
         coEvery {
             permissionService.create(

--- a/search-service/src/test/kotlin/com/egm/stellio/search/authorization/subject/listener/IAMListenerTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/authorization/subject/listener/IAMListenerTests.kt
@@ -67,7 +67,7 @@ class IAMListenerTests {
     }
 
     @Test
-    fun `dispatchIamMessage should handle a create event with unknwon properties for an user`() = runTest {
+    fun `dispatchIamMessage should handle a create event with unknown properties for a user`() = runTest {
         val subjectCreateEvent = loadSampleData("events/authorization/UserCreateEventUnknownProperties.json")
 
         coEvery { subjectReferentialService.create(any()) } returns Unit.right()

--- a/search-service/src/test/kotlin/com/egm/stellio/search/authorization/subject/service/SubjectReferentialServiceTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/authorization/subject/service/SubjectReferentialServiceTests.kt
@@ -58,7 +58,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer, WithKafkaContaine
     }
 
     @Test
-    fun `it should persist a subject referential`() = runTest {
+    fun `create should persist a subject referential`() = runTest {
         val subjectReferential = SubjectReferential(
             subjectId = USER_UUID,
             subjectType = SubjectType.USER,
@@ -73,7 +73,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer, WithKafkaContaine
     }
 
     @Test
-    fun `it should persist a subject referential for a non-existing client`() = runTest {
+    fun `create should persist a subject referential for a non-existing client`() = runTest {
         val subjectReferential = SubjectReferential(
             subjectId = SERVICE_ACCOUNT_UUID,
             subjectType = SubjectType.CLIENT,
@@ -87,7 +87,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer, WithKafkaContaine
     }
 
     @Test
-    fun `it should upsert a subject referential for an existing client`() = runTest {
+    fun `create should upsert a subject referential for an existing client`() = runTest {
         val subjectReferential = SubjectReferential(
             subjectId = SERVICE_ACCOUNT_UUID,
             subjectType = SubjectType.CLIENT,
@@ -110,7 +110,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer, WithKafkaContaine
     }
 
     @Test
-    fun `it should retrieve a subject referential`() = runTest {
+    fun `retrieve should retrieve a subject referential`() = runTest {
         val subjectReferential = SubjectReferential(
             subjectId = USER_UUID,
             subjectType = SubjectType.USER,
@@ -129,7 +129,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer, WithKafkaContaine
     }
 
     @Test
-    fun `it should retrieve a subject referential with subject info`() = runTest {
+    fun `retrieve should retrieve a subject referential with subject info`() = runTest {
         val subjectReferential = SubjectReferential(
             subjectId = USER_UUID,
             subjectType = SubjectType.USER,
@@ -149,7 +149,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer, WithKafkaContaine
 
     @Test
     @WithMockCustomUser(sub = USER_UUID, name = "Mock User", groupsUUIDs = ["group-uuid-1", "group-uuid-2"])
-    fun `it should retrieve UUID from subject and groups memberships`() = runTest {
+    fun `getCurrentSubjectClaims should retrieve UUID from subject and groups memberships`() = runTest {
         val groups = listOf("group-uuid-1", "group-uuid-2")
 
         subjectReferentialService.getCurrentSubjectClaims()
@@ -161,7 +161,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer, WithKafkaContaine
 
     @Test
     @WithMockCustomUser(sub = USER_UUID, name = "Mock User")
-    fun `it should retrieve UUIDs from subject when it has no groups memberships`() = runTest {
+    fun `getCurrentSubjectClaims should retrieve UUIDs from subject when it has no groups memberships`() = runTest {
         subjectReferentialService.getCurrentSubjectClaims()
             .shouldSucceedWith {
                 assertEquals(3, it.size)
@@ -171,7 +171,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer, WithKafkaContaine
 
     @Test
     @WithMockCustomUser(sub = USER_UUID, name = "Mock User", roles = ["stellio-admin", "test-role"])
-    fun `it should retrieve UUIDs from subject and roles`() = runTest {
+    fun `getCurrentSubjectClaims should retrieve UUIDs from subject and roles`() = runTest {
         val roles = listOf("stellio-admin", "test-role")
 
         subjectReferentialService.getCurrentSubjectClaims()
@@ -183,7 +183,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer, WithKafkaContaine
 
     @Test
     @WithMockCustomUser(sub = USER_UUID, name = "Mock User")
-    fun `it should get the groups memberships of an user`() = runTest {
+    fun `getGroups should get the groups memberships of an user`() = runTest {
         val allGroupsUuids = List(3) {
             val groupUuid = UUID.randomUUID().toString()
             subjectReferentialService.create(
@@ -220,7 +220,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer, WithKafkaContaine
 
     @Test
     @WithMockCustomUser(sub = USER_UUID, name = "Mock User")
-    fun `it should get all groups for an admin`() = runTest {
+    fun `getAllGroups should get all groups for an admin`() = runTest {
         val allGroupsUuids = List(3) {
             val groupUuid = UUID.randomUUID().toString()
             subjectReferentialService.create(
@@ -259,7 +259,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer, WithKafkaContaine
     }
 
     @Test
-    fun `it should get all users`() = runTest {
+    fun `getUsers should get all users`() = runTest {
         val allUsersUuids = List(3) {
             val userUuid = UUID.randomUUID().toString()
             subjectReferentialService.create(
@@ -287,7 +287,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer, WithKafkaContaine
     }
 
     @Test
-    fun `it should get an user with all available information`() = runTest {
+    fun `getUsers should get an user with all available information`() = runTest {
         val userUuid = UUID.randomUUID().toString()
         subjectReferentialService.create(
             SubjectReferential(
@@ -322,7 +322,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer, WithKafkaContaine
     }
 
     @Test
-    fun `it should update the global role of a subject`() = runTest {
+    fun `setGlobalRoles should update the global role of a subject`() = runTest {
         val subjectReferential = SubjectReferential(
             subjectId = USER_UUID,
             subjectInfo = EMPTY_JSON_PAYLOAD,
@@ -346,7 +346,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer, WithKafkaContaine
 
     @Test
     @WithMockCustomUser(sub = USER_UUID, name = "Mock User", roles = ["stellio-admin"])
-    fun `it should find if an user is a stellio admin`() = runTest {
+    fun `currentSubjectIsAdmin should find if an user is a stellio admin`() = runTest {
         subjectReferentialService.currentSubjectIsAdmin()
             .shouldSucceedWith {
                 assertTrue(it)
@@ -355,7 +355,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer, WithKafkaContaine
 
     @Test
     @WithMockCustomUser(sub = USER_UUID, name = "Mock User")
-    fun `it should find if an user is not a stellio admin`() = runTest {
+    fun `currentSubjectIsAdmin should find if an user is not a stellio admin`() = runTest {
         subjectReferentialService.currentSubjectIsAdmin()
             .shouldSucceedWith {
                 assertFalse(it)
@@ -363,7 +363,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer, WithKafkaContaine
     }
 
     @Test
-    fun `it should add a group membership to an user`() = runTest {
+    fun `addGroupMembershipToUser should add a group membership to an user`() = runTest {
         val userAccessRights = SubjectReferential(
             subjectId = USER_UUID,
             subjectType = SubjectType.USER,
@@ -382,7 +382,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer, WithKafkaContaine
     }
 
     @Test
-    fun `it should add a group membership to an user inside an existing list`() = runTest {
+    fun `addGroupMembershipToUser should add a group membership to an user inside an existing list`() = runTest {
         val userAccessRights = SubjectReferential(
             subjectId = USER_UUID,
             subjectType = SubjectType.USER,
@@ -404,7 +404,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer, WithKafkaContaine
     }
 
     @Test
-    fun `it should remove a group membership to an user`() = runTest {
+    fun `removeGroupMembershipToUser should remove a group membership to an user`() = runTest {
         val userAccessRights = SubjectReferential(
             subjectId = USER_UUID,
             subjectType = SubjectType.USER,
@@ -424,7 +424,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer, WithKafkaContaine
     }
 
     @Test
-    fun `it should update an existing subject info for an user`() = runTest {
+    fun `updateSubjectInfo should update an existing subject info for an user`() = runTest {
         val subjectReferential = SubjectReferential(
             subjectId = USER_UUID,
             subjectType = SubjectType.USER,
@@ -445,7 +445,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer, WithKafkaContaine
     }
 
     @Test
-    fun `it should add a subject info for an user`() = runTest {
+    fun `updateSubjectInfo should add a subject info for an user`() = runTest {
         val subjectReferential = SubjectReferential(
             subjectId = USER_UUID,
             subjectType = SubjectType.USER,
@@ -468,7 +468,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer, WithKafkaContaine
     }
 
     @Test
-    fun `it should delete a subject referential`() = runTest {
+    fun `delete should delete a subject referential`() = runTest {
         val userAccessRights = SubjectReferential(
             subjectId = USER_UUID,
             subjectType = SubjectType.USER,
@@ -490,7 +490,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer, WithKafkaContaine
     }
 
     @Test
-    fun `it should delete a subject referential when it is a client`() = runTest {
+    fun `delete should delete a subject referential when it is a client`() = runTest {
         val subjectReferential = SubjectReferential(
             subjectId = SERVICE_ACCOUNT_UUID,
             subjectType = SubjectType.CLIENT,
@@ -513,7 +513,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer, WithKafkaContaine
     }
 
     @Test
-    fun `it should return false when user does not have the requested roles`() = runTest {
+    fun `hasOneOfGlobalRoles should return false when user does not have the requested roles`() = runTest {
         val subjectReferential = SubjectReferential(
             subjectId = USER_UUID,
             subjectType = SubjectType.USER,
@@ -525,7 +525,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer, WithKafkaContaine
     }
 
     @Test
-    fun `it should return true when user has admin roles`() = runTest {
+    fun `hasOneOfGlobalRoles should return true when user has admin roles`() = runTest {
         val subjectReferential = SubjectReferential(
             subjectId = USER_UUID,
             subjectType = SubjectType.USER,
@@ -538,7 +538,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer, WithKafkaContaine
     }
 
     @Test
-    fun `it should return true when user has creation roles`() = runTest {
+    fun `hasOneOfGlobalRoles should return true when user has creation roles`() = runTest {
         val subjectReferential = SubjectReferential(
             subjectId = USER_UUID,
             subjectType = SubjectType.USER,
@@ -552,7 +552,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer, WithKafkaContaine
 
     @Test
     @WithMockCustomUser(sub = USER_UUID, name = "Mock User", groupsUUIDs = [GROUP_UUID])
-    fun `it should return true when user has a global role inherited from a group`() = runTest {
+    fun `hasOneOfGlobalRoles should return true when user has a global role inherited from a group`() = runTest {
         subjectReferentialService.create(
             SubjectReferential(
                 subjectId = USER_UUID,

--- a/search-service/src/test/kotlin/com/egm/stellio/search/authorization/subject/service/SubjectReferentialServiceTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/authorization/subject/service/SubjectReferentialServiceTests.kt
@@ -110,7 +110,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer, WithKafkaContaine
     }
 
     @Test
-    fun `retrieve should retrieve a subject referential`() = runTest {
+    fun `retrieve should return a SubjectReferential for a known subject`() = runTest {
         val subjectReferential = SubjectReferential(
             subjectId = USER_UUID,
             subjectType = SubjectType.USER,
@@ -129,7 +129,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer, WithKafkaContaine
     }
 
     @Test
-    fun `retrieve should retrieve a subject referential with subject info`() = runTest {
+    fun `retrieve should include SubjectInfo in the returned referential`() = runTest {
         val subjectReferential = SubjectReferential(
             subjectId = USER_UUID,
             subjectType = SubjectType.USER,
@@ -183,7 +183,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer, WithKafkaContaine
 
     @Test
     @WithMockCustomUser(sub = USER_UUID, name = "Mock User")
-    fun `getGroups should get the groups memberships of an user`() = runTest {
+    fun `getGroups should return the group memberships for a user`() = runTest {
         val allGroupsUuids = List(3) {
             val groupUuid = UUID.randomUUID().toString()
             subjectReferentialService.create(
@@ -220,7 +220,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer, WithKafkaContaine
 
     @Test
     @WithMockCustomUser(sub = USER_UUID, name = "Mock User")
-    fun `getAllGroups should get all groups for an admin`() = runTest {
+    fun `getAllGroups should return all groups when caller has the admin role`() = runTest {
         val allGroupsUuids = List(3) {
             val groupUuid = UUID.randomUUID().toString()
             subjectReferentialService.create(
@@ -259,7 +259,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer, WithKafkaContaine
     }
 
     @Test
-    fun `getUsers should get all users`() = runTest {
+    fun `getUsers should return all users`() = runTest {
         val allUsersUuids = List(3) {
             val userUuid = UUID.randomUUID().toString()
             subjectReferentialService.create(
@@ -287,7 +287,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer, WithKafkaContaine
     }
 
     @Test
-    fun `getUsers should get an user with all available information`() = runTest {
+    fun `getUsers should return a user with all available fields`() = runTest {
         val userUuid = UUID.randomUUID().toString()
         subjectReferentialService.create(
             SubjectReferential(
@@ -468,7 +468,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer, WithKafkaContaine
     }
 
     @Test
-    fun `delete should delete a subject referential`() = runTest {
+    fun `delete should remove the subject referential from persistence`() = runTest {
         val userAccessRights = SubjectReferential(
             subjectId = USER_UUID,
             subjectType = SubjectType.USER,
@@ -490,7 +490,7 @@ class SubjectReferentialServiceTests : WithTimescaleContainer, WithKafkaContaine
     }
 
     @Test
-    fun `delete should delete a subject referential when it is a client`() = runTest {
+    fun `delete should remove the referential for a service-account subject`() = runTest {
         val subjectReferential = SubjectReferential(
             subjectId = SERVICE_ACCOUNT_UUID,
             subjectType = SubjectType.CLIENT,

--- a/search-service/src/test/kotlin/com/egm/stellio/search/authorization/subject/web/AnonymousUserHandlerTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/authorization/subject/web/AnonymousUserHandlerTests.kt
@@ -53,7 +53,7 @@ class AnonymousUserHandlerTests {
 
     @Test
     @WithAnonymousUser
-    fun `it should not authorize an anonymous to call the API`() {
+    fun `GET should return 401 for an anonymous user`() {
         webClient
             .get()
             .uri("/ngsi-ld/v1/entities/urn:ngsi-ld:Sensor:0022CCC")

--- a/search-service/src/test/kotlin/com/egm/stellio/search/authorization/subject/web/AnonymousUserHandlerTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/authorization/subject/web/AnonymousUserHandlerTests.kt
@@ -53,7 +53,7 @@ class AnonymousUserHandlerTests {
 
     @Test
     @WithAnonymousUser
-    fun `GET should return 401 for an anonymous user`() {
+    fun `GET requests should return 401 for an anonymous user`() {
         webClient
             .get()
             .uri("/ngsi-ld/v1/entities/urn:ngsi-ld:Sensor:0022CCC")

--- a/search-service/src/test/kotlin/com/egm/stellio/search/csr/model/ContextSourceRegistrationTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/csr/model/ContextSourceRegistrationTests.kt
@@ -140,7 +140,7 @@ class ContextSourceRegistrationTests {
     }
 
     @Test
-    fun `getAttributesMatchingCSFAndEntity should get the matching attributes`() = runTest {
+    fun `getAttributesMatchingCSFAndEntity should return the matching attributes`() = runTest {
         val entity = expandJsonLdEntity(entityPayload)
         val registrationInfoFilter = CSRFilters(
             ids = setOf(entity.id),
@@ -235,7 +235,7 @@ class ContextSourceRegistrationTests {
     }
 
     @Test
-    fun `deserialize should deserialize a CSR payload containing contextSourceInfo`() = runTest {
+    fun `deserialize should parse a CSR payload containing contextSourceInfo`() = runTest {
         val payload = mapOf(
             "id" to "urn:ngsi-ld:Beehive:1234567890".toUri(),
             "endpoint" to endpoint,

--- a/search-service/src/test/kotlin/com/egm/stellio/search/csr/model/ContextSourceRegistrationTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/csr/model/ContextSourceRegistrationTests.kt
@@ -43,7 +43,7 @@ class ContextSourceRegistrationTests {
     """.trimIndent()
 
     @Test
-    fun `it should not allow a CSR with an empty id`() = runTest {
+    fun `validate should reject a CSR with an empty id`() = runTest {
         val payload = mapOf(
             "id" to "",
             "type" to NGSILD_CSR_TERM,
@@ -63,7 +63,7 @@ class ContextSourceRegistrationTests {
     }
 
     @Test
-    fun `it should not allow a CSR with an invalid id`() = runTest {
+    fun `validate should reject a CSR with an invalid id`() = runTest {
         val payload = mapOf(
             "id" to "invalidId",
             "type" to NGSILD_CSR_TERM,
@@ -83,7 +83,7 @@ class ContextSourceRegistrationTests {
     }
 
     @Test
-    fun `it should not allow a CSR with an invalid idPattern`() = runTest {
+    fun `validate should reject a CSR with an invalid idPattern`() = runTest {
         val payload = mapOf(
             "id" to "urn:ngsi-ld:Beehive:1234567890".toUri(),
             "type" to NGSILD_CSR_TERM,
@@ -103,7 +103,7 @@ class ContextSourceRegistrationTests {
     }
 
     @Test
-    fun `it should not allow a CSR with empty RegistrationInfo`() = runTest {
+    fun `validate should reject a CSR with empty RegistrationInfo`() = runTest {
         val payload = mapOf(
             "id" to "urn:ngsi-ld:Beehive:1234567890".toUri(),
             "information" to listOf(mapOf<String, Any>()),
@@ -123,7 +123,7 @@ class ContextSourceRegistrationTests {
     }
 
     @Test
-    fun `it should allow a valid CSR`() = runTest {
+    fun `validate should allow a valid CSR`() = runTest {
         val payload = mapOf(
             "id" to "urn:ngsi-ld:Beehive:1234567890".toUri(),
             "information" to listOf(mapOf("entities" to listOf(mapOf("type" to BEEHIVE_IRI)))),
@@ -235,7 +235,7 @@ class ContextSourceRegistrationTests {
     }
 
     @Test
-    fun `it should deserialize a CSR payload containing contextSourceInfo`() = runTest {
+    fun `deserialize should deserialize a CSR payload containing contextSourceInfo`() = runTest {
         val payload = mapOf(
             "id" to "urn:ngsi-ld:Beehive:1234567890".toUri(),
             "endpoint" to endpoint,

--- a/search-service/src/test/kotlin/com/egm/stellio/search/discovery/service/AttributeServiceTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/discovery/service/AttributeServiceTests.kt
@@ -116,7 +116,7 @@ class AttributeServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should return an AttributeList`() = runTest {
+    fun `getAttributeList should return an AttributeList`() = runTest {
         val attributeNames = attributeService.getAttributeList(APIC_COMPOUND_CONTEXTS)
 
         assertThat(attributeNames.attributeList)
@@ -124,7 +124,7 @@ class AttributeServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should return an empty list of attributes if no attributes was found`() = runTest {
+    fun `getAttributeList should return an empty list when no attribute is found`() = runTest {
         clearPreviousAttributesAndObservations()
 
         val attributeNames = attributeService.getAttributeList(APIC_COMPOUND_CONTEXTS)
@@ -133,7 +133,7 @@ class AttributeServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should return a list of AttributeDetails`() = runTest {
+    fun `getAttributeDetails should return a list of AttributeDetails`() = runTest {
         val attributeDetails = attributeService.getAttributeDetails(APIC_COMPOUND_CONTEXTS)
 
         assertEquals(4, attributeDetails.size)
@@ -165,7 +165,7 @@ class AttributeServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should return an empty list of AttributeDetails if no attribute was found`() = runTest {
+    fun `getAttributeDetails should return an empty list when no AttributeDetails is found`() = runTest {
         clearPreviousAttributesAndObservations()
 
         val attributeDetails = attributeService.getAttributeDetails(APIC_COMPOUND_CONTEXTS)
@@ -174,7 +174,7 @@ class AttributeServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should return an attribute Information by specific attribute`() = runTest {
+    fun `getAttributeTypeInfoByAttribute should return attribute information for a specific attribute`() = runTest {
         val attributeTypeInfo =
             attributeService.getAttributeTypeInfoByAttribute(INCOMING_IRI, APIC_COMPOUND_CONTEXTS)
                 .shouldSucceedAndResult()
@@ -188,7 +188,7 @@ class AttributeServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should error when type doesn't exist`() = runTest {
+    fun `getAttributeTypeInfoByAttribute should error when type does not exist`() = runTest {
         val attributeTypeInfo =
             attributeService.getAttributeTypeInfoByAttribute(TEMPERATURE_IRI, APIC_COMPOUND_CONTEXTS)
 

--- a/search-service/src/test/kotlin/com/egm/stellio/search/discovery/service/EntityTypeServiceTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/discovery/service/EntityTypeServiceTests.kt
@@ -146,14 +146,14 @@ class EntityTypeServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should return a list of all known entity types`() = runTest {
+    fun `getEntityTypeList should return a list of all known entity types`() = runTest {
         val entityTypes = entityTypeService.getEntityTypeList(APIC_COMPOUND_CONTEXTS)
 
         assertEquals(listOf(APIARY_TERM, BEEHIVE_TERM, SENSOR_TERM), entityTypes.typeList)
     }
 
     @Test
-    fun `it should return an empty list of types if no entity exists`() = runTest {
+    fun `getEntityTypeList should return an empty list of types if no entity exists`() = runTest {
         clearPreviousAttributesAndObservations()
 
         val entityTypes = entityTypeService.getEntityTypeList(listOf(AQUAC_COMPOUND_CONTEXT))
@@ -161,7 +161,7 @@ class EntityTypeServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should return all known entity types with details`() = runTest {
+    fun `getEntityTypes should return all known entity types with details`() = runTest {
         val entityTypes = entityTypeService.getEntityTypes(APIC_COMPOUND_CONTEXTS)
 
         assertThat(entityTypes)
@@ -202,7 +202,7 @@ class EntityTypeServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should return an empty list of detailed entity types if no entity exists`() = runTest {
+    fun `getEntityTypes should return an empty list of detailed entity types if no entity exists`() = runTest {
         clearPreviousAttributesAndObservations()
 
         val entityTypes = entityTypeService.getEntityTypes(listOf(AQUAC_COMPOUND_CONTEXT))
@@ -210,7 +210,7 @@ class EntityTypeServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should return entity type info for a specific type`() = runTest {
+    fun `getEntityTypeInfoByType should return entity type info for a specific type`() = runTest {
         val entityTypeInfo = entityTypeService.getEntityTypeInfoByType(SENSOR_IRI, APIC_COMPOUND_CONTEXTS)
 
         entityTypeInfo.shouldSucceedWith {
@@ -253,7 +253,7 @@ class EntityTypeServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should return an error when entity type doesn't exist`() = runTest {
+    fun `getEntityTypeInfoByType should return an error when the entity type does not exist`() = runTest {
         entityTypeService.getEntityTypeInfoByType(TEMPERATURE_IRI, APIC_COMPOUND_CONTEXTS)
             .shouldFail {
                 assertEquals(ResourceNotFoundException(typeNotFoundMessage(TEMPERATURE_IRI)), it)

--- a/search-service/src/test/kotlin/com/egm/stellio/search/entity/listener/TelemetryListenerTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/entity/listener/TelemetryListenerTests.kt
@@ -49,7 +49,7 @@ class TelemetryListenerTests {
     )
 
     @Test
-    fun `it should ingest a valid telemetry message`() = runTest {
+    fun `handleTelemetryMessage should ingest a valid telemetry message`() = runTest {
         coEvery {
             entityService.mergeAttribute(any(), any(), any(), any())
         } returns listOf(
@@ -64,7 +64,7 @@ class TelemetryListenerTests {
     }
 
     @Test
-    fun `it should ingest a valid telemetry message having a datasetId`() = runTest {
+    fun `handleTelemetryMessage should ingest a valid telemetry message having a datasetId`() = runTest {
         coEvery {
             entityService.mergeAttribute(any(), any(), any(), any())
         } returns listOf(
@@ -79,7 +79,7 @@ class TelemetryListenerTests {
     }
 
     @Test
-    fun `it should not call ingestAttribute when message is malformed JSON`() = runTest {
+    fun `handleTelemetryMessage should not call ingestAttribute when message is malformed JSON`() = runTest {
         telemetryListener.handleTelemetryMessage("not valid json{")
 
         coVerify(exactly = 0) {

--- a/search-service/src/test/kotlin/com/egm/stellio/search/entity/model/EntityModelTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/entity/model/EntityModelTests.kt
@@ -26,7 +26,7 @@ class EntityModelTests {
     )
 
     @Test
-    fun `it should serialize entityPayload with createdAt and modifiedAt`() {
+    fun `serializeProperties should serialize entityPayload with createdAt and modifiedAt`() {
         val serializedEntity = entity.serializeProperties()
         assertTrue(serializedEntity.contains(NGSILD_CREATED_AT_IRI))
         assertTrue(serializedEntity.contains(NGSILD_MODIFIED_AT_IRI))
@@ -34,7 +34,7 @@ class EntityModelTests {
     }
 
     @Test
-    fun `it should serialize entityPayload with SAP if present`() {
+    fun `serializeProperties should serialize entityPayload with SAP if present`() {
         val entityPayloadWithSAP =
             entity.copy(specificAccessPolicy = Action.WRITE)
         val serializedEntity = entityPayloadWithSAP.serializeProperties()

--- a/search-service/src/test/kotlin/com/egm/stellio/search/entity/model/UpdateResultTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/entity/model/UpdateResultTests.kt
@@ -7,19 +7,19 @@ import org.junit.jupiter.api.Test
 class UpdateResultTests {
 
     @Test
-    fun `it should find the successful update operation results`() {
+    fun `isSuccessResult should find the successful update operation results`() {
         assertTrue(OperationStatus.UPDATED.isSuccessResult())
         assertTrue(OperationStatus.CREATED.isSuccessResult())
         assertTrue(OperationStatus.DELETED.isSuccessResult())
     }
 
     @Test
-    fun `it should find the failed update operation results`() {
+    fun `isSuccessResult should find the failed update operation results`() {
         assertFalse(OperationStatus.FAILED.isSuccessResult())
     }
 
     @Test
-    fun `it should find a successful update result`() {
+    fun `isSuccessful should find a successful update result`() {
         val updateResult =
             UpdateResult(
                 notUpdated = emptyList(),
@@ -30,7 +30,7 @@ class UpdateResultTests {
     }
 
     @Test
-    fun `it should find a failed update result if there is one not updated attribute`() {
+    fun `isSuccessful should find a failed update result when there is one not updated attribute`() {
         val updateResult =
             UpdateResult(
                 notUpdated = listOf(NotUpdatedDetails("attributeName", "attribute is malformed")),
@@ -41,7 +41,7 @@ class UpdateResultTests {
     }
 
     @Test
-    fun `it should find a failed update result if an attribute update has failed`() {
+    fun `isSuccessful should find a failed update result when an attribute update has failed`() {
         val updateResult =
             UpdateResult(
                 notUpdated = listOf(

--- a/search-service/src/test/kotlin/com/egm/stellio/search/entity/service/EntityAttributeServiceTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/entity/service/EntityAttributeServiceTests.kt
@@ -117,7 +117,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
     }
 
     @Test
-    fun `it should retrieve a persisted temporal entity attribute`() = runTest {
+    fun `getForEntity should retrieve a persisted temporal entity attribute`() = runTest {
         val rawEntity = loadSampleData("beehive_two_temporal_properties.jsonld")
 
         coEvery { attributeInstanceService.create(any()) } returns Unit.right()
@@ -145,7 +145,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
 
     @Test
     @WithMockCustomUser(sub = USER_UUID, name = "Mock User")
-    fun `it should create entries for all attributes of an entity`() = runTest {
+    fun `createAttributes should create entries for all attributes of an entity`() = runTest {
         val rawEntity = loadSampleData()
 
         coEvery { attributeInstanceService.create(any()) } returns Unit.right()
@@ -196,7 +196,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
     }
 
     @Test
-    fun `it should create entries for a multi-instance property`() = runTest {
+    fun `createAttributes should create entries for a multi-instance property`() = runTest {
         val rawEntity = loadSampleData("beehive_multi_instance_property.jsonld")
 
         coEvery { attributeInstanceService.create(any()) } returns Unit.right()
@@ -246,7 +246,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
     }
 
     @Test
-    fun `it should create entries for a multi-valued-relationships`() = runTest {
+    fun `createAttributes should create entries for a multi-valued-relationships`() = runTest {
         val rawEntity =
             """
             {
@@ -292,7 +292,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
     }
 
     @Test
-    fun `it should rollback the whole operation if one DB update fails`() = runTest {
+    fun `createAttributes should rollback the whole operation if one DB update fails`() = runTest {
         val rawEntity = loadSampleData()
 
         coEvery { attributeInstanceService.create(any()) } returns Unit.right()
@@ -314,7 +314,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
     }
 
     @Test
-    fun `it should raise a BadRequestData error when creating property with a NGSI-LD Null value`() = runTest {
+    fun `createAttributes should fail when creating a property with a NGSI-LD Null value`() = runTest {
         coEvery { attributeInstanceService.create(any()) } returns Unit.right()
 
         val entityWithNullAttribute = """
@@ -336,7 +336,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
     }
 
     @Test
-    fun `it should raise a BadRequestData error when creating relationship with a NGSI-LD Null value`() = runTest {
+    fun `createAttributes should fail when creating a relationship with a NGSI-LD Null value`() = runTest {
         coEvery { attributeInstanceService.create(any()) } returns Unit.right()
 
         val entityWithNullAttribute = """
@@ -358,7 +358,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
     }
 
     @Test
-    fun `it should replace a temporal entity attribute`() = runTest {
+    fun `addOrReplaceAttribute should replace a temporal entity attribute`() = runTest {
         val rawEntity = loadSampleData()
 
         coEvery { attributeInstanceService.create(any()) } returns Unit.right()
@@ -402,7 +402,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
     }
 
     @Test
-    fun `it should merge an entity attribute`() = runTest {
+    fun `mergeAttribute should merge an entity attribute`() = runTest {
         val rawEntity = loadSampleData()
 
         coEvery { attributeInstanceService.create(any()) } returns Unit.right()
@@ -464,7 +464,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
     }
 
     @Test
-    fun `it should merge a previously deleted entity attribute by replacing the deleted one`() = runTest {
+    fun `mergeAttributes should merge a previously deleted attribute by replacing the deleted one`() = runTest {
         val rawEntity = loadSampleData()
 
         coEvery { attributeInstanceService.create(any()) } returns Unit.right()
@@ -500,7 +500,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
     }
 
     @Test
-    fun `it should merge an entity attributes`() = runTest {
+    fun `mergeAttributes should merge an entity attributes`() = runTest {
         val rawEntity = loadSampleData()
 
         coEvery { attributeInstanceService.create(any()) } returns Unit.right()
@@ -561,7 +561,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
     }
 
     @Test
-    fun `it should merge an entity attributes with observedAt parameter`() = runTest {
+    fun `mergeAttributes should merge an entity attributes with observedAt parameter`() = runTest {
         val rawEntity = loadSampleData()
 
         coEvery { attributeInstanceService.create(any()) } returns Unit.right()
@@ -599,7 +599,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
     }
 
     @Test
-    fun `it should delete an attribute in merge operation if its value is NGSI-LD null`() = runTest {
+    fun `mergeAttributes should delete an attribute when its value is NGSI-LD null`() = runTest {
         val rawEntity = loadSampleData()
 
         coEvery { attributeInstanceService.create(any()) } returns Unit.right()
@@ -645,7 +645,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
     }
 
     @Test
-    fun `it should delete an attribute in update operation if its value is NGSI-LD null`() = runTest {
+    fun `updateAttributes should delete an attribute when its value is NGSI-LD null`() = runTest {
         val rawEntity = loadSampleData()
 
         coEvery { attributeInstanceService.create(any()) } returns Unit.right()
@@ -690,7 +690,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
     }
 
     @Test
-    fun `it should update a previously deleted attribute by replacing the deleted one`() = runTest {
+    fun `updateAttributes should update a previously deleted attribute by replacing the deleted one`() = runTest {
         val rawEntity = loadSampleData()
 
         coEvery { attributeInstanceService.create(any()) } returns Unit.right()
@@ -729,7 +729,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
     }
 
     @Test
-    fun `it should delete an attribute in partial attribute update operation if its value is NGSI-LD null`() = runTest {
+    fun `partialUpdateAttribute should delete an attribute when its value is NGSI-LD null`() = runTest {
         val rawEntity = loadSampleData()
 
         coEvery { attributeInstanceService.create(any()) } returns Unit.right()
@@ -770,7 +770,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
     }
 
     @Test
-    fun `it should partial update a property without providing its value`() = runTest {
+    fun `partialUpdateAttribute should partial update a property without providing its value`() = runTest {
         val rawEntity = loadSampleData()
 
         coEvery { attributeInstanceService.create(any()) } returns Unit.right()
@@ -826,7 +826,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
     }
 
     @Test
-    fun `it should replace an entity attribute`() = runTest {
+    fun `replaceAttribute should replace an entity attribute`() = runTest {
         val rawEntity = loadSampleData()
 
         coEvery { attributeInstanceService.create(any()) } returns Unit.right()
@@ -862,7 +862,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
     }
 
     @Test
-    fun `it should ignore a replace attribute if attribute does not exist`() = runTest {
+    fun `replaceAttribute should ignore a replace when the attribute does not exist`() = runTest {
         val rawEntity = loadSampleData()
 
         coEvery { attributeInstanceService.create(any()) } returns Unit.right()
@@ -887,7 +887,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
     }
 
     @Test
-    fun `it should ignore a replace attribute if attribute was previously deleted`() = runTest {
+    fun `replaceAttribute should ignore a replace if the attribute was previously deleted`() = runTest {
         val rawEntity = loadSampleData()
 
         coEvery { attributeInstanceService.create(any()) } returns Unit.right()
@@ -920,7 +920,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
     }
 
     @Test
-    fun `it should raise a BadRequestData error when replacing an attribute with a NGSI-LD Null value`() = runTest {
+    fun `replaceAttribute should raise a BadRequestData error when replacing with a NGSI-LD Null value`() = runTest {
         val rawEntity = loadSampleData()
 
         coEvery { attributeInstanceService.create(any()) } returns Unit.right()
@@ -948,7 +948,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
     }
 
     @Test
-    fun `it should raise a BadRequestData error when appending an attribute with a NGSI-LD Null value`() = runTest {
+    fun `appendAttributes should raise a BadRequestData error when appending a NGSI-LD Null value`() = runTest {
         val rawEntity = loadSampleData()
 
         coEvery { attributeInstanceService.create(any()) } returns Unit.right()
@@ -979,7 +979,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
     }
 
     @Test
-    fun `it should return the attributeId of a given entityId and attributeName`() = runTest {
+    fun `getForEntityAndAttribute should return the attributeId for an entityId and attributeName`() = runTest {
         val rawEntity = loadSampleData()
 
         coEvery { attributeInstanceService.create(any()) } returns Unit.right()
@@ -993,7 +993,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
     }
 
     @Test
-    fun `it should return the attributeId of a given entityId attributeName and datasetId`() = runTest {
+    fun `getForEntityAndAttribute should return the attributeId for entityId attributeName and datasetId`() = runTest {
         val rawEntity = loadSampleData("beehive_multi_instance_property.jsonld")
 
         coEvery { attributeInstanceService.create(any()) } returns Unit.right()
@@ -1008,7 +1008,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
     }
 
     @Test
-    fun `it should not return a attributeId if the datasetId is unknown`() = runTest {
+    fun `getForEntityAndAttribute should not return an attributeId if the datasetId is unknown`() = runTest {
         val rawEntity = loadSampleData("beehive_multi_instance_property.jsonld")
 
         coEvery { attributeInstanceService.create(any()) } returns Unit.right()
@@ -1025,7 +1025,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
     }
 
     @Test
-    fun `it should flag and audit a deleted attribute`() = runTest {
+    fun `deleteAttribute should flag and audit a deleted attribute`() = runTest {
         val rawEntity = loadSampleData("beehive_two_temporal_properties.jsonld")
 
         coEvery { attributeInstanceService.create(any()) } returns Unit.right()
@@ -1069,7 +1069,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
     }
 
     @Test
-    fun `it should flag and audit all instances of a deleted attribute`() = runTest {
+    fun `deleteAttribute should flag and audit all instances of a deleted attribute`() = runTest {
         val rawEntity = loadSampleData("beehive_multi_instance_property.jsonld")
 
         coEvery { attributeInstanceService.create(any()) } returns Unit.right()
@@ -1096,7 +1096,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
     }
 
     @Test
-    fun `it should flag and audit all deleted attributes of an entity`() = runTest {
+    fun `deleteAttributes should flag and audit all deleted attributes of an entity`() = runTest {
         val rawEntity = loadSampleData("beehive.jsonld")
 
         coEvery { attributeInstanceService.create(any()) } returns Unit.right()
@@ -1120,7 +1120,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
     }
 
     @Test
-    fun `it should permanently delete an attribute of an entity`() = runTest {
+    fun `permanentlyDeleteAttribute should permanently delete an attribute of an entity`() = runTest {
         val rawEntity = loadSampleData("beehive.jsonld")
 
         coEvery { attributeInstanceService.create(any()) } returns Unit.right()
@@ -1144,7 +1144,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
     }
 
     @Test
-    fun `it should permanently delete all attribute of an entity`() = runTest {
+    fun `permanentlyDeleteAttributes should permanently delete all attributes of an entity`() = runTest {
         val rawEntity = loadSampleData("beehive.jsonld")
 
         coEvery { attributeInstanceService.create(any()) } returns Unit.right()
@@ -1166,7 +1166,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
     }
 
     @Test
-    fun `it should return a right unit if entiy and attribute exist`() = runTest {
+    fun `checkEntityAndAttributeExistence should return a right unit if entity and attribute exist`() = runTest {
         val rawEntity = loadSampleData()
 
         coEvery { attributeInstanceService.create(any()) } returns Unit.right()
@@ -1178,7 +1178,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
     }
 
     @Test
-    fun `it should return a right unit if entiy and attribute exist whatever its datasetId`() = runTest {
+    fun `checkEntityAndAttributeExistence should succeed whatever the datasetId when both exist`() = runTest {
         val rawEntity = loadSampleData("beehive_multi_instance_property.jsonld")
 
         coEvery { attributeInstanceService.create(any()) } returns Unit.right()
@@ -1190,7 +1190,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
     }
 
     @Test
-    fun `it should return a left attribute not found if entity exists but not the attribute`() = runTest {
+    fun `checkEntityAndAttributeExistence should return a left when the attribute is not found`() = runTest {
         val rawEntity = loadSampleData()
 
         coEvery { attributeInstanceService.create(any()) } returns Unit.right()
@@ -1206,7 +1206,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
     }
 
     @Test
-    fun `it should return a left entity not found if entity does not exist`() = runTest {
+    fun `checkEntityAndAttributeExistence should return a left entity not found if entity does not exist`() = runTest {
         entityAttributeService.checkEntityAndAttributeExistence(
             "urn:ngsi-ld:Entity:01".toUri(),
             "speed"

--- a/search-service/src/test/kotlin/com/egm/stellio/search/entity/service/EntityEventServiceTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/entity/service/EntityEventServiceTests.kt
@@ -110,7 +110,7 @@ class EntityEventServiceTests {
         """.trimIndent()
 
     @Test
-    fun `it should publish all events on the catch-all topic`() {
+    fun `publishEntityEvent should publish all events on the catch-all topic`() {
         every { kafkaTemplate.send(any(), any(), any()) } returns CompletableFuture()
 
         entityEventService.publishEntityEvent(
@@ -127,7 +127,7 @@ class EntityEventServiceTests {
     }
 
     @Test
-    fun `it should publish an ENTITY_CREATE event`() = runTest {
+    fun `publishEntityCreateEvent should publish an ENTITY_CREATE event`() = runTest {
         every { kafkaTemplate.send(any(), any(), any()) } returns CompletableFuture()
 
         entityEventService.publishEntityCreateEvent(
@@ -139,7 +139,7 @@ class EntityEventServiceTests {
     }
 
     @Test
-    fun `it should publish an ENTITY_DELETE event`() = runTest {
+    fun `publishEntityDeleteEvent should publish an ENTITY_DELETE event`() = runTest {
         val entity = mockk<Entity>(relaxed = true) {
             every { entityId } returns breedingServiceUri
         }
@@ -151,7 +151,7 @@ class EntityEventServiceTests {
     }
 
     @Test
-    fun `it should publish a single ATTRIBUTE_CREATE event if an attribute was appended`() = runTest {
+    fun `publishAttributeChangeEvents should publish an ATTRIBUTE_CREATE event on append`() = runTest {
         val expandedAttribute =
             expandAttribute(fishNumberTerm, fishNumberAttributeFragment, listOf(AQUAC_COMPOUND_CONTEXT))
         entityEventService.publishAttributeChangeEvents(
@@ -183,7 +183,7 @@ class EntityEventServiceTests {
     }
 
     @Test
-    fun `it should publish ATTRIBUTE_CREATE and ATTRIBUTE_UPDATE events if attributes were appended and replaced`() =
+    fun `publishAttributeChangeEvents should publish CREATE and UPDATE events on append and replace`() =
         runTest {
             val attributesPayload = """
                 {
@@ -246,7 +246,7 @@ class EntityEventServiceTests {
         }
 
     @Test
-    fun `it should publish ATTRIBUTE_UPDATE events if two attributes are replaced`() = runTest {
+    fun `publishAttributeChangeEvents should publish ATTRIBUTE_UPDATE events on two replaced attributes`() = runTest {
         val attributesPayload =
             """
             {
@@ -298,7 +298,7 @@ class EntityEventServiceTests {
     }
 
     @Test
-    fun `it should publish ATTRIBUTE_UPDATE events if a multi-attribute is replaced`() = runTest {
+    fun `publishAttributeChangeEvents should publish ATTRIBUTE_UPDATE events on multi-attribute replace`() = runTest {
         val fishNameAttributeFragment2 =
             """
             {
@@ -364,7 +364,7 @@ class EntityEventServiceTests {
     }
 
     @Test
-    fun `it should publish ATTRIBUTE_UPDATE event if an attribute is updated`() = runTest {
+    fun `publishAttributeChangeEvents should publish ATTRIBUTE_UPDATE event if an attribute is updated`() = runTest {
         val expandedAttribute = expandAttribute(
             fishNameTerm,
             fishNameAttributeFragment,
@@ -401,7 +401,7 @@ class EntityEventServiceTests {
     }
 
     @Test
-    fun `it should publish ATTRIBUTE_DELETE event if an attribute has been deleted as part of an update `() = runTest {
+    fun `publishAttributeChangeEvents should publish ATTRIBUTE_DELETE event on delete during update`() = runTest {
         entityEventService.publishAttributeChangeEvents(
             null,
             originalEntity,
@@ -433,7 +433,7 @@ class EntityEventServiceTests {
     }
 
     @Test
-    fun `it should publish ATTRIBUTE_DELETE event if an instance of an attribute is deleted`() = runTest {
+    fun `publishAttributeDeleteEvent should publish ATTRIBUTE_DELETE event when an instance is deleted`() = runTest {
         entityEventService.publishAttributeDeleteEvent(
             null,
             originalEntity,

--- a/search-service/src/test/kotlin/com/egm/stellio/search/entity/service/EntityQueryServiceTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/entity/service/EntityQueryServiceTests.kt
@@ -126,7 +126,7 @@ class EntityQueryServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `retrieve should retrieve an entity payload`() = runTest {
+    fun `retrieve should return the stored entity payload`() = runTest {
         loadMinimalEntity(entity01Uri, setOf(BEEHIVE_IRI))
             .sampleDataToNgsiLdEntity()
             .map {
@@ -149,7 +149,7 @@ class EntityQueryServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `retrieve should retrieve a list of entity payloads`() = runTest {
+    fun `retrieve should return all requested entity payloads`() = runTest {
         val entityPayload = loadSampleData("beehive.jsonld")
         val createdAt = ZonedDateTime.parse("2023-08-20T15:44:10.381090Z")
         entityPayload.sampleDataToNgsiLdEntity().map {

--- a/search-service/src/test/kotlin/com/egm/stellio/search/entity/service/EntityQueryServiceTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/entity/service/EntityQueryServiceTests.kt
@@ -63,7 +63,7 @@ class EntityQueryServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should return a JSON-LD entity when querying by id`() = runTest {
+    fun `queryEntity should return a JSON-LD entity when querying by id`() = runTest {
         coEvery { authorizationService.userCanReadEntity(any()) } returns Unit.right()
 
         loadAndPrepareSampleData("beehive.jsonld")
@@ -84,7 +84,7 @@ class EntityQueryServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should return an API exception if no entity exists with the given id`() = runTest {
+    fun `queryEntity should return an API exception when no entity exists with the given id`() = runTest {
         entityQueryService.queryEntity(entity01Uri)
             .shouldFail {
                 assertTrue(it is ResourceNotFoundException)
@@ -92,7 +92,7 @@ class EntityQueryServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should return a list of JSON-LD entities when querying entities`() = runTest {
+    fun `queryEntities should return a list of JSON-LD entities when querying entities`() = runTest {
         coEvery { authorizationService.userCanCreateEntities() } returns Unit.right()
         coEvery { authorizationService.createEntityOwnerRight(any()) } returns Unit.right()
         coEvery { authorizationService.getAccessRightWithClauseAndFilter() } returns null
@@ -115,7 +115,7 @@ class EntityQueryServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should return an empty list if no entity matched the query`() = runTest {
+    fun `queryEntities should return an empty list when no entity matched the query`() = runTest {
         coEvery { authorizationService.getAccessRightWithClauseAndFilter() } returns null
 
         entityQueryService.queryEntities(buildDefaultQueryParams().copy(ids = setOf(entity01Uri)))
@@ -126,7 +126,7 @@ class EntityQueryServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should retrieve an entity payload`() = runTest {
+    fun `retrieve should retrieve an entity payload`() = runTest {
         loadMinimalEntity(entity01Uri, setOf(BEEHIVE_IRI))
             .sampleDataToNgsiLdEntity()
             .map {
@@ -149,7 +149,7 @@ class EntityQueryServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should retrieve a list of entity payloads`() = runTest {
+    fun `retrieve should retrieve a list of entity payloads`() = runTest {
         val entityPayload = loadSampleData("beehive.jsonld")
         val createdAt = ZonedDateTime.parse("2023-08-20T15:44:10.381090Z")
         entityPayload.sampleDataToNgsiLdEntity().map {
@@ -167,7 +167,7 @@ class EntityQueryServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should filter existing entities from a list of ids`() = runTest {
+    fun `filterExistingEntitiesAsIds should filter existing entities from a list of ids`() = runTest {
         loadMinimalEntity(entity01Uri, setOf(BEEHIVE_IRI))
             .sampleDataToNgsiLdEntity()
             .map {
@@ -184,13 +184,13 @@ class EntityQueryServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should return an empty list if no ids are provided to the filter on existence`() = runTest {
+    fun `filterExistingEntitiesAsIds should return an empty list when no ids are provided`() = runTest {
         val existingEntities = entityQueryService.filterExistingEntitiesAsIds(emptyList())
         assertTrue(existingEntities.isEmpty())
     }
 
     @Test
-    fun `it should check the existence of an entity`() = runTest {
+    fun `checkEntityExistence should check the existence of an entity`() = runTest {
         loadMinimalEntity(entity01Uri, setOf(BEEHIVE_IRI))
             .sampleDataToNgsiLdEntity()
             .map {
@@ -207,7 +207,7 @@ class EntityQueryServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should check the state of an entity`() = runTest {
+    fun `isMarkedAsDeleted should check the state of an entity`() = runTest {
         loadMinimalEntity(entity01Uri, setOf(BEEHIVE_IRI))
             .sampleDataToNgsiLdEntity()
             .map {

--- a/search-service/src/test/kotlin/com/egm/stellio/search/entity/service/EntityServiceQueriesTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/entity/service/EntityServiceQueriesTests.kt
@@ -110,7 +110,7 @@ class EntityServiceQueriesTests : WithTimescaleContainer, WithKafkaContainer() {
         "$SENSOR_IRI, 1, urn:ngsi-ld:MultiTypes:03",
         "'($BEEKEEPER_IRI;$SENSOR_IRI),$DEVICE_IRI', 1, urn:ngsi-ld:MultiTypes:03"
     )
-    fun `it should retrieve entities according types selection languages`(
+    fun `queryEntities should retrieve entities according types selection languages`(
         types: String,
         expectedCount: Int,
         expectedListOfEntities: String?
@@ -139,7 +139,7 @@ class EntityServiceQueriesTests : WithTimescaleContainer, WithKafkaContainer() {
         "/Madrid/Gardens/ParqueNorte;/CompanyA/OrganizationB/UnitC, 1, urn:ngsi-ld:BeeHive:01",
         "'/Madrid/Gardens/ParqueNorte,/CompanyA/OrganizationB/UnitC',2,'urn:ngsi-ld:BeeHive:01,urn:ngsi-ld:BeeHive:02'"
     )
-    fun `it should retrieve entities according to scope query`(
+    fun `queryEntities should retrieve entities according to scope query`(
         scopeQ: String,
         expectedCount: Int,
         expectedListOfEntities: String?
@@ -161,7 +161,7 @@ class EntityServiceQueriesTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should retrieve entities according to ids and a type`() = runTest {
+    fun `queryEntities should retrieve entities according to ids and a type`() = runTest {
         val entitiesIds =
             entityQueryService.queryEntities(
                 EntitiesQueryFromGet(
@@ -178,7 +178,7 @@ class EntityServiceQueriesTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should retrieve entities according to ids and a selection of types`() = runTest {
+    fun `queryEntities should retrieve entities according to ids and a selection of types`() = runTest {
         val entitiesIds =
             entityQueryService.queryEntities(
                 EntitiesQueryFromGet(
@@ -195,7 +195,7 @@ class EntityServiceQueriesTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should retrieve entities according to attrs and types`() = runTest {
+    fun `queryEntities should retrieve entities according to attrs and types`() = runTest {
         val entitiesIds =
             entityQueryService.queryEntities(
                 EntitiesQueryFromGet(
@@ -212,7 +212,7 @@ class EntityServiceQueriesTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should retrieve entities by a list of ids`() = runTest {
+    fun `queryEntities should retrieve entities by a list of ids`() = runTest {
         val entitiesIds =
             entityQueryService.queryEntities(
                 EntitiesQueryFromGet(
@@ -229,7 +229,7 @@ class EntityServiceQueriesTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should retrieve entities with respect to limit and offset`() = runTest {
+    fun `queryEntities should retrieve entities with respect to limit and offset`() = runTest {
         val entitiesIds =
             entityQueryService.queryEntities(
                 EntitiesQueryFromGet(
@@ -244,7 +244,7 @@ class EntityServiceQueriesTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should retrieve entities with respect to idPattern`() = runTest {
+    fun `queryEntities should retrieve entities with respect to idPattern`() = runTest {
         val entitiesIds =
             entityQueryService.queryEntities(
                 EntitiesQueryFromGet(
@@ -326,7 +326,7 @@ class EntityServiceQueriesTests : WithTimescaleContainer, WithKafkaContainer() {
         "propWithLangSub.langSub[en]~=\"sub lang.*\", 2, 'urn:ngsi-ld:BeeHive:01,urn:ngsi-ld:BeeHive:02'",
         "propWithLangSub.langSub[de]==\"anything\", 0, "
     )
-    fun `it should retrieve entities according to q parameter`(
+    fun `queryEntities should retrieve entities according to q parameter`(
         q: String,
         expectedCount: Int,
         expectedListOfEntities: String?
@@ -360,7 +360,7 @@ class EntityServiceQueriesTests : WithTimescaleContainer, WithKafkaContainer() {
         "disjoint, Point, '[101.0, 0.0]', 2",
         "disjoint, Polygon, '[[[100.0, 0.0], [101.0, 0.0], [101.0, -1.0], [100.0, 0.0]]]', 1"
     )
-    fun `it should retrieve entities according to geoquery parameter`(
+    fun `queryEntities should retrieve entities according to geoquery parameter`(
         georel: String,
         geometry: String,
         coordinates: String,
@@ -388,7 +388,7 @@ class EntityServiceQueriesTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should retrieve entities according to one entity selector`() = runTest {
+    fun `queryEntities should retrieve entities according to one entity selector`() = runTest {
         val entitiesIds =
             entityQueryService.queryEntities(
                 EntitiesQueryFromPost(
@@ -432,7 +432,7 @@ class EntityServiceQueriesTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should retrieve entities with a query without an entity selector`() = runTest {
+    fun `queryEntities should retrieve entities with a query without an entity selector`() = runTest {
         val entitiesIds =
             entityQueryService.queryEntities(
                 EntitiesQueryFromPost(
@@ -449,7 +449,7 @@ class EntityServiceQueriesTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should retrieve entities according to two entity selectors with type and idPattern`() = runTest {
+    fun `queryEntities should retrieve entities according to two entity selectors with type and idPattern`() = runTest {
         val entitiesIds =
             entityQueryService.queryEntities(
                 EntitiesQueryFromPost(
@@ -473,7 +473,7 @@ class EntityServiceQueriesTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should retrieve entities according to two entity selectors with type and id`() = runTest {
+    fun `queryEntities should retrieve entities according to two entity selectors with type and id`() = runTest {
         val entitiesIds =
             entityQueryService.queryEntities(
                 EntitiesQueryFromPost(
@@ -497,7 +497,7 @@ class EntityServiceQueriesTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should retrieve entities according to two entity selectors with one not matching any entities`() = runTest {
+    fun `queryEntities should retrieve entities for two selectors with one matching nothing`() = runTest {
         val entitiesIds =
             entityQueryService.queryEntities(
                 EntitiesQueryFromPost(
@@ -578,7 +578,7 @@ class EntityServiceQueriesTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should retrieve the count of entities`() = runTest {
+    fun `queryEntitiesCount should retrieve the count of entities`() = runTest {
         entityQueryService.queryEntitiesCount(
             EntitiesQueryFromGet(
                 typeSelection = BEEHIVE_IRI,
@@ -590,7 +590,7 @@ class EntityServiceQueriesTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should retrieve the count of entities according to access rights`() = runTest {
+    fun `queryEntitiesCount should retrieve the count of entities according to access rights`() = runTest {
         entityQueryService.queryEntitiesCount(
             EntitiesQueryFromGet(
                 ids = setOf(entity02Uri, entity01Uri),
@@ -604,7 +604,7 @@ class EntityServiceQueriesTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should return an empty list if no entity matches the requested type`() = runTest {
+    fun `queryEntities should return an empty list if no entity matches the requested type`() = runTest {
         val entitiesIds =
             entityQueryService.queryEntities(
                 EntitiesQueryFromGet(
@@ -620,7 +620,7 @@ class EntityServiceQueriesTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should return an empty list if no entity matches the requested attributes`() = runTest {
+    fun `queryEntities should return an empty list if no entity matches the requested attributes`() = runTest {
         val entitiesIds =
             entityQueryService.queryEntities(
                 EntitiesQueryFromGet(
@@ -649,7 +649,7 @@ class EntityServiceQueriesTests : WithTimescaleContainer, WithKafkaContainer() {
         "propWithJsonSub.jsonSub[reading]==7.3, propWithJsonSub, 1, urn:ngsi-ld:BeeHive:01",
         "propWithJsonSub.jsonSub[reading]==3..8, propWithJsonSub, 2, "
     )
-    fun `it should retrieve entities according to q parameter with a JsonProperty attribute and sub-attribute`(
+    fun `queryEntities should retrieve entities with q on a JsonProperty attribute and sub-attribute`(
         q: String,
         jsonKeys: String,
         expectedCount: Int,
@@ -680,7 +680,7 @@ class EntityServiceQueriesTests : WithTimescaleContainer, WithKafkaContainer() {
         "propWithVocabSub.vocabSub==\"Apiary\", propWithVocabSub, 1, urn:ngsi-ld:BeeHive:02",
         "propWithVocabSub.vocabSub==\"Beekeeper\", propWithVocabSub, 0, ",
     )
-    fun `it should retrieve entities according to q parameter with a VocabProperty attribute and sub-attribute`(
+    fun `queryEntities should retrieve entities with q on a VocabProperty attribute and sub-attribute`(
         q: String,
         expandValues: String,
         expectedCount: Int,
@@ -704,7 +704,7 @@ class EntityServiceQueriesTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should not match entities when expandValues is not set for a vocab attribute`() = runTest {
+    fun `queryEntities should not match entities when expandValues is not set for a vocab attribute`() = runTest {
         val entitiesIds =
             entityQueryService.queryEntities(
                 EntitiesQueryFromGet(
@@ -727,7 +727,7 @@ class EntityServiceQueriesTests : WithTimescaleContainer, WithKafkaContainer() {
         "boolean==true, 1, urn:ngsi-ld:BeeHive:01",
         "!name;integer==143, 1, urn:ngsi-ld:BeeHive:02"
     )
-    fun `it should retrieve entities according to q parameter via POST query`(
+    fun `queryEntities should retrieve entities according to q parameter via POST query`(
         q: String,
         expectedCount: Int,
         expectedListOfEntities: String?
@@ -751,7 +751,7 @@ class EntityServiceQueriesTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should retrieve entities according to jsonKeys via POST query`() = runTest {
+    fun `queryEntities should retrieve entities according to jsonKeys via POST query`() = runTest {
         val entitiesIds =
             entityQueryService.queryEntities(
                 EntitiesQueryFromPost(
@@ -771,7 +771,7 @@ class EntityServiceQueriesTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should retrieve entities according to expandValues via POST query`() = runTest {
+    fun `queryEntities should retrieve entities according to expandValues via POST query`() = runTest {
         val entitiesIds =
             entityQueryService.queryEntities(
                 EntitiesQueryFromPost(
@@ -798,7 +798,7 @@ class EntityServiceQueriesTests : WithTimescaleContainer, WithKafkaContainer() {
         "propWithJsonSub.jsonSub[reading]==3.1, 1, urn:ngsi-ld:BeeHive:02",
         "propWithJsonSub.jsonSub[sensor]==\"S99\", 0, "
     )
-    fun `it should retrieve entities according to q parameter with json property sub-attribute`(
+    fun `queryEntities should retrieve entities according to q parameter with json property sub-attribute`(
         q: String,
         expectedCount: Int,
         expectedListOfEntities: String?

--- a/search-service/src/test/kotlin/com/egm/stellio/search/entity/service/EntityServiceTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/entity/service/EntityServiceTests.kt
@@ -104,7 +104,7 @@ class EntityServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should create an entity payload from string if none existed yet`() = runTest {
+    fun `createEntityPayload should create an entity payload from string if none existed yet`() = runTest {
         loadMinimalEntity(entity01Uri, setOf(BEEHIVE_IRI))
             .sampleDataToNgsiLdEntity()
             .map {
@@ -117,7 +117,7 @@ class EntityServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should create an entity payload from an NGSI-LD Entity if none existed yet`() = runTest {
+    fun `createEntityPayload should create an entity payload from an NGSI-LD Entity if none existed yet`() = runTest {
         val (jsonLdEntity, ngsiLdEntity) = loadSampleData().sampleDataToNgsiLdEntity().shouldSucceedAndResult()
         entityService.createEntityPayload(ngsiLdEntity, jsonLdEntity, now)
             .shouldSucceed()
@@ -132,7 +132,7 @@ class EntityServiceTests : WithTimescaleContainer, WithKafkaContainer() {
 
     @Test
     @WithMockCustomUser(sub = USER_UUID, name = "Mock User")
-    fun `it should only create an entity payload for a minimal entity`() = runTest {
+    fun `createEntity should only create an entity payload for a minimal entity`() = runTest {
         coEvery { authorizationService.userCanCreateEntities() } returns Unit.right()
         coEvery { entityEventService.publishEntityCreateEvent(any(), any()) } returns Job()
         coEvery {
@@ -171,7 +171,7 @@ class EntityServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should not create an entity payload if one already exists`() = runTest {
+    fun `createEntity should not create an entity when one already exists`() = runTest {
         val (jsonLdEntity, ngsiLdEntity) =
             loadMinimalEntity(entity01Uri, setOf(BEEHIVE_IRI)).sampleDataToNgsiLdEntity().shouldSucceedAndResult()
         entityService.createEntityPayload(
@@ -187,7 +187,7 @@ class EntityServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should not create an entity if it contains an NGSI-LD Null value`() = runTest {
+    fun `createEntity should not create an entity if it contains an NGSI-LD Null value`() = runTest {
         val (jsonLdEntity, ngsiLdEntity) = """
             {
                 "id": "urn:ngsi-ld:Entity:01",
@@ -207,7 +207,7 @@ class EntityServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should allow to create an entity over a deleted one if authorized`() = runTest {
+    fun `createEntity should allow creating an entity over a deleted one if authorized`() = runTest {
         coEvery {
             entityAttributeService.deleteAttributes(any(), any())
         } returns emptyList<SucceededAttributeOperationResult>().right()
@@ -238,7 +238,7 @@ class EntityServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should not allow to create an entity over a deleted one if not authorized`() = runTest {
+    fun `createEntity should not allow creating an entity over a deleted one if not authorized`() = runTest {
         coEvery {
             entityAttributeService.deleteAttributes(any(), any())
         } returns emptyList<SucceededAttributeOperationResult>().right()
@@ -268,7 +268,7 @@ class EntityServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should create the deleted representation of an entity when deleting it`() = runTest {
+    fun `deleteEntityPayload should create the deleted representation when deleting an entity`() = runTest {
         val (expandedEntity, ngsiLdEntity) =
             loadMinimalEntity(entity01Uri, setOf(BEEHIVE_IRI))
                 .sampleDataToNgsiLdEntity()
@@ -293,7 +293,7 @@ class EntityServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should merge an entity`() = runTest {
+    fun `mergeEntity should merge an entity`() = runTest {
         coEvery { authorizationService.userCanCreateEntities() } returns Unit.right()
         coEvery { authorizationService.userCanUpdateEntity(any()) } returns Unit.right()
         coEvery {
@@ -352,7 +352,7 @@ class EntityServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should merge an entity with new types`() = runTest {
+    fun `mergeEntity should merge an entity with new types`() = runTest {
         coEvery { authorizationService.userCanCreateEntities() } returns Unit.right()
         coEvery { authorizationService.userCanUpdateEntity(any()) } returns Unit.right()
         coEvery {
@@ -392,7 +392,7 @@ class EntityServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should merge an entity with new types and scopes`() = runTest {
+    fun `mergeEntity should merge an entity with new types and scopes`() = runTest {
         coEvery { authorizationService.userCanCreateEntities() } returns Unit.right()
         coEvery { authorizationService.userCanUpdateEntity(any()) } returns Unit.right()
         coEvery {
@@ -434,7 +434,7 @@ class EntityServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should replace an entity payload if entity previously existed`() = runTest {
+    fun `replaceEntityPayload should replace an entity payload if entity previously existed`() = runTest {
         val (jsonLdEntity, ngsiLdEntity) = loadSampleData().sampleDataToNgsiLdEntity().shouldSucceedAndResult()
         entityService.createEntityPayload(ngsiLdEntity, jsonLdEntity, now).shouldSucceed()
 
@@ -442,7 +442,7 @@ class EntityServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should replace an entity`() = runTest {
+    fun `replaceEntity should replace an entity`() = runTest {
         // called when creating the initial entity
         coEvery { authorizationService.userCanCreateEntities() } returns Unit.right()
         coEvery {
@@ -505,7 +505,7 @@ class EntityServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should replace an attribute`() = runTest {
+    fun `replaceAttribute should replace an attribute`() = runTest {
         coEvery { authorizationService.userCanUpdateEntity(any()) } returns Unit.right()
         coEvery { entityAttributeService.getAllForEntity(any()) } returns emptyList()
         coEvery {
@@ -533,7 +533,7 @@ class EntityServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should add a type to an entity`() = runTest {
+    fun `updateTypes should add a type to an entity`() = runTest {
         val entityPayload = loadSampleData("beehive.jsonld")
         entityPayload.sampleDataToNgsiLdEntity().map {
             entityService.createEntityPayload(
@@ -561,7 +561,7 @@ class EntityServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should add a type to an entity even if existing types are not in the list of types to add`() = runTest {
+    fun `updateTypes should add a type even if existing types are not in the list to add`() = runTest {
         loadMinimalEntity(entity01Uri, setOf(BEEHIVE_IRI))
             .sampleDataToNgsiLdEntity()
             .map {
@@ -585,7 +585,7 @@ class EntityServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should remove the scopes from an entity`() = runTest {
+    fun `deleteAttribute should remove the scopes from an entity`() = runTest {
         coEvery { authorizationService.userCanUpdateEntity(any()) } returns Unit.right()
         coEvery {
             entityAttributeService.addOrReplaceAttribute(any(), any(), any(), any(), any())
@@ -614,7 +614,7 @@ class EntityServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should permanently delete an entity`() = runTest {
+    fun `permanentlyDeleteEntity should permanently delete an entity`() = runTest {
         coEvery { authorizationService.userCanAdminEntity(any()) } returns Unit.right()
         coEvery { entityAttributeService.permanentlyDeleteAttributes(any()) } returns Unit.right()
         coEvery { authorizationService.removeRightsOnEntity(any()) } returns Unit.right()
@@ -638,7 +638,7 @@ class EntityServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should permanently delete an attribute`() = runTest {
+    fun `permanentlyDeleteAttribute should permanently delete an attribute`() = runTest {
         coEvery { authorizationService.userCanUpdateEntity(any()) } returns Unit.right()
         coEvery {
             entityAttributeService.checkEntityAndAttributeExistence(any(), any(), any(), any(), any())
@@ -671,7 +671,7 @@ class EntityServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should return a ResourceNotFound error if trying to permanently delete an unknown attribute`() = runTest {
+    fun `permanentlyDeleteAttribute should return a ResourceNotFound error for an unknown attribute`() = runTest {
         coEvery { authorizationService.userCanUpdateEntity(any()) } returns Unit.right()
         coEvery {
             entityAttributeService.checkEntityAndAttributeExistence(any(), any(), any(), any(), any())

--- a/search-service/src/test/kotlin/com/egm/stellio/search/entity/service/LinkedEntityServiceTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/entity/service/LinkedEntityServiceTests.kt
@@ -96,7 +96,7 @@ class LinkedEntityServiceTests {
     """.trimIndent().deserializeAsMap()
 
     @Test
-    fun `it should return the input entity if no join is specified`() = runTest {
+    fun `processLinkedEntities should return the input entity if no join is specified`() = runTest {
         val compactedEntities = linkedEntityService.processLinkedEntities(
             linkingEntityWithTwoRelationships,
             EntitiesQueryFromGet(
@@ -117,7 +117,7 @@ class LinkedEntityServiceTests {
     }
 
     @Test
-    fun `it should return the input entity if @none join is specified`() = runTest {
+    fun `processLinkedEntities should return the input entity if @none join is specified`() = runTest {
         val compactedEntities = linkedEntityService.processLinkedEntities(
             linkingEntityWithTwoRelationships,
             EntitiesQueryFromGet(
@@ -139,7 +139,7 @@ class LinkedEntityServiceTests {
     }
 
     @Test
-    fun `it should return the input entities if no join is specified`() = runTest {
+    fun `processLinkedEntities should return the input entities if no join is specified`() = runTest {
         val compactedEntities = linkedEntityService.processLinkedEntities(
             listOf(linkingEntityWithTwoRelationships, otherLinkingEntityWithTwoRelationships),
             EntitiesQueryFromGet(
@@ -160,7 +160,7 @@ class LinkedEntityServiceTests {
     }
 
     @Test
-    fun `it should return only the input entity if it has no relationships`() = runTest {
+    fun `processLinkedEntities should return only the input entity if it has no relationships`() = runTest {
         val compactedEntities = linkedEntityService.processLinkedEntities(
             linkingEntityWithoutRelationships,
             EntitiesQueryFromGet(
@@ -182,7 +182,7 @@ class LinkedEntityServiceTests {
     }
 
     @Test
-    fun `it should return an empty list if no entities are provided in the input`() = runTest {
+    fun `processLinkedEntities should return an empty list if no entities are provided in the input`() = runTest {
         val compactedEntities = linkedEntityService.processLinkedEntities(
             emptyList(),
             EntitiesQueryFromGet(
@@ -199,7 +199,7 @@ class LinkedEntityServiceTests {
     }
 
     @Test
-    fun `it should flatten lists of linking and linked entities`() = runTest {
+    fun `flattenLinkedEntities should flatten lists of linking and linked entities`() = runTest {
         val linkedEntity01 = """
             {
                 "id": "urn:ngsi-ld:LinkedEntity:01",
@@ -259,7 +259,7 @@ class LinkedEntityServiceTests {
     }
 
     @Test
-    fun `it should flatten a linking entity with multi-instance relationship and linked entities`() = runTest {
+    fun `flattenLinkedEntities should flatten a linking entity with multi-instance relationship`() = runTest {
         val linkedEntity01 = """
             {
                 "id": "urn:ngsi-ld:LinkedEntity:01",
@@ -308,7 +308,7 @@ class LinkedEntityServiceTests {
     }
 
     @Test
-    fun `it should inline a linking entity with multi-instance relationship and linked entities`() = runTest {
+    fun `inlineLinkedEntities should inline a linking entity with multi-instance relationship`() = runTest {
         val linkedEntity01 = """
             {
                 "id": "urn:ngsi-ld:LinkedEntity:01",
@@ -357,7 +357,7 @@ class LinkedEntityServiceTests {
     }
 
     @Test
-    fun `it should inline a linking entity with multivalued relationship and linked entities`() = runTest {
+    fun `inlineLinkedEntities should inline a linking entity with multivalued relationship`() = runTest {
         val linkingEntity = """
             {
                 "id": "urn:ngsi-ld:LinkingEntity:01",
@@ -416,7 +416,7 @@ class LinkedEntityServiceTests {
     }
 
     @Test
-    fun `it should flatten an entity with a multivalued relationship`() = runTest {
+    fun `processLinkedEntities should flatten an entity with a multivalued relationship`() = runTest {
         val linkingEntity = """
             {
                 "id": "urn:ngsi-ld:LinkingEntity:01",
@@ -504,7 +504,7 @@ class LinkedEntityServiceTests {
     }
 
     @Test
-    fun `it should flatten an entity up to the asked 2nd level`() = runTest {
+    fun `processLinkedEntities should flatten an entity up to the asked 2nd level`() = runTest {
         prepareMockedAnswersForJoinLevel2OnEntity()
 
         val flattenedEntities =
@@ -565,7 +565,7 @@ class LinkedEntityServiceTests {
     }
 
     @Test
-    fun `it should inline an entity up to the asked 2nd level`() = runTest {
+    fun `processLinkedEntities should inline an entity up to the asked 2nd level`() = runTest {
         prepareMockedAnswersForJoinLevel2OnEntity()
 
         val inlinedEntities =
@@ -670,7 +670,7 @@ class LinkedEntityServiceTests {
     }
 
     @Test
-    fun `it should flatten entities up to the asked 2nd level`() = runTest {
+    fun `processLinkedEntities should flatten entities up to the asked 2nd level`() = runTest {
         prepareMockedAnswersForJoinLevel2OnEntities()
 
         val flattenedEntities =
@@ -699,7 +699,7 @@ class LinkedEntityServiceTests {
     }
 
     @Test
-    fun `it should inline entities up to the asked 2nd level`() = runTest {
+    fun `processLinkedEntities should inline entities up to the asked 2nd level`() = runTest {
         prepareMockedAnswersForJoinLevel2OnEntities()
 
         val inlinedEntities =
@@ -826,7 +826,7 @@ class LinkedEntityServiceTests {
     }
 
     @Test
-    fun `it should flatten an entity and apply pick on relationships`() = runTest {
+    fun `processLinkedEntities should flatten an entity and apply pick on relationships`() = runTest {
         prepareMockedAnswersForJoinLevelWithPickOnEntity()
 
         val flattenedEntities =
@@ -876,7 +876,7 @@ class LinkedEntityServiceTests {
     }
 
     @Test
-    fun `it should inline an entity and apply pick on relationships`() = runTest {
+    fun `processLinkedEntities should inline an entity and apply pick on relationships`() = runTest {
         prepareMockedAnswersForJoinLevelWithPickOnEntity()
 
         val inlinedEntities =

--- a/search-service/src/test/kotlin/com/egm/stellio/search/entity/util/AttributeUtilsTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/entity/util/AttributeUtilsTests.kt
@@ -22,7 +22,7 @@ import java.time.LocalTime
 class AttributeUtilsTests {
 
     @Test
-    fun `it should guess the value type of a string property`() = runTest {
+    fun `guessAttributeValueType should guess the value type of a string property`() = runTest {
         val expandedStringProperty = expandAttribute(
             "property",
             mapOf("type" to "Property", "value" to "A string"),
@@ -35,7 +35,7 @@ class AttributeUtilsTests {
     }
 
     @Test
-    fun `it should guess the value type of a double property`() = runTest {
+    fun `guessAttributeValueType should guess the value type of a double property`() = runTest {
         val expandedBooleanProperty = expandAttribute(
             "property",
             mapOf("type" to "Property", "value" to 20.0),
@@ -48,7 +48,7 @@ class AttributeUtilsTests {
     }
 
     @Test
-    fun `it should guess the value type of an int property`() = runTest {
+    fun `guessAttributeValueType should guess the value type of an int property`() = runTest {
         val expandedBooleanProperty = expandAttribute(
             "property",
             mapOf("type" to "Property", "value" to 20),
@@ -61,7 +61,7 @@ class AttributeUtilsTests {
     }
 
     @Test
-    fun `it should guess the value type of a boolean property`() = runTest {
+    fun `guessAttributeValueType should guess the value type of a boolean property`() = runTest {
         val expandedBooleanProperty = expandAttribute(
             "property",
             mapOf("type" to "Property", "value" to true),
@@ -74,7 +74,7 @@ class AttributeUtilsTests {
     }
 
     @Test
-    fun `it should guess the value type of an object property`() = runTest {
+    fun `guessAttributeValueType should guess the value type of an object property`() = runTest {
         val expandedListProperty = expandAttribute(
             "property",
             mapOf("type" to "Property", "value" to mapOf("key1" to "value1", "key2" to "value3")),
@@ -87,7 +87,7 @@ class AttributeUtilsTests {
     }
 
     @Test
-    fun `it should guess the value type of an array property`() = runTest {
+    fun `guessAttributeValueType should guess the value type of an array property`() = runTest {
         val expandedListProperty = expandAttribute(
             "property",
             mapOf("type" to "Property", "value" to listOf("A", "B")),
@@ -100,7 +100,7 @@ class AttributeUtilsTests {
     }
 
     @Test
-    fun `it should guess the value type of a time property`() = runTest {
+    fun `guessAttributeValueType should guess the value type of a time property`() = runTest {
         val expandedTimeProperty = expandAttribute(
             "property",
             mapOf("type" to "Property", "value" to mapOf("@type" to "Time", "@value" to LocalTime.now())),
@@ -113,7 +113,7 @@ class AttributeUtilsTests {
     }
 
     @Test
-    fun `it should guess the value type of a datetime property`() = runTest {
+    fun `guessAttributeValueType should guess the value type of a datetime property`() = runTest {
         val expandedTimeProperty = expandAttribute(
             "property",
             mapOf("type" to "Property", "value" to mapOf("@type" to "DateTime", "@value" to ngsiLdDateTime())),
@@ -126,7 +126,7 @@ class AttributeUtilsTests {
     }
 
     @Test
-    fun `it should guess the value type of a geo-property`() = runTest {
+    fun `guessAttributeValueType should guess the value type of a geo-property`() = runTest {
         val expandedGeoProperty = expandAttribute(
             "location",
             mapOf(
@@ -142,7 +142,7 @@ class AttributeUtilsTests {
     }
 
     @Test
-    fun `it should guess the value type of a JSON property`() = runTest {
+    fun `guessAttributeValueType should guess the value type of a JSON property`() = runTest {
         val expandedJsonProperty = expandAttribute(
             "jsonProperty",
             mapOf(
@@ -158,7 +158,7 @@ class AttributeUtilsTests {
     }
 
     @Test
-    fun `it should guess the value type of a relationship`() = runTest {
+    fun `guessAttributeValueType should guess the value type of a relationship`() = runTest {
         val expandedRelationship = expandAttribute(
             "relationship",
             mapOf("type" to "Relationship", "object" to URI("urn:ngsi-ld")),
@@ -174,7 +174,7 @@ class AttributeUtilsTests {
     }
 
     @Test
-    fun `it should guess the value type of a multivalued relationship`() = runTest {
+    fun `guessAttributeValueType should guess the value type of a multivalued relationship`() = runTest {
         val expandedRelationship = expandAttribute(
             "relationship",
             mapOf(
@@ -194,7 +194,7 @@ class AttributeUtilsTests {
     }
 
     @Test
-    fun `it should find a Property whose value is NGSI-LD Null`() = runTest {
+    fun `hasNgsiLdNullValue should find a Property whose value is NGSI-LD Null`() = runTest {
         val expandedProperty = expandAttribute(
             """
                 {
@@ -211,7 +211,7 @@ class AttributeUtilsTests {
     }
 
     @Test
-    fun `it should find a LanguageProperty whose value is NGSI-LD Null`() = runTest {
+    fun `hasNgsiLdNullValue should find a LanguageProperty whose value is NGSI-LD Null`() = runTest {
         val expandedProperty = expandAttribute(
             """
                 {
@@ -230,7 +230,7 @@ class AttributeUtilsTests {
     }
 
     @Test
-    fun `it should find a JsonProperty whose value is NGSI-LD Null`() = runTest {
+    fun `hasNgsiLdNullValue should find a JsonProperty whose value is NGSI-LD Null`() = runTest {
         val expandedProperty = expandAttribute(
             """
                 {
@@ -247,7 +247,7 @@ class AttributeUtilsTests {
     }
 
     @Test
-    fun `it should find a Relationship whose value is NGSI-LD Null`() = runTest {
+    fun `hasNgsiLdNullValue should find a Relationship whose value is NGSI-LD Null`() = runTest {
         val expandedProperty = expandAttribute(
             """
                 {

--- a/search-service/src/test/kotlin/com/egm/stellio/search/entity/util/EntitiesQueryUtilsTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/entity/util/EntitiesQueryUtilsTests.kt
@@ -49,7 +49,7 @@ import java.net.URI
 class EntitiesQueryUtilsTests {
 
     @Test
-    fun `it should parse query parameters`() = runTest {
+    fun `composeEntitiesQueryFromGet should parse query parameters`() = runTest {
         val requestParams = gimmeEntitiesQueryParams()
         val entitiesQuery = composeEntitiesQueryFromGet(
             buildDefaultPagination(1, 20),
@@ -85,7 +85,7 @@ class EntitiesQueryUtilsTests {
     }
 
     @Test
-    fun `it should set default values in query parameters`() = runTest {
+    fun `composeEntitiesQueryFromGet should set default values in query parameters`() = runTest {
         val requestParams = LinkedMultiValueMap<String, String>()
         val entitiesQuery = composeEntitiesQueryFromGet(
             buildDefaultPagination(30, 100),
@@ -120,7 +120,7 @@ class EntitiesQueryUtilsTests {
     }
 
     @Test
-    fun `it should return a BadRequest error if join parameter is not recognized`() = runTest {
+    fun `composeEntitiesQueryFromGet should return a BadRequest error when join is not recognized`() = runTest {
         composeEntitiesQueryFromGet(
             buildDefaultPagination(30, 100),
             LinkedMultiValueMap<String, String>().apply {
@@ -137,7 +137,7 @@ class EntitiesQueryUtilsTests {
     }
 
     @Test
-    fun `it should return a BadRequest error if joinLevel parameter is not a positive integer`() = runTest {
+    fun `composeEntitiesQueryFromGet should fail when joinLevel is not a positive integer`() = runTest {
         composeEntitiesQueryFromGet(
             buildDefaultPagination(30, 100),
             LinkedMultiValueMap<String, String>().apply {
@@ -155,7 +155,7 @@ class EntitiesQueryUtilsTests {
     }
 
     @Test
-    fun `it should return a BadRequest error if join is not specified and joinLevel is specified`() = runTest {
+    fun `composeEntitiesQueryFromGet should return a BadRequest error when joinLevel is set without join`() = runTest {
         composeEntitiesQueryFromGet(
             buildDefaultPagination(30, 100),
             LinkedMultiValueMap<String, String>().apply {
@@ -172,7 +172,7 @@ class EntitiesQueryUtilsTests {
     }
 
     @Test
-    fun `it should return a BadRequest error if join is not specified and containedBy is specified`() = runTest {
+    fun `composeEntitiesQueryFromGet should fail when containedBy is set without join`() = runTest {
         composeEntitiesQueryFromGet(
             buildDefaultPagination(30, 100),
             LinkedMultiValueMap<String, String>().apply {
@@ -189,7 +189,7 @@ class EntitiesQueryUtilsTests {
     }
 
     @Test
-    fun `it should return a BadRequest error if an entity member is in pick and omit parameters`() = runTest {
+    fun `composeEntitiesQueryFromGet should return a BadRequest error when a member is in pick and omit`() = runTest {
         composeEntitiesQueryFromGet(
             buildDefaultPagination(30, 100),
             LinkedMultiValueMap<String, String>().apply {
@@ -207,7 +207,7 @@ class EntitiesQueryUtilsTests {
     }
 
     @Test
-    fun `it should return a BadRequest error if attrs and pick parameters are specified`() = runTest {
+    fun `composeEntitiesQueryFromGet should return a BadRequest error when attrs and pick are specified`() = runTest {
         composeEntitiesQueryFromGet(
             buildDefaultPagination(30, 100),
             LinkedMultiValueMap<String, String>().apply {
@@ -240,7 +240,7 @@ class EntitiesQueryUtilsTests {
     }
 
     @Test
-    fun `it should parse a valid complete Query datatype`() = runTest {
+    fun `composeEntitiesQueryFromPostRequest should parse a valid complete Query datatype`() = runTest {
         val query = """
             {
                 "type": "Query",
@@ -307,7 +307,7 @@ class EntitiesQueryUtilsTests {
     }
 
     @Test
-    fun `it should parse a valid simple Query datatype`() = runTest {
+    fun `composeEntitiesQueryFromPostRequest should parse a valid simple Query datatype`() = runTest {
         val query = """
             {
                 "type": "Query",
@@ -332,7 +332,7 @@ class EntitiesQueryUtilsTests {
     }
 
     @Test
-    fun `it should default to location geoproperty if not provided in the GeoQuery`() = runTest {
+    fun `composeEntitiesQueryFromPostRequest should default to location geoproperty if not provided`() = runTest {
         val query = """
             {
                 "type": "Query",
@@ -355,7 +355,7 @@ class EntitiesQueryUtilsTests {
     }
 
     @Test
-    fun `it should parse a Query datatype with more than one entity selectors`() = runTest {
+    fun `composeEntitiesQueryFromPostRequest should parse a Query datatype with multiple entity selectors`() = runTest {
         val query = """
             {
                 "type": "Query",
@@ -438,7 +438,7 @@ class EntitiesQueryUtilsTests {
         }
 
     @Test
-    fun `it should not validate a Query if the type is not correct`() {
+    fun `composeEntitiesQueryFromPostRequest should not validate a Query if the type is not correct`() {
         val query = """
             {
                 "type": "NotAQuery",
@@ -458,7 +458,7 @@ class EntitiesQueryUtilsTests {
     }
 
     @Test
-    fun `it should not validate a Query if the payload could not be parsed because the JSON is invalid`() {
+    fun `composeEntitiesQueryFromPostRequest should not validate a Query if the JSON payload is invalid`() {
         val query = """
             {
                 "type": "Query",,
@@ -478,7 +478,7 @@ class EntitiesQueryUtilsTests {
     }
 
     @Test
-    fun `it should not validate a Query if the payload contains unexpected parameters`() {
+    fun `composeEntitiesQueryFromPostRequest should not validate a Query with unexpected parameters`() {
         val query = """
             {
                 "type": "Query",
@@ -498,7 +498,7 @@ class EntitiesQueryUtilsTests {
     }
 
     @Test
-    fun `it should not validate a Query if an entity selector has no type member`() {
+    fun `composeEntitiesQueryFromPostRequest should not validate a Query if an entity selector has no type member`() {
         val query = """
             {
                 "type": "Query",
@@ -522,7 +522,7 @@ class EntitiesQueryUtilsTests {
     }
 
     @Test
-    fun `it should not validate a Query if joinLevel is invalid`() {
+    fun `composeEntitiesQueryFromPostRequest should not validate a Query if joinLevel is invalid`() {
         val query = """
             {
                 "type": "Query",
@@ -545,7 +545,7 @@ class EntitiesQueryUtilsTests {
     }
 
     @Test
-    fun `it should not validate a Query if join is invalid`() {
+    fun `composeEntitiesQueryFromPostRequest should not validate a Query if join is invalid`() {
         val query = """
             {
                 "type": "Query",
@@ -568,7 +568,7 @@ class EntitiesQueryUtilsTests {
     }
 
     @Test
-    fun `it should not validate a Query if pick and omit are invalid`() {
+    fun `composeEntitiesQueryFromPostRequest should not validate a Query if pick and omit are invalid`() {
         val query = """
             {
                 "type": "Query",
@@ -589,7 +589,7 @@ class EntitiesQueryUtilsTests {
     }
 
     @Test
-    fun `it should parse a Query with multiple orderBy`() {
+    fun `composeEntitiesQueryFromPostRequest should parse a Query with multiple orderBy`() {
         val query = """
             {
                 "type": "Query",

--- a/search-service/src/test/kotlin/com/egm/stellio/search/entity/util/PatchAttributeTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/entity/util/PatchAttributeTests.kt
@@ -721,7 +721,7 @@ class PatchAttributeTests {
 
     @ParameterizedTest
     @MethodSource("com.egm.stellio.search.entity.util.PatchAttributeTests#partialUpdatePatchProvider")
-    fun `it should apply a partial update patch behavior to attribute instance`(
+    fun `partialUpdatePatch should apply a partial update patch behavior to attribute instance`(
         source: String,
         target: String,
         expected: String
@@ -739,7 +739,7 @@ class PatchAttributeTests {
 
     @ParameterizedTest
     @MethodSource("com.egm.stellio.search.entity.util.PatchAttributeTests#mergePatchProvider")
-    fun `it should apply a merge patch behavior to attribute instance`(
+    fun `mergePatch should apply a merge patch behavior to attribute instance`(
         source: String,
         target: String,
         expected: String

--- a/search-service/src/test/kotlin/com/egm/stellio/search/scope/ScopeServiceTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/scope/ScopeServiceTests.kt
@@ -98,7 +98,7 @@ class ScopeServiceTests : WithTimescaleContainer, WithKafkaContainer() {
 
     @ParameterizedTest
     @MethodSource("generateScopes")
-    fun `update should update scopes as requested by the type of the operation`(
+    fun `update should persist scopes according to the requested operation type`(
         initialEntity: String,
         inputScopes: List<String>,
         operationType: OperationType,
@@ -145,7 +145,7 @@ class ScopeServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `retrieveHistory should retrieve the history of scopes`() = runTest {
+    fun `retrieveHistory should return the history of scopes`() = runTest {
         createScopeHistory()
 
         val scopeHistoryEntries = scopeService.retrieveHistory(
@@ -170,7 +170,7 @@ class ScopeServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `retrieveHistory should retrieve the history of scopes with a time interval`() = runTest {
+    fun `retrieveHistory should return the history of scopes with a time interval`() = runTest {
         createScopeHistory()
 
         val scopeHistoryEntries = scopeService.retrieveHistory(
@@ -199,7 +199,7 @@ class ScopeServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `retrieveHistory should retrieve the history of scopes with aggregated values`() = runTest {
+    fun `retrieveHistory should return the history of scopes with aggregated values`() = runTest {
         createScopeHistory()
 
         val scopeHistoryEntries = scopeService.retrieveHistory(
@@ -232,7 +232,7 @@ class ScopeServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `retrieveHistory should retrieve the history of scopes with aggregated values on whole time range`() = runTest {
+    fun `retrieveHistory should return the history of scopes with aggregated values on whole time range`() = runTest {
         createScopeHistory()
 
         val scopeHistoryEntries = scopeService.retrieveHistory(
@@ -265,7 +265,7 @@ class ScopeServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `retrieveHistory should retrieve aggregated scopes over the whole time range without interval`() =
+    fun `retrieveHistory should return aggregated scopes over the whole time range without interval`() =
         runTest {
             createScopeHistory()
 
@@ -297,7 +297,7 @@ class ScopeServiceTests : WithTimescaleContainer, WithKafkaContainer() {
         }
 
     @Test
-    fun `retrieveHistory should retrieve the last n instances of history of scopes with aggregated values`() = runTest {
+    fun `retrieveHistory should return the last n instances of history of scopes with aggregated values`() = runTest {
         createScopeHistory()
 
         val scopeHistoryEntries = scopeService.retrieveHistory(
@@ -421,7 +421,7 @@ class ScopeServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `delete should delete scope and its history`() = runTest {
+    fun `delete should remove the scope and its history`() = runTest {
         loadSampleData("beehive_with_scope.jsonld")
             .sampleDataToNgsiLdEntity()
             .map { entityService.createEntityPayload(it.second, it.first, ngsiLdDateTime()) }

--- a/search-service/src/test/kotlin/com/egm/stellio/search/scope/ScopeServiceTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/scope/ScopeServiceTests.kt
@@ -98,7 +98,7 @@ class ScopeServiceTests : WithTimescaleContainer, WithKafkaContainer() {
 
     @ParameterizedTest
     @MethodSource("generateScopes")
-    fun `it shoud update scopes as requested by the type of the operation`(
+    fun `update should update scopes as requested by the type of the operation`(
         initialEntity: String,
         inputScopes: List<String>,
         operationType: OperationType,
@@ -145,7 +145,7 @@ class ScopeServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should retrieve the history of scopes`() = runTest {
+    fun `retrieveHistory should retrieve the history of scopes`() = runTest {
         createScopeHistory()
 
         val scopeHistoryEntries = scopeService.retrieveHistory(
@@ -170,7 +170,7 @@ class ScopeServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should retrieve the history of scopes with a time interval`() = runTest {
+    fun `retrieveHistory should retrieve the history of scopes with a time interval`() = runTest {
         createScopeHistory()
 
         val scopeHistoryEntries = scopeService.retrieveHistory(
@@ -199,7 +199,7 @@ class ScopeServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should retrieve the history of scopes with aggregated values`() = runTest {
+    fun `retrieveHistory should retrieve the history of scopes with aggregated values`() = runTest {
         createScopeHistory()
 
         val scopeHistoryEntries = scopeService.retrieveHistory(
@@ -232,7 +232,7 @@ class ScopeServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should retrieve the history of scopes with aggregated values on whole time range`() = runTest {
+    fun `retrieveHistory should retrieve the history of scopes with aggregated values on whole time range`() = runTest {
         createScopeHistory()
 
         val scopeHistoryEntries = scopeService.retrieveHistory(
@@ -265,7 +265,7 @@ class ScopeServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should retrieve the history of scopes with aggregated values on whole time range without interval`() =
+    fun `retrieveHistory should retrieve aggregated scopes over the whole time range without interval`() =
         runTest {
             createScopeHistory()
 
@@ -297,7 +297,7 @@ class ScopeServiceTests : WithTimescaleContainer, WithKafkaContainer() {
         }
 
     @Test
-    fun `it should retrieve the last n instances of history of scopes with aggregated values`() = runTest {
+    fun `retrieveHistory should retrieve the last n instances of history of scopes with aggregated values`() = runTest {
         createScopeHistory()
 
         val scopeHistoryEntries = scopeService.retrieveHistory(
@@ -331,7 +331,7 @@ class ScopeServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should include lower bound of interval with after timerel`() = runTest {
+    fun `retrieveHistory should include the lower bound of the interval with the after timerel`() = runTest {
         loadSampleData("beehive_with_scope.jsonld")
             .sampleDataToNgsiLdEntity()
             .map { entityService.createEntityPayload(it.second, it.first, ngsiLdDateTime()) }
@@ -371,7 +371,7 @@ class ScopeServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should exclude upper bound of interval with between timerel`() = runTest {
+    fun `retrieveHistory should exclude the upper bound of the interval with the between timerel`() = runTest {
         loadSampleData("beehive_with_scope.jsonld")
             .sampleDataToNgsiLdEntity()
             .map { entityService.createEntityPayload(it.second, it.first, ngsiLdDateTime()) }
@@ -421,7 +421,7 @@ class ScopeServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should delete scope and its history`() = runTest {
+    fun `delete should delete scope and its history`() = runTest {
         loadSampleData("beehive_with_scope.jsonld")
             .sampleDataToNgsiLdEntity()
             .map { entityService.createEntityPayload(it.second, it.first, ngsiLdDateTime()) }

--- a/search-service/src/test/kotlin/com/egm/stellio/search/scope/TemporalScopeBuilderTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/scope/TemporalScopeBuilderTests.kt
@@ -22,7 +22,7 @@ class TemporalScopeBuilderTests {
     private val entityId = "urn:ngsi-ld:Beehive:1234".toUri()
 
     @Test
-    fun `it should build an aggregated temporal representation of scopes`() {
+    fun `buildScopeAttributeInstances should build an aggregated temporal representation of scopes`() {
         val scopeInstances = listOf(
             AggregatedScopeInstanceResult(
                 entityId = entityId,
@@ -83,7 +83,7 @@ class TemporalScopeBuilderTests {
     }
 
     @Test
-    fun `it should build a temporal values representation of scopes`() {
+    fun `buildScopeAttributeInstances should build a temporal values representation of scopes`() {
         val scopeInstances = listOf(
             SimplifiedScopeInstanceResult(
                 entityId = entityId,
@@ -118,7 +118,7 @@ class TemporalScopeBuilderTests {
     }
 
     @Test
-    fun `it should build a full representation of scopes`() {
+    fun `buildScopeAttributeInstances should build a full representation of scopes`() {
         val scopeInstances = listOf(
             FullScopeInstanceResult(
                 entityId = entityId,

--- a/search-service/src/test/kotlin/com/egm/stellio/search/temporal/service/AggregatedTemporalQueryServiceTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/temporal/service/AggregatedTemporalQueryServiceTests.kt
@@ -95,7 +95,7 @@ class AggregatedTemporalQueryServiceTests : WithTimescaleContainer, WithKafkaCon
         "stddev, 3.0276503541",
         "sumsq, 385.0"
     )
-    fun `it should correctly aggregate on JSON Number values`(aggrMethod: String, expectedValue: String) = runTest {
+    fun `search should aggregate on JSON Number values`(aggrMethod: String, expectedValue: String) = runTest {
         val attribute = createAttribute(Attribute.AttributeValueType.NUMBER)
         (1..10).forEach { i ->
             val attributeInstance = gimmeNumericPropertyAttributeInstance(
@@ -126,7 +126,7 @@ class AggregatedTemporalQueryServiceTests : WithTimescaleContainer, WithKafkaCon
         "stddev, ''",
         "sumsq, ''"
     )
-    fun `it should correctly aggregate on JSON String values`(aggrMethod: String, expectedValue: String?) = runTest {
+    fun `search should aggregate on JSON String values`(aggrMethod: String, expectedValue: String?) = runTest {
         val attribute = createAttribute(Attribute.AttributeValueType.STRING)
         (1..10).forEach { i ->
             val attributeInstance = gimmeNumericPropertyAttributeInstance(
@@ -157,7 +157,7 @@ class AggregatedTemporalQueryServiceTests : WithTimescaleContainer, WithKafkaCon
         "stddev, ''",
         "sumsq, ''"
     )
-    fun `it should correctly aggregate on JSON Object values`(aggrMethod: String, expectedValue: String?) = runTest {
+    fun `search should aggregate on JSON Object values`(aggrMethod: String, expectedValue: String?) = runTest {
         val attribute = createAttribute(Attribute.AttributeValueType.OBJECT)
         (1..10).forEach { i ->
             val attributeInstance = gimmeNumericPropertyAttributeInstance(
@@ -188,7 +188,7 @@ class AggregatedTemporalQueryServiceTests : WithTimescaleContainer, WithKafkaCon
         "stddev, ''",
         "sumsq, ''"
     )
-    fun `it should correctly aggregate on JSON Array values`(aggrMethod: String, expectedValue: String?) = runTest {
+    fun `search should aggregate on JSON Array values`(aggrMethod: String, expectedValue: String?) = runTest {
         val attribute = createAttribute(Attribute.AttributeValueType.ARRAY)
         (1..10).forEach { i ->
             val attributeInstance = gimmeNumericPropertyAttributeInstance(
@@ -219,7 +219,7 @@ class AggregatedTemporalQueryServiceTests : WithTimescaleContainer, WithKafkaCon
         "stddev, 0.52704627669472988867",
         "sumsq, 5.0"
     )
-    fun `it should correctly aggregate on JSON Boolean values`(aggrMethod: String, expectedValue: String?) = runTest {
+    fun `search should aggregate on JSON Boolean values`(aggrMethod: String, expectedValue: String?) = runTest {
         val attribute = createAttribute(Attribute.AttributeValueType.BOOLEAN)
         (1..10).forEach { i ->
             val attributeInstance = gimmeNumericPropertyAttributeInstance(
@@ -250,7 +250,7 @@ class AggregatedTemporalQueryServiceTests : WithTimescaleContainer, WithKafkaCon
         "stddev, ''",
         "sumsq, ''"
     )
-    fun `it should correctly aggregate on DateTime values`(aggrMethod: String, expectedValue: String?) = runTest {
+    fun `search should aggregate on DateTime values`(aggrMethod: String, expectedValue: String?) = runTest {
         val attribute = createAttribute(Attribute.AttributeValueType.DATETIME)
         val baseDateTime = ZonedDateTime.parse("2023-03-05T00:01:01Z")
         (1..10).forEach { i ->
@@ -282,7 +282,7 @@ class AggregatedTemporalQueryServiceTests : WithTimescaleContainer, WithKafkaCon
         "stddev, ''",
         "sumsq, ''"
     )
-    fun `it should correctly aggregate on Date values`(aggrMethod: String, expectedValue: String?) = runTest {
+    fun `search should aggregate on Date values`(aggrMethod: String, expectedValue: String?) = runTest {
         val attribute = createAttribute(Attribute.AttributeValueType.DATE)
         val baseDateTime = LocalDate.parse("2023-03-05")
         (1..10).forEach { i ->
@@ -314,7 +314,7 @@ class AggregatedTemporalQueryServiceTests : WithTimescaleContainer, WithKafkaCon
         "stddev, ''",
         "sumsq, ''"
     )
-    fun `it should correctly aggregate on Time values`(aggrMethod: String, expectedValue: String?) = runTest {
+    fun `search should aggregate on Time values`(aggrMethod: String, expectedValue: String?) = runTest {
         val attribute = createAttribute(Attribute.AttributeValueType.TIME)
         val baseDateTime = OffsetTime.parse("00:00:01Z")
         (1..10).forEach { i ->
@@ -346,7 +346,7 @@ class AggregatedTemporalQueryServiceTests : WithTimescaleContainer, WithKafkaCon
         "stddev, ''",
         "sumsq, ''"
     )
-    fun `it should correctly aggregate on URI values`(aggrMethod: String, expectedValue: String?) = runTest {
+    fun `search should aggregate on URI values`(aggrMethod: String, expectedValue: String?) = runTest {
         val attribute = createAttribute(Attribute.AttributeValueType.URI)
         (1..10).forEach { i ->
             val attributeInstance = gimmeNumericPropertyAttributeInstance(
@@ -367,7 +367,7 @@ class AggregatedTemporalQueryServiceTests : WithTimescaleContainer, WithKafkaCon
     }
 
     @Test
-    fun `it should aggregate on the whole time range if no aggrPeriodDuration is given`() = runTest {
+    fun `search should aggregate on the whole time range if no aggrPeriodDuration is given`() = runTest {
         val attribute = createAttribute(Attribute.AttributeValueType.NUMBER)
         (1..10).forEach { i ->
             val attributeInstance = gimmeNumericPropertyAttributeInstance(
@@ -402,7 +402,7 @@ class AggregatedTemporalQueryServiceTests : WithTimescaleContainer, WithKafkaCon
         "P2W, 1",
         "P1M, 2"
     )
-    fun `it should aggregate on the asked aggrPeriodDuration`(
+    fun `search should aggregate on the asked aggrPeriodDuration`(
         aggrPeriodDuration: String,
         expectedNumberOfBuckets: Int
     ) = runTest {
@@ -430,7 +430,7 @@ class AggregatedTemporalQueryServiceTests : WithTimescaleContainer, WithKafkaCon
     }
 
     @Test
-    fun `it should handle aggregates for an attribute having different types of values in history`() = runTest {
+    fun `search should handle aggregates for an attribute having different types of values in history`() = runTest {
         val attribute = createAttribute(Attribute.AttributeValueType.ARRAY)
         (1..10).forEach { i ->
             val attributeInstanceWithArrayValue = gimmeNumericPropertyAttributeInstance(
@@ -454,7 +454,7 @@ class AggregatedTemporalQueryServiceTests : WithTimescaleContainer, WithKafkaCon
     }
 
     @Test
-    fun `it should aggregate using the specified timezone`() = runTest {
+    fun `search should aggregate using the specified timezone`() = runTest {
         // set the timezone to Europe/Paris to have all the results aggregated on January 2024
         every { searchProperties.timezoneForTimeBuckets } returns "Europe/Paris"
 

--- a/search-service/src/test/kotlin/com/egm/stellio/search/temporal/service/AttributeInstanceServiceTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/temporal/service/AttributeInstanceServiceTests.kt
@@ -195,7 +195,7 @@ class AttributeInstanceServiceTests : WithTimescaleContainer, WithKafkaContainer
     }
 
     @Test
-    fun `it should retrieve a full instance if temporalValues are not asked for`() = runTest {
+    fun `search should retrieve a full instance if temporalValues are not asked for`() = runTest {
         val observation = gimmeNumericPropertyAttributeInstance(
             attributeUuid = incomingAttribute.id,
             measuredValue = 12.4,
@@ -218,7 +218,7 @@ class AttributeInstanceServiceTests : WithTimescaleContainer, WithKafkaContainer
     }
 
     @Test
-    fun `it should retrieve an instance having the corresponding time property value`() = runTest {
+    fun `search should retrieve an instance having the corresponding time property value`() = runTest {
         val observation = gimmeNumericPropertyAttributeInstance(
             attributeUuid = incomingAttribute.id,
             timeProperty = AttributeInstance.TemporalProperty.CREATED_AT,
@@ -242,7 +242,7 @@ class AttributeInstanceServiceTests : WithTimescaleContainer, WithKafkaContainer
     }
 
     @Test
-    fun `it should retrieve an instance with audit info if time property is not observedAt`() = runTest {
+    fun `search should retrieve an instance with audit info if time property is not observedAt`() = runTest {
         val observation = gimmeNumericPropertyAttributeInstance(
             attributeUuid = incomingAttribute.id,
             timeProperty = AttributeInstance.TemporalProperty.CREATED_AT,
@@ -268,7 +268,7 @@ class AttributeInstanceServiceTests : WithTimescaleContainer, WithKafkaContainer
     }
 
     @Test
-    fun `it should not retrieve an instance not having the corresponding time property value`() = runTest {
+    fun `search should not retrieve an instance not having the corresponding time property value`() = runTest {
         val observation = gimmeNumericPropertyAttributeInstance(
             attributeUuid = incomingAttribute.id,
             timeProperty = AttributeInstance.TemporalProperty.CREATED_AT,
@@ -292,7 +292,7 @@ class AttributeInstanceServiceTests : WithTimescaleContainer, WithKafkaContainer
     }
 
     @Test
-    fun `it should retrieve all full instances if temporalValues are not asked for`() = runTest {
+    fun `search should retrieve all full instances if temporalValues are not asked for`() = runTest {
         (1..10).forEach { _ ->
             attributeInstanceService.create(gimmeNumericPropertyAttributeInstance(incomingAttribute.id))
         }
@@ -311,7 +311,7 @@ class AttributeInstanceServiceTests : WithTimescaleContainer, WithKafkaContainer
     }
 
     @Test
-    fun `it should retrieve all instances when no timerel and time parameters are provided`() = runTest {
+    fun `search should retrieve all instances when no timerel and time parameters are provided`() = runTest {
         (1..10).forEach { _ ->
             attributeInstanceService.create(gimmeNumericPropertyAttributeInstance(incomingAttribute.id))
         }
@@ -327,7 +327,7 @@ class AttributeInstanceServiceTests : WithTimescaleContainer, WithKafkaContainer
     }
 
     @Test
-    fun `it should retrieve instances of a temporal entity attribute whose value type is Any`() = runTest {
+    fun `search should retrieve instances of a temporal entity attribute whose value type is Any`() = runTest {
         val attribute2 = Attribute(
             entityId = entityId,
             attributeName = "propWithStringValue",
@@ -374,7 +374,7 @@ class AttributeInstanceServiceTests : WithTimescaleContainer, WithKafkaContainer
     }
 
     @Test
-    fun `it should set the start time to the oldest value if asking for no timerel`() = runTest {
+    fun `selectOldestDate should set the start time to the oldest value when asking for no timerel`() = runTest {
         (1..9).forEachIndexed { index, _ ->
             val attributeInstance =
                 gimmeNumericPropertyAttributeInstance(
@@ -402,7 +402,7 @@ class AttributeInstanceServiceTests : WithTimescaleContainer, WithKafkaContainer
     }
 
     @Test
-    fun `it should include lower bound of interval with after timerel`() = runTest {
+    fun `search should include lower bound of interval with after timerel`() = runTest {
         (1..5).forEachIndexed { index, _ ->
             val attributeInstance =
                 gimmeNumericPropertyAttributeInstance(
@@ -427,7 +427,7 @@ class AttributeInstanceServiceTests : WithTimescaleContainer, WithKafkaContainer
     }
 
     @Test
-    fun `it should exclude upper bound of interval with between timerel`() = runTest {
+    fun `search should exclude upper bound of interval with between timerel`() = runTest {
         (1..5).forEachIndexed { index, _ ->
             val attributeInstance =
                 gimmeNumericPropertyAttributeInstance(
@@ -456,7 +456,7 @@ class AttributeInstanceServiceTests : WithTimescaleContainer, WithKafkaContainer
     }
 
     @Test
-    fun `it should only return the limited instances asked in the temporal query`() = runTest {
+    fun `search should only return the limited instances asked in the temporal query`() = runTest {
         (1..10).forEach { _ ->
             val attributeInstance = gimmeNumericPropertyAttributeInstance(
                 attributeUuid = incomingAttribute.id,
@@ -480,7 +480,7 @@ class AttributeInstanceServiceTests : WithTimescaleContainer, WithKafkaContainer
     }
 
     @Test
-    fun `it should only return the limited instances asked in an aggregated temporal query`() = runTest {
+    fun `search should only return the limited instances asked in an aggregated temporal query`() = runTest {
         val now = ngsiLdDateTime()
         (1..10).forEachIndexed { index, _ ->
             val attributeInstance =
@@ -510,7 +510,7 @@ class AttributeInstanceServiceTests : WithTimescaleContainer, WithKafkaContainer
     }
 
     @Test
-    fun `it should only retrieve the temporal evolution of the provided temporal entity attribute`() = runTest {
+    fun `search should only retrieve the temporal evolution of the provided temporal entity attribute`() = runTest {
         val attribute2 = Attribute(
             entityId = entityId,
             attributeName = OUTGOING_TERM,
@@ -545,7 +545,7 @@ class AttributeInstanceServiceTests : WithTimescaleContainer, WithKafkaContainer
     }
 
     @Test
-    fun `it should not retrieve any instance if temporal entity does not match`() = runTest {
+    fun `search should not retrieve any instance if temporal entity does not match`() = runTest {
         (1..10).forEach { _ ->
             attributeInstanceService.create(gimmeNumericPropertyAttributeInstance(incomingAttribute.id))
         }
@@ -566,7 +566,7 @@ class AttributeInstanceServiceTests : WithTimescaleContainer, WithKafkaContainer
     }
 
     @Test
-    fun `it should not retrieve any instance if there is no value in the time interval`() = runTest {
+    fun `search should not retrieve any instance if there is no value in the time interval`() = runTest {
         (1..10).forEach { _ ->
             attributeInstanceService.create(gimmeNumericPropertyAttributeInstance(incomingAttribute.id))
         }
@@ -585,7 +585,7 @@ class AttributeInstanceServiceTests : WithTimescaleContainer, WithKafkaContainer
     }
 
     @Test
-    fun `it should update an existing attribute instance with same observation date`() = runTest {
+    fun `search should update an existing attribute instance with same observation date`() = runTest {
         val attributeInstance = gimmeNumericPropertyAttributeInstance(
             attributeUuid = incomingAttribute.id,
             time = now
@@ -621,7 +621,7 @@ class AttributeInstanceServiceTests : WithTimescaleContainer, WithKafkaContainer
     }
 
     @Test
-    fun `it should create an observed attribute instance if it has a non null value`() = runTest {
+    fun `addObservedAttributeInstance should create an observed attribute instance for a non null value`() = runTest {
         val attributeInstanceService = spyk(
             AttributeInstanceService(databaseClient, searchProperties),
             recordPrivateCalls = true
@@ -683,7 +683,7 @@ class AttributeInstanceServiceTests : WithTimescaleContainer, WithKafkaContainer
     }
 
     @Test
-    fun `it should create an observed attribute instance with boolean value`() = runTest {
+    fun `addObservedAttributeInstance should create an observed attribute instance with boolean value`() = runTest {
         val attributeInstanceService = spyk(
             AttributeInstanceService(databaseClient, searchProperties),
             recordPrivateCalls = true
@@ -745,7 +745,7 @@ class AttributeInstanceServiceTests : WithTimescaleContainer, WithKafkaContainer
     }
 
     @Test
-    fun `it should create a deleted attribute instance`() = runTest {
+    fun `addDeletedAttributeInstance should create a deleted attribute instance`() = runTest {
         val attributeInstanceService = spyk(
             AttributeInstanceService(databaseClient, searchProperties),
             recordPrivateCalls = true
@@ -800,7 +800,7 @@ class AttributeInstanceServiceTests : WithTimescaleContainer, WithKafkaContainer
     }
 
     @Test
-    fun `it should modify attribute instance for a property`() = runTest {
+    fun `modifyAttributeInstance should modify attribute instance for a property`() = runTest {
         val attributeInstance = gimmeNumericPropertyAttributeInstance(incomingAttribute.id)
         attributeInstanceService.create(attributeInstance)
 
@@ -837,7 +837,7 @@ class AttributeInstanceServiceTests : WithTimescaleContainer, WithKafkaContainer
     }
 
     @Test
-    fun `it should modify attribute instance for a JSON property`() = runTest {
+    fun `modifyAttributeInstance should modify attribute instance for a JSON property`() = runTest {
         val attributeInstance = gimmeJsonPropertyAttributeInstance(jsonAttribute.id)
         attributeInstanceService.create(attributeInstance)
 
@@ -876,7 +876,7 @@ class AttributeInstanceServiceTests : WithTimescaleContainer, WithKafkaContainer
     }
 
     @Test
-    fun `it should modify attribute instance for a LanguageProperty property`() = runTest {
+    fun `modifyAttributeInstance should modify attribute instance for a LanguageProperty property`() = runTest {
         val attributeInstance = gimmeLanguagePropertyAttributeInstance(languageAttribute.id)
         attributeInstanceService.create(attributeInstance)
 
@@ -920,7 +920,7 @@ class AttributeInstanceServiceTests : WithTimescaleContainer, WithKafkaContainer
     }
 
     @Test
-    fun `it should modify attribute instance for a VocabProperty property`() = runTest {
+    fun `modifyAttributeInstance should modify attribute instance for a VocabProperty property`() = runTest {
         val attributeInstance = gimmeVocabPropertyAttributeInstance(vocabAttribute.id)
         attributeInstanceService.create(attributeInstance)
 
@@ -965,7 +965,7 @@ class AttributeInstanceServiceTests : WithTimescaleContainer, WithKafkaContainer
     }
 
     @Test
-    fun `it should delete attribute instance`() = runTest {
+    fun `deleteInstance should delete attribute instance`() = runTest {
         val attributeInstance = gimmeNumericPropertyAttributeInstance(incomingAttribute.id)
         attributeInstanceService.create(attributeInstance).shouldSucceed()
 
@@ -986,7 +986,7 @@ class AttributeInstanceServiceTests : WithTimescaleContainer, WithKafkaContainer
     }
 
     @Test
-    fun `it should not delete attribute instance if attribute name is not found`() = runTest {
+    fun `deleteInstance should not delete attribute instance if attribute name is not found`() = runTest {
         val attributeInstance = gimmeNumericPropertyAttributeInstance(incomingAttribute.id)
         attributeInstanceService.create(attributeInstance).shouldSucceed()
 
@@ -1007,7 +1007,7 @@ class AttributeInstanceServiceTests : WithTimescaleContainer, WithKafkaContainer
     }
 
     @Test
-    fun `it should not delete attribute instance if instanceID is not found`() = runTest {
+    fun `deleteInstance should not delete attribute instance if instanceID is not found`() = runTest {
         val attributeInstance = gimmeNumericPropertyAttributeInstance(incomingAttribute.id)
         val instanceId = "urn:ngsi-ld:Instance:notFound".toUri()
         attributeInstanceService.create(attributeInstance).shouldSucceed()
@@ -1029,7 +1029,7 @@ class AttributeInstanceServiceTests : WithTimescaleContainer, WithKafkaContainer
     }
 
     @Test
-    fun `it should delete all instances of an entity`() = runTest {
+    fun `deleteInstancesOfEntity should delete all instances of an entity`() = runTest {
         (1..10).forEachIndexed { index, _ ->
             if (index % 2 == 0)
                 attributeInstanceService.create(
@@ -1068,7 +1068,7 @@ class AttributeInstanceServiceTests : WithTimescaleContainer, WithKafkaContainer
     }
 
     @Test
-    fun `it should delete all instances of an attribute`() = runTest {
+    fun `deleteAllInstancesOfAttribute should delete all instances of an attribute`() = runTest {
         (1..10).forEachIndexed { index, _ ->
             if (index % 2 == 0)
                 attributeInstanceService.create(
@@ -1095,7 +1095,7 @@ class AttributeInstanceServiceTests : WithTimescaleContainer, WithKafkaContainer
     }
 
     @Test
-    fun `it should delete all instances of an attribute on default dataset`() = runTest {
+    fun `deleteInstancesOfAttribute should delete all instances of an attribute on default dataset`() = runTest {
         (1..10).forEachIndexed { index, _ ->
             if (index % 2 == 0)
                 attributeInstanceService.create(
@@ -1122,7 +1122,7 @@ class AttributeInstanceServiceTests : WithTimescaleContainer, WithKafkaContainer
     }
 
     @Test
-    fun `it should retrieve temporal values for boolean properties`() = runTest {
+    fun `search should retrieve temporal values for boolean properties`() = runTest {
         val booleanAttribute = Attribute(
             entityId = entityId,
             attributeName = "booleanProperty",
@@ -1165,7 +1165,7 @@ class AttributeInstanceServiceTests : WithTimescaleContainer, WithKafkaContainer
     }
 
     @Test
-    fun `it should retrieve temporal values for text properties`() = runTest {
+    fun `search should retrieve temporal values for text properties`() = runTest {
         val textAttribute = Attribute(
             entityId = entityId,
             attributeName = "textProperty",
@@ -1207,7 +1207,7 @@ class AttributeInstanceServiceTests : WithTimescaleContainer, WithKafkaContainer
     }
 
     @Test
-    fun `it should retrieve temporal values for list of text properties`() = runTest {
+    fun `search should retrieve temporal values for list of text properties`() = runTest {
         val arrayAttribute = Attribute(
             entityId = entityId,
             attributeName = "arrayProperty",
@@ -1253,7 +1253,7 @@ class AttributeInstanceServiceTests : WithTimescaleContainer, WithKafkaContainer
     }
 
     @Test
-    fun `it should retrieve temporal values for geoproperty`() = runTest {
+    fun `search should retrieve temporal values for geoproperty`() = runTest {
         val geoAttribute = Attribute(
             entityId = entityId,
             attributeName = "geoProperty",

--- a/search-service/src/test/kotlin/com/egm/stellio/search/temporal/service/TemporalQueryServiceTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/temporal/service/TemporalQueryServiceTests.kt
@@ -100,7 +100,7 @@ class TemporalQueryServiceTests {
     }
 
     @Test
-    fun `it should return an API exception if the entity does not exist`() = runTest {
+    fun `queryTemporalEntity should return an API exception when the entity does not exist`() = runTest {
         coEvery {
             entityQueryService.retrieve(any(), any())
         } returns ResourceNotFoundException(entityNotFoundMessage(entityUri.toString())).left()
@@ -122,7 +122,7 @@ class TemporalQueryServiceTests {
     }
 
     @Test
-    fun `it should query a temporal entity as requested by query params`() = runTest {
+    fun `queryTemporalEntity should query a temporal entity as requested by query params`() = runTest {
         val attributes =
             listOf(INCOMING_IRI, OUTGOING_IRI).map {
                 Attribute(
@@ -180,7 +180,7 @@ class TemporalQueryServiceTests {
     }
 
     @Test
-    fun `it should retrieve a temporal entity as requested by pick and omit params`() = runTest {
+    fun `queryTemporalEntity should retrieve a temporal entity as requested by pick and omit params`() = runTest {
         val attributes =
             listOf(INCOMING_IRI, OUTGOING_IRI).map {
                 Attribute(
@@ -235,7 +235,7 @@ class TemporalQueryServiceTests {
     }
 
     @Test
-    fun `it should not return an oldest timestamp if not in an aggregation query`() = runTest {
+    fun `calculateOldestTimestamp should not return an oldest timestamp outside an aggregation query`() = runTest {
         val origin = temporalQueryService.calculateOldestTimestamp(
             entityUri,
             TemporalEntitiesQueryFromGet(
@@ -254,7 +254,7 @@ class TemporalQueryServiceTests {
     }
 
     @Test
-    fun `it should return timeAt as the oldest timestamp if it is provided in the temporal query`() = runTest {
+    fun `calculateOldestTimestamp should return timeAt as the oldest timestamp when provided`() = runTest {
         val origin = temporalQueryService.calculateOldestTimestamp(
             entityUri,
             TemporalEntitiesQueryFromGet(
@@ -277,7 +277,7 @@ class TemporalQueryServiceTests {
     }
 
     @Test
-    fun `it should return the oldest timestamp from the DB if none is provided in the temporal query`() = runTest {
+    fun `calculateOldestTimestamp should return the oldest timestamp from the DB when none is provided`() = runTest {
         coEvery {
             attributeInstanceService.selectOldestDate(any(), any())
         } returns ZonedDateTime.parse("2023-09-03T12:34:56Z")
@@ -315,7 +315,7 @@ class TemporalQueryServiceTests {
     }
 
     @Test
-    fun `it should query temporal entities as requested by query params`() = runTest {
+    fun `queryTemporalEntities should query temporal entities as requested by query params`() = runTest {
         val attribute = Attribute(
             entityId = entityUri,
             attributeName = INCOMING_IRI,
@@ -377,7 +377,7 @@ class TemporalQueryServiceTests {
     }
 
     @Test
-    fun `it should query temporal entities as requested by pick and omit params`() = runTest {
+    fun `queryTemporalEntities should query temporal entities as requested by pick and omit params`() = runTest {
         val attribute = Attribute(
             entityId = entityUri,
             attributeName = INCOMING_IRI,
@@ -429,7 +429,7 @@ class TemporalQueryServiceTests {
     }
 
     @Test
-    fun `it should not return any entity if no attribute is matching the temporal query`() = runTest {
+    fun `queryTemporalEntities should not return any entity when no attribute matches the temporal query`() = runTest {
         val attribute = Attribute(
             entityId = entityUri,
             attributeName = INCOMING_IRI,

--- a/search-service/src/test/kotlin/com/egm/stellio/search/temporal/service/TemporalServiceTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/temporal/service/TemporalServiceTests.kt
@@ -49,7 +49,7 @@ class TemporalServiceTests {
     }
 
     @Test
-    fun `it should ask to create a temporal entity if it does not exist yet`() = runTest {
+    fun `createOrUpdateTemporalEntity should create a temporal entity when it does not exist yet`() = runTest {
         mockkAuthorizationForCreation()
         coEvery {
             entityQueryService.isMarkedAsDeleted(entityUri)
@@ -63,7 +63,7 @@ class TemporalServiceTests {
     }
 
     @Test
-    fun `it should ask to create a temporal entity if it already exists but is deleted`() = runTest {
+    fun `createOrUpdateTemporalEntity should create a temporal entity when it exists but is deleted`() = runTest {
         mockkAuthorizationForCreation()
         coEvery { entityQueryService.isMarkedAsDeleted(entityUri) } returns false.right()
         coEvery { entityService.createEntity(any(), any()) } returns Unit.right()
@@ -75,7 +75,7 @@ class TemporalServiceTests {
     }
 
     @Test
-    fun `it should ask to upsert a temporal entity if it already exists but is not deleted`() = runTest {
+    fun `createOrUpdateTemporalEntity should upsert a temporal entity when it exists and is not deleted`() = runTest {
         mockkAuthorizationForCreation()
         coEvery { entityQueryService.isMarkedAsDeleted(entityUri) } returns false.right()
         coEvery { entityService.upsertAttributes(any(), any()) } returns Unit.right()
@@ -86,7 +86,7 @@ class TemporalServiceTests {
     }
 
     @Test
-    fun `it should ask to permanently delete a temporal entity`() = runTest {
+    fun `deleteEntity should permanently delete a temporal entity`() = runTest {
         coEvery { entityService.permanentlyDeleteEntity(any(), any()) } returns Unit.right()
 
         temporalService.deleteEntity(entityUri).shouldSucceed()
@@ -97,7 +97,7 @@ class TemporalServiceTests {
     }
 
     @Test
-    fun `it should ask to permanently delete a temporal attribute`() = runTest {
+    fun `deleteAttribute should permanently delete a temporal attribute`() = runTest {
         coEvery { entityService.permanentlyDeleteAttribute(any(), any(), any(), any()) } returns Unit.right()
 
         temporalService.deleteAttribute(entityUri, INCOMING_IRI, null).shouldSucceed()
@@ -108,7 +108,7 @@ class TemporalServiceTests {
     }
 
     @Test
-    fun `it should ask to permanently delete a temporal attribute instance`() = runTest {
+    fun `deleteAttributeInstance should permanently delete a temporal attribute instance`() = runTest {
         val instanceId = "urn:ngsi-ld:Instance:01".toUri()
 
         coEvery { entityQueryService.checkEntityExistence(entityUri) } returns Unit.right()

--- a/search-service/src/test/kotlin/com/egm/stellio/search/temporal/util/TemporalEntityBuilderTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/temporal/util/TemporalEntityBuilderTests.kt
@@ -36,7 +36,7 @@ class TemporalEntityBuilderTests {
 
     @ParameterizedTest
     @MethodSource("com.egm.stellio.search.temporal.util.TemporalEntityParameterizedSource#rawResultsProvider")
-    fun `it should correctly build a temporal entity`(
+    fun `buildTemporalEntity should correctly build a temporal entity`(
         scopeHistory: List<ScopeInstanceResult>,
         attributeAndResultsMap: AttributesWithInstances,
         temporalRepresentation: TemporalRepresentation,
@@ -69,7 +69,7 @@ class TemporalEntityBuilderTests {
 
     @ParameterizedTest
     @MethodSource("com.egm.stellio.search.temporal.util.TemporalEntitiesParameterizedSource#rawResultsProvider")
-    fun `it should correctly build temporal entities`(
+    fun `buildTemporalEntities should correctly build temporal entities`(
         entityTemporalResults: List<EntityTemporalResult>,
         temporalRepresentation: TemporalRepresentation,
         withAudit: Boolean,
@@ -94,7 +94,7 @@ class TemporalEntityBuilderTests {
 
     @SuppressWarnings("LongMethod")
     @Test
-    fun `it should return a temporal entity with values aggregated`() {
+    fun `buildTemporalEntity should return a temporal entity with values aggregated`() {
         val attribute = Attribute(
             entityId = "urn:ngsi-ld:Beehive:1234".toUri(),
             attributeName = OUTGOING_IRI,

--- a/search-service/src/test/kotlin/com/egm/stellio/search/temporal/util/TemporalPaginationUtilsTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/temporal/util/TemporalPaginationUtilsTests.kt
@@ -275,7 +275,7 @@ class TemporalPaginationUtilsTests {
     }
 
     @Test
-    fun `range calculation with aggregatedValues`() {
+    fun `range calculation with aggregatedValues should return the computed range`() {
         val query = TemporalEntitiesQueryFromGet(
             temporalQuery = buildDefaultTestTemporalQuery(
                 instanceLimit = 2,

--- a/search-service/src/test/kotlin/com/egm/stellio/search/temporal/util/TemporalPaginationUtilsTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/temporal/util/TemporalPaginationUtilsTests.kt
@@ -275,7 +275,7 @@ class TemporalPaginationUtilsTests {
     }
 
     @Test
-    fun `range calculation with aggregatedValues should return the computed range`() {
+    fun `getPaginatedAttributeWithInstancesAndRange should return the computed range for aggregatedValues`() {
         val query = TemporalEntitiesQueryFromGet(
             temporalQuery = buildDefaultTestTemporalQuery(
                 instanceLimit = 2,

--- a/search-service/src/test/kotlin/com/egm/stellio/search/temporal/util/TemporalQueryUtilsTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/temporal/util/TemporalQueryUtilsTests.kt
@@ -39,7 +39,7 @@ import java.time.ZonedDateTime
 class TemporalQueryUtilsTests {
 
     @Test
-    fun `it should not validate the temporal query if type or attrs are not present`() = runTest {
+    fun `composeTemporalEntitiesQueryFromGet should reject a query without type or attrs`() = runTest {
         val queryParams = LinkedMultiValueMap<String, String>()
         val pagination = mockkClass(ApplicationProperties.Pagination::class)
         every { pagination.limitDefault } returns 30
@@ -60,7 +60,7 @@ class TemporalQueryUtilsTests {
     }
 
     @Test
-    fun `it should not validate the temporal query if timerel is present without time`() = runTest {
+    fun `composeTemporalEntitiesQueryFromGet should reject a query with timerel but no time`() = runTest {
         val queryParams = LinkedMultiValueMap<String, String>()
         queryParams.add("timerel", "before")
 
@@ -79,7 +79,7 @@ class TemporalQueryUtilsTests {
     }
 
     @Test
-    fun `it should not validate the temporal query if timerel and time are not present`() = runTest {
+    fun `composeTemporalEntitiesQueryFromGet should reject a query without timerel and time`() = runTest {
         val queryParams = LinkedMultiValueMap<String, String>()
         queryParams.add("type", "Beehive")
 
@@ -99,7 +99,7 @@ class TemporalQueryUtilsTests {
     }
 
     @Test
-    fun `it shouldn't validate the temporal query if both temporalValues and aggregatedValues are present`() = runTest {
+    fun `composeTemporalEntitiesQueryFromGet should reject temporalValues with aggregatedValues`() = runTest {
         val queryParams = gimmeTemporalEntitiesQueryParams()
         queryParams.replace("options", listOf("aggregatedValues,temporalValues"))
         queryParams.add("aggrMethods", "sum")
@@ -122,7 +122,7 @@ class TemporalQueryUtilsTests {
     }
 
     @Test
-    fun `it shouldn't validate the temporal query if format contains an invalid value`() = runTest {
+    fun `composeTemporalEntitiesQueryFromGet should reject an invalid format value`() = runTest {
         val queryParams = gimmeTemporalEntitiesQueryParams()
         queryParams.add("format", "invalid")
         val pagination = mockkClass(ApplicationProperties.Pagination::class)
@@ -141,7 +141,7 @@ class TemporalQueryUtilsTests {
     }
 
     @Test
-    fun `it shouldn't validate the temporal query if options contains an invalid value`() = runTest {
+    fun `composeTemporalEntitiesQueryFromGet should reject an invalid options value`() = runTest {
         val queryParams = gimmeTemporalEntitiesQueryParams()
         queryParams.replace("options", listOf("invalidOptions"))
         val pagination = mockkClass(ApplicationProperties.Pagination::class)
@@ -160,7 +160,7 @@ class TemporalQueryUtilsTests {
     }
 
     @Test
-    fun `it should parse a valid temporal query`() = runTest {
+    fun `composeTemporalEntitiesQueryFromGet should parse a valid temporal query`() = runTest {
         val queryParams = gimmeTemporalEntitiesQueryParams()
 
         val pagination = mockkClass(ApplicationProperties.Pagination::class)
@@ -197,7 +197,7 @@ class TemporalQueryUtilsTests {
     }
 
     @Test
-    fun `it should parse temporal query parameters with audit enabled`() = runTest {
+    fun `composeTemporalEntitiesQueryFromGet should parse query parameters with audit enabled`() = runTest {
         val queryParams = gimmeTemporalEntitiesQueryParams()
         queryParams["options"] = listOf("audit")
 
@@ -230,7 +230,7 @@ class TemporalQueryUtilsTests {
     }
 
     @Test
-    fun `it should parse a temporal query containing one attrs parameter`() = runTest {
+    fun `composeTemporalEntitiesQueryFromGet should parse a query with one attrs parameter`() = runTest {
         val pagination = mockkClass(ApplicationProperties.Pagination::class)
         every { pagination.limitDefault } returns 30
         every { pagination.limitMax } returns 100
@@ -250,7 +250,7 @@ class TemporalQueryUtilsTests {
     }
 
     @Test
-    fun `it should parse a temporal query containing two attrs parameter`() = runTest {
+    fun `composeTemporalEntitiesQueryFromGet should parse a query with two attrs parameters`() = runTest {
         val pagination = mockkClass(ApplicationProperties.Pagination::class)
         every { pagination.limitDefault } returns 30
         every { pagination.limitMax } returns 100
@@ -270,7 +270,7 @@ class TemporalQueryUtilsTests {
     }
 
     @Test
-    fun `it should parse a temporal query containing no attrs parameter`() = runTest {
+    fun `composeTemporalEntitiesQueryFromGet should parse a query with no attrs parameter`() = runTest {
         val pagination = mockkClass(ApplicationProperties.Pagination::class)
         every { pagination.limitDefault } returns 30
         every { pagination.limitMax } returns 100
@@ -287,7 +287,7 @@ class TemporalQueryUtilsTests {
     }
 
     @Test
-    fun `it should parse lastN parameter if it is a positive integer`() = runTest {
+    fun `buildTemporalQuery should parse lastN when it is a positive integer`() = runTest {
         val queryParams = LinkedMultiValueMap<String, String>()
         queryParams.add("timerel", "after")
         queryParams.add("timeAt", "2019-10-17T07:31:39Z")
@@ -305,7 +305,7 @@ class TemporalQueryUtilsTests {
     }
 
     @Test
-    fun `it should ignore lastN parameter if it is not an integer`() = runTest {
+    fun `buildTemporalQuery should ignore lastN when it is not an integer`() = runTest {
         val queryParams = LinkedMultiValueMap<String, String>()
         queryParams.add("timerel", "after")
         queryParams.add("timeAt", "2019-10-17T07:31:39Z")
@@ -323,7 +323,7 @@ class TemporalQueryUtilsTests {
     }
 
     @Test
-    fun `it should ignore lastN parameter if it is not a positive integer`() = runTest {
+    fun `buildTemporalQuery should ignore lastN when it is not a positive integer`() = runTest {
         val queryParams = LinkedMultiValueMap<String, String>()
         queryParams.add("timerel", "after")
         queryParams.add("timeAt", "2019-10-17T07:31:39Z")
@@ -342,7 +342,7 @@ class TemporalQueryUtilsTests {
     }
 
     @Test
-    fun `it should treat time and timerel properties as optional in a temporal query`() = runTest {
+    fun `buildTemporalQuery should treat time and timerel as optional`() = runTest {
         val queryParams = LinkedMultiValueMap<String, String>()
 
         val temporalQuery = buildTemporalQuery(
@@ -357,7 +357,7 @@ class TemporalQueryUtilsTests {
     }
 
     @Test
-    fun `it should parse a temporal query containing a timeproperty parameter`() = runTest {
+    fun `buildTemporalQuery should parse a query with a timeproperty parameter`() = runTest {
         val queryParams = LinkedMultiValueMap<String, String>()
         queryParams.add("timeproperty", "createdAt")
 
@@ -372,7 +372,7 @@ class TemporalQueryUtilsTests {
     }
 
     @Test
-    fun `it should set timeproperty to observedAt if no value is provided in query parameters`() = runTest {
+    fun `buildTemporalQuery should default timeproperty to observedAt when not provided`() = runTest {
         val queryParams = LinkedMultiValueMap<String, String>()
 
         val temporalQuery = buildTemporalQuery(
@@ -386,7 +386,7 @@ class TemporalQueryUtilsTests {
     }
 
     @Test
-    fun `it should raise an error if timeproperty provided in query parameters is unknown`() = runTest {
+    fun `buildTemporalQuery should raise an error when timeproperty is unknown`() = runTest {
         val queryParams = LinkedMultiValueMap<String, String>()
         queryParams.add("timeproperty", "unknown")
 
@@ -402,7 +402,7 @@ class TemporalQueryUtilsTests {
     }
 
     @Test
-    fun `it should parse a temporal query containing one datasetId parameter`() = runTest {
+    fun `composeTemporalEntitiesQueryFromGet should parse a query with one datasetId parameter`() = runTest {
         val pagination = mockkClass(ApplicationProperties.Pagination::class)
         every { pagination.limitDefault } returns 30
         every { pagination.limitMax } returns 100
@@ -421,7 +421,7 @@ class TemporalQueryUtilsTests {
     }
 
     @Test
-    fun `it should parse a temporal query containing two datasetIds parameter`() = runTest {
+    fun `composeTemporalEntitiesQueryFromGet should parse a query with two datasetIds parameters`() = runTest {
         val pagination = mockkClass(ApplicationProperties.Pagination::class)
         every { pagination.limitDefault } returns 30
         every { pagination.limitMax } returns 100
@@ -443,7 +443,7 @@ class TemporalQueryUtilsTests {
     }
 
     @Test
-    fun `it should parse a Query datatype with a TemporalQuery`() = runTest {
+    fun `composeTemporalEntitiesQueryFromPost should parse a Query datatype with a TemporalQuery`() = runTest {
         val query = """
             {
                 "type": "Query",

--- a/search-service/src/test/kotlin/com/egm/stellio/search/temporal/web/TemporalEntityHandlerDistributionTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/temporal/web/TemporalEntityHandlerDistributionTests.kt
@@ -27,7 +27,7 @@ class TemporalEntityHandlerDistributionTests : TemporalEntityHandlerTestCommon()
     private val entityUri = "urn:ngsi-ld:BeeHive:TESTC".toUri()
 
     @Test
-    fun `it should return 200 when entity is not found locally but found in a remote CSR`() = runTest {
+    fun `query temporal entity should return 200 when not found locally but found in a remote CSR`() = runTest {
         val csr = gimmeRawCSR()
         val remoteEntity = mapOf(
             "id" to entityUri.toString(),
@@ -53,7 +53,7 @@ class TemporalEntityHandlerDistributionTests : TemporalEntityHandlerTestCommon()
     }
 
     @Test
-    fun `it should return 404 when entity is not found locally nor in any remote CSR`() {
+    fun `query temporal entity should return 404 when not found locally nor in any remote CSR`() {
         coEvery {
             temporalQueryService.queryTemporalEntity(any(), any())
         } returns ResourceNotFoundException(entityNotFoundMessage(entityUri.toString())).left()
@@ -71,7 +71,7 @@ class TemporalEntityHandlerDistributionTests : TemporalEntityHandlerTestCommon()
     }
 
     @Test
-    fun `it should surface NGSILD-Warning headers when distributed query raises warnings`() = runTest {
+    fun `query temporal entities should surface NGSILD-Warning headers on distributed warnings`() = runTest {
         val csr = gimmeRawCSR()
         val warning = MiscellaneousWarning("CSR unavailable", csr)
 

--- a/search-service/src/test/kotlin/com/egm/stellio/search/temporal/web/TemporalEntityHandlerTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/temporal/web/TemporalEntityHandlerTests.kt
@@ -100,7 +100,7 @@ class TemporalEntityHandlerTests : TemporalEntityHandlerTestCommon() {
     }
 
     @Test
-    fun `it should correctly handle an attribute with one instance`() {
+    fun `add temporal entity attributes should correctly handle an attribute with one instance`() {
         val entityTemporalFragment =
             loadSampleData("fragments/temporal_entity_fragment_one_attribute_one_instance.jsonld")
 
@@ -125,7 +125,7 @@ class TemporalEntityHandlerTests : TemporalEntityHandlerTestCommon() {
     }
 
     @Test
-    fun `it should correctly handle an attribute with many instances`() {
+    fun `add temporal entity attributes should correctly handle an attribute with many instances`() {
         val entityTemporalFragment =
             loadSampleData("fragments/temporal_entity_fragment_one_attribute_many_instances.jsonld")
 
@@ -150,7 +150,7 @@ class TemporalEntityHandlerTests : TemporalEntityHandlerTestCommon() {
     }
 
     @Test
-    fun `it should correctly handle many attributes with one instance`() {
+    fun `add temporal entity attributes should correctly handle many attributes with one instance`() {
         val entityTemporalFragment =
             loadSampleData("fragments/temporal_entity_fragment_many_attributes_one_instance.jsonld")
 
@@ -175,7 +175,7 @@ class TemporalEntityHandlerTests : TemporalEntityHandlerTestCommon() {
     }
 
     @Test
-    fun `it should correctly handle many attributes with many instances`() {
+    fun `add temporal entity attributes should correctly handle many attributes with many instances`() {
         val entityTemporalFragment =
             loadSampleData("fragments/temporal_entity_fragment_many_attributes_many_instances.jsonld")
 
@@ -200,7 +200,7 @@ class TemporalEntityHandlerTests : TemporalEntityHandlerTestCommon() {
     }
 
     @Test
-    fun `it should return a 400 if temporal entity fragment is badly formed`() {
+    fun `add temporal entity attributes should return a 400 if the fragment is badly formed`() {
         webClient.post()
             .uri("/ngsi-ld/v1/temporal/entities/$entityUri/attrs")
             .header("Link", APIC_HEADER_LINK)
@@ -219,7 +219,7 @@ class TemporalEntityHandlerTests : TemporalEntityHandlerTestCommon() {
     }
 
     @Test
-    fun `it should return a 403 is user is not authorized to write on the entity`() {
+    fun `add temporal entity attributes should return a 403 if user cannot write on the entity`() {
         val entityTemporalFragment =
             loadSampleData("fragments/temporal_entity_fragment_many_attributes_many_instances.jsonld")
 
@@ -237,7 +237,7 @@ class TemporalEntityHandlerTests : TemporalEntityHandlerTestCommon() {
     }
 
     @Test
-    fun `it should raise a 400 if timerel is present without time query param`() {
+    fun `query temporal entity should return 400 if timerel is present without time`() {
         webClient.get()
             .uri("/ngsi-ld/v1/temporal/entities/urn:ngsi-ld:Entity:01?timerel=before")
             .exchange()
@@ -253,7 +253,7 @@ class TemporalEntityHandlerTests : TemporalEntityHandlerTestCommon() {
     }
 
     @Test
-    fun `it should raise a 400 if time is present without timerel query param`() {
+    fun `query temporal entity should return 400 if time is present without timerel`() {
         webClient.get()
             .uri("/ngsi-ld/v1/temporal/entities/urn:ngsi-ld:Entity:01?timeAt=2020-10-29T18:00:00Z")
             .exchange()
@@ -269,7 +269,7 @@ class TemporalEntityHandlerTests : TemporalEntityHandlerTestCommon() {
     }
 
     @Test
-    fun `it should give a 200 if no timerel and no time query params are in the request`() = runTest {
+    fun `query temporal entity should return 200 if no timerel and time params are provided`() = runTest {
         val expandedTemporalEntity = loadAndExpandSampleData("temporal/beehive_create_temporal_entity.jsonld")
         coEvery {
             temporalQueryService.queryTemporalEntity(any(), any())
@@ -282,7 +282,7 @@ class TemporalEntityHandlerTests : TemporalEntityHandlerTestCommon() {
     }
 
     @Test
-    fun `it should raise a 400 if timerel is between and no endTimeAt provided`() {
+    fun `query temporal entity should return 400 if timerel is between and no endTimeAt`() {
         webClient.get()
             .uri("/ngsi-ld/v1/temporal/entities/urn:ngsi-ld:Entity:01?timerel=between&timeAt=2020-10-29T18:00:00Z")
             .exchange()
@@ -298,7 +298,7 @@ class TemporalEntityHandlerTests : TemporalEntityHandlerTestCommon() {
     }
 
     @Test
-    fun `it should raise a 400 if time is not parsable`() {
+    fun `query temporal entity should return 400 if time is not parsable`() {
         webClient.get()
             .uri("/ngsi-ld/v1/temporal/entities/urn:ngsi-ld:Entity:01?timerel=before&timeAt=badTime")
             .exchange()
@@ -314,7 +314,7 @@ class TemporalEntityHandlerTests : TemporalEntityHandlerTestCommon() {
     }
 
     @Test
-    fun `it should raise a 400 if timerel is not a valid value`() {
+    fun `query temporal entity should return 400 if timerel is not a valid value`() {
         webClient.get()
             .uri("/ngsi-ld/v1/temporal/entities/urn:ngsi-ld:Entity:01?timerel=befor&timeAt=badTime")
             .exchange()
@@ -330,7 +330,7 @@ class TemporalEntityHandlerTests : TemporalEntityHandlerTestCommon() {
     }
 
     @Test
-    fun `it should raise a 400 if timerel is between and endTimeAt is not parseable`() {
+    fun `query temporal entity should return 400 if timerel is between and endTimeAt is not parseable`() {
         webClient.get()
             .uri(
                 "/ngsi-ld/v1/temporal/entities/urn:ngsi-ld:Entity:01?" +
@@ -349,7 +349,7 @@ class TemporalEntityHandlerTests : TemporalEntityHandlerTestCommon() {
     }
 
     @Test
-    fun `it should raise a 400 if one of time bucket or aggregate is missing`() {
+    fun `query temporal entity should return 400 if time bucket or aggregate is missing`() {
         webClient.get()
             .uri(
                 "/ngsi-ld/v1/temporal/entities/urn:ngsi-ld:Entity:01?" +
@@ -368,7 +368,7 @@ class TemporalEntityHandlerTests : TemporalEntityHandlerTestCommon() {
     }
 
     @Test
-    fun `it should raise a 400 if aggregate function is unknown`() {
+    fun `query temporal entity should return 400 if aggregate function is unknown`() {
         webClient.get()
             .uri(
                 "/ngsi-ld/v1/temporal/entities/urn:ngsi-ld:Entity:01?" +
@@ -387,7 +387,7 @@ class TemporalEntityHandlerTests : TemporalEntityHandlerTestCommon() {
     }
 
     @Test
-    fun `it should raise a 400 if aggrPeriodDuration is not in the correct format`() {
+    fun `query temporal entity should return 400 if aggrPeriodDuration format is invalid`() {
         webClient.get()
             .uri(
                 "/ngsi-ld/v1/temporal/entities/urn:ngsi-ld:Entity:01?" +
@@ -406,7 +406,7 @@ class TemporalEntityHandlerTests : TemporalEntityHandlerTestCommon() {
     }
 
     @Test
-    fun `it should raise a 400 if temporalValues and aggregatedValues exist in options query param`() {
+    fun `query temporal entity should return 400 if temporalValues and aggregatedValues both set`() {
         webClient.get()
             .uri(
                 "/ngsi-ld/v1/temporal/entities/urn:ngsi-ld:Entity:01?" +
@@ -426,7 +426,7 @@ class TemporalEntityHandlerTests : TemporalEntityHandlerTestCommon() {
     }
 
     @Test
-    fun `it should raise a 400 if format query param has an invalid value`() {
+    fun `query temporal entity should return 400 if format query param is invalid`() {
         webClient.get()
             .uri(
                 "/ngsi-ld/v1/temporal/entities/urn:ngsi-ld:Entity:01?" +
@@ -446,7 +446,7 @@ class TemporalEntityHandlerTests : TemporalEntityHandlerTestCommon() {
     }
 
     @Test
-    fun `it should raise a 400 if options query param has an invalid value`() {
+    fun `query temporal entity should return 400 if options query param is invalid`() {
         webClient.get()
             .uri(
                 "/ngsi-ld/v1/temporal/entities/urn:ngsi-ld:Entity:01?" +
@@ -466,7 +466,7 @@ class TemporalEntityHandlerTests : TemporalEntityHandlerTestCommon() {
     }
 
     @Test
-    fun `it should return a 404 if temporal entity attribute does not exist`() {
+    fun `query temporal entity should return 404 if the attribute does not exist`() {
         coEvery {
             temporalQueryService.queryTemporalEntity(any(), any())
         } returns ResourceNotFoundException("Entity urn:ngsi-ld:BeeHive:TESTC does not exist").left()
@@ -489,7 +489,7 @@ class TemporalEntityHandlerTests : TemporalEntityHandlerTestCommon() {
     }
 
     @Test
-    fun `it should return a 404 if no temporal entity member matches pick and omit parameters`() = runTest {
+    fun `query temporal entity should return 404 if no member matches pick and omit`() = runTest {
         val expandedTemporalEntity = loadAndExpandSampleData("temporal/beehive_create_temporal_entity.jsonld")
         coEvery {
             temporalQueryService.queryTemporalEntity(any(), any())
@@ -510,7 +510,7 @@ class TemporalEntityHandlerTests : TemporalEntityHandlerTestCommon() {
     }
 
     @Test
-    fun `it should return a 200 if minimal required parameters are valid`() = runTest {
+    fun `query temporal entity should return 200 if minimal required parameters are valid`() = runTest {
         val expandedTemporalEntity = loadAndExpandSampleData("temporal/beehive_create_temporal_entity.jsonld")
         coEvery {
             temporalQueryService.queryTemporalEntity(any(), any())
@@ -542,7 +542,7 @@ class TemporalEntityHandlerTests : TemporalEntityHandlerTestCommon() {
     }
 
     @Test
-    fun `it should return an entity with two temporal properties evolution`() = runTest {
+    fun `query temporal entity should return an entity with two temporal properties evolution`() = runTest {
         mockWithIncomingAndOutgoingTemporalProperties(false)
 
         webClient.get()
@@ -562,7 +562,7 @@ class TemporalEntityHandlerTests : TemporalEntityHandlerTestCommon() {
     }
 
     @Test
-    fun `it should return a json entity with two temporal properties evolution`() = runTest {
+    fun `query temporal entity should return a json entity with two temporal properties evolution`() = runTest {
         mockWithIncomingAndOutgoingTemporalProperties(false)
 
         webClient.get()
@@ -584,7 +584,7 @@ class TemporalEntityHandlerTests : TemporalEntityHandlerTestCommon() {
     }
 
     @Test
-    fun `it should return an entity with two temporal properties evolution with temporalValues option`() = runTest {
+    fun `query temporal entity should return temporal properties with the temporalValues option`() = runTest {
         mockWithIncomingAndOutgoingTemporalProperties(true)
 
         webClient.get()
@@ -604,7 +604,7 @@ class TemporalEntityHandlerTests : TemporalEntityHandlerTestCommon() {
     }
 
     @Test
-    fun `it should wrap single instance normalized attributes to a list of one instance`() = runTest {
+    fun `query temporal entity should wrap single instance normalized attributes in a list`() = runTest {
         val temporalEntity = loadAndExpandSampleData("beehive_with_two_temporal_attributes_one_evolution.jsonld")
         coEvery {
             temporalQueryService.queryTemporalEntity(any(), any())
@@ -636,7 +636,7 @@ class TemporalEntityHandlerTests : TemporalEntityHandlerTestCommon() {
     }
 
     @Test
-    fun `it should raise a 400 and return an error response`() {
+    fun `query temporal entities should return a 400 and an error response`() {
         webClient.get()
             .uri("/ngsi-ld/v1/temporal/entities?type=Beehive&timerel=before")
             .exchange()
@@ -652,7 +652,7 @@ class TemporalEntityHandlerTests : TemporalEntityHandlerTestCommon() {
     }
 
     @Test
-    fun `it should return a 200 with empty payload if no temporal attribute is found`() {
+    fun `query temporal entity should return 200 with an empty payload if no attribute is found`() {
         val temporalQuery = buildDefaultTestTemporalQuery(
             timerel = TemporalQuery.Timerel.BETWEEN,
             timeAt = ZonedDateTime.parse("2019-10-17T07:31:39Z"),
@@ -689,7 +689,7 @@ class TemporalEntityHandlerTests : TemporalEntityHandlerTestCommon() {
     }
 
     @Test
-    fun `it should return 200 with jsonld response body for query temporal entities`() = runTest {
+    fun `query temporal entities should return 200 with a JSON-LD response body`() = runTest {
         val firstTemporalEntity = loadAndExpandSampleData("beehive_with_two_temporal_attributes_evolution.jsonld")
         val secondTemporalEntity = loadAndExpandSampleData("beehive.jsonld")
 
@@ -714,7 +714,7 @@ class TemporalEntityHandlerTests : TemporalEntityHandlerTestCommon() {
     }
 
     @Test
-    fun `it should return 200 with json response body for query temporal entities`() = runTest {
+    fun `query temporal entities should return 200 with a JSON response body`() = runTest {
         val firstTemporalEntity = loadAndExpandSampleData("beehive_with_two_temporal_attributes_evolution.jsonld")
         val secondTemporalEntity = loadAndExpandSampleData("beehive.jsonld")
 

--- a/search-service/src/test/kotlin/com/egm/stellio/search/temporal/web/TemporalEntityOperationsHandlerTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/temporal/web/TemporalEntityOperationsHandlerTests.kt
@@ -60,7 +60,7 @@ class TemporalEntityOperationsHandlerTests {
     }
 
     @Test
-    fun `it should return a 200 and retrieve requested temporal attributes`() {
+    fun `query temporal entities should return 200 and retrieve the requested temporal attributes`() {
         val temporalQuery = buildDefaultTestTemporalQuery(
             timerel = TemporalQuery.Timerel.BETWEEN,
             timeAt = ZonedDateTime.parse("2019-10-17T07:31:39Z"),
@@ -111,7 +111,7 @@ class TemporalEntityOperationsHandlerTests {
     }
 
     @Test
-    fun `it should return a 200 and the number of results if count is asked for`() {
+    fun `query temporal entities should return 200 and the number of results when count is asked`() {
         val temporalQuery = buildDefaultTestTemporalQuery(
             timerel = TemporalQuery.Timerel.BETWEEN,
             timeAt = ZonedDateTime.parse("2019-10-17T07:31:39Z"),
@@ -166,7 +166,7 @@ class TemporalEntityOperationsHandlerTests {
     }
 
     @Test
-    fun `it should raise a 400 if required parameters are missing`() {
+    fun `query temporal entities should return 400 when required parameters are missing`() {
         val query = """
             {
                 "type": "Query",
@@ -195,7 +195,7 @@ class TemporalEntityOperationsHandlerTests {
     }
 
     @Test
-    fun `it should return entities with only the picked attributes`() = runTest {
+    fun `query temporal entities should return entities with only the picked attributes`() = runTest {
         val expandedEntity = loadAndExpandSampleData("beehive_with_two_temporal_attributes_evolution.jsonld")
 
         coEvery {
@@ -227,7 +227,7 @@ class TemporalEntityOperationsHandlerTests {
     }
 
     @Test
-    fun `it should return entities without the omitted attributes`() = runTest {
+    fun `query temporal entities should return entities without the omitted attributes`() = runTest {
         val expandedEntity = loadAndExpandSampleData("beehive_with_two_temporal_attributes_evolution.jsonld")
 
         coEvery {
@@ -259,7 +259,7 @@ class TemporalEntityOperationsHandlerTests {
     }
 
     @Test
-    fun `it should return an empty list if no entity member matches pick parameter`() = runTest {
+    fun `query temporal entities should return an empty list when no member matches the pick parameter`() = runTest {
         val expandedEntity = loadAndExpandSampleData("beehive_with_two_temporal_attributes_evolution.jsonld")
 
         coEvery {

--- a/search-service/src/test/kotlin/db/migration/V0_29_JsonLd_migrationTests.kt
+++ b/search-service/src/test/kotlin/db/migration/V0_29_JsonLd_migrationTests.kt
@@ -15,7 +15,7 @@ class V0_29_JsonLd_migrationTests {
     private val contexts = APIC_COMPOUND_CONTEXTS
 
     @Test
-    fun `it should remove instances when attribute has more than one instance with the same datasetId`() = runTest {
+    fun `keepOnlyOneInstanceByDatasetId should remove duplicate instances with the same datasetId`() = runTest {
         val payload = loadSampleData("fragments/attribute_with_two_instances_and_same_dataset_id.jsonld")
             .deserializeAsMap()
 
@@ -37,7 +37,7 @@ class V0_29_JsonLd_migrationTests {
     }
 
     @Test
-    fun `it should not remove instances when attribute has a default instance and one with a datasetId`() = runTest {
+    fun `keepOnlyOneInstanceByDatasetId should keep a default instance and one with a datasetId`() = runTest {
         val payload = loadSampleData("fragments/attribute_with_default_instance_and_dataset_id.jsonld")
             .deserializeAsMap()
 
@@ -63,7 +63,7 @@ class V0_29_JsonLd_migrationTests {
     }
 
     @Test
-    fun `it should not remove instances when attribute has instances with different values for datasetId`() = runTest {
+    fun `keepOnlyOneInstanceByDatasetId should keep instances with different datasetId values`() = runTest {
         val payload = loadSampleData("fragments/attribute_with_two_instances_and_different_dataset_id.jsonld")
             .deserializeAsMap()
 
@@ -90,7 +90,7 @@ class V0_29_JsonLd_migrationTests {
     }
 
     @Test
-    fun `it should remove instance when attribute has two default instances`() = runTest {
+    fun `keepOnlyOneInstanceByDatasetId should remove one of two default instances`() = runTest {
         val payload = loadSampleData("fragments/attribute_with_two_default_instances.jsonld")
             .deserializeAsMap()
 

--- a/shared/config/detekt/baseline.xml
+++ b/shared/config/detekt/baseline.xml
@@ -2,9 +2,9 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
-    <ID>LongMethod:CompactedEntityLinkedTests.kt$CompactedEntityLinkedTests$@Test fun `it should inline an entity with a multi-instance multivalued relationship`()</ID>
-    <ID>LongMethod:CompactedEntityLinkedTests.kt$CompactedEntityLinkedTests$@Test fun `it should inline two entities with their respective relationhips`()</ID>
-    <ID>LongMethod:CompactedEntityLinkedTests.kt$CompactedEntityLinkedTests$@Test fun `it should simplify relationships for inlined entities`()</ID>
+    <ID>LongMethod:CompactedEntityLinkedTests.kt$CompactedEntityLinkedTests$@Test fun `inlineLinkedEntities should inline an entity with a multi-instance multivalued relationship`()</ID>
+    <ID>LongMethod:CompactedEntityLinkedTests.kt$CompactedEntityLinkedTests$@Test fun `inlineLinkedEntities should inline two entities with their respective relationhips`()</ID>
+    <ID>LongMethod:CompactedEntityLinkedTests.kt$CompactedEntityLinkedTests$@Test fun `toSimplifiedAttributes should simplify relationships for inlined entities`()</ID>
     <ID>LongParameterList:ApiResponses.kt$( body: String, count: Int, resourceUrl: String, paginationQuery: PaginationQuery, requestParams: MultiValueMap&lt;String, String&gt;, mediaType: MediaType, contexts: List&lt;String&gt; )</ID>
     <ID>LongParameterList:ApiResponses.kt$( entities: Any, count: Int, resourceUrl: String, paginationQuery: PaginationQuery, requestParams: MultiValueMap&lt;String, String&gt;, mediaType: MediaType, contexts: List&lt;String&gt; )</ID>
     <ID>NestedBlockDepth:JsonLdUtils.kt$JsonLdUtils$fun expandJsonLdTerm(term: String, contexts: List&lt;String&gt;): String</ID>

--- a/shared/src/test/kotlin/com/egm/stellio/shared/model/AttributePathTests.kt
+++ b/shared/src/test/kotlin/com/egm/stellio/shared/model/AttributePathTests.kt
@@ -52,7 +52,7 @@ class AttributePathTests {
 
     @ParameterizedTest
     @MethodSource("com.egm.stellio.shared.model.AttributePathTests#attributePathProvider")
-    fun `it should correctly parse an AttributePath`(
+    fun `AttributePath should correctly parse an AttributePath`(
         term: String,
         expectedMainPath: List<ExpandedTerm>,
         expectedTrailingPath: List<ExpandedTerm> = emptyList()
@@ -63,7 +63,7 @@ class AttributePathTests {
     }
 
     @Test
-    fun `it should mark attribute as jsonKeys and keep trailing path unexpanded`() = runTest {
+    fun `AttributePath should mark attribute as jsonKeys and keep trailing path unexpanded`() = runTest {
         val attrPath = AttributePath(
             "$INCOMING_TERM[$TEMPERATURE_TERM]",
             APIC_COMPOUND_CONTEXTS,
@@ -76,7 +76,7 @@ class AttributePathTests {
     }
 
     @Test
-    fun `it should keep composed trailing path unexpanded when attribute is in jsonKeys`() = runTest {
+    fun `AttributePath should keep composed trailing path unexpanded when attribute is in jsonKeys`() = runTest {
         val attrPath = AttributePath(
             "$INCOMING_TERM[$TEMPERATURE_TERM.$NAME_TERM]",
             APIC_COMPOUND_CONTEXTS,
@@ -87,7 +87,7 @@ class AttributePathTests {
     }
 
     @Test
-    fun `it should mark attribute as expandValues`() = runTest {
+    fun `AttributePath should mark attribute as expandValues`() = runTest {
         val attrPath = AttributePath(
             INCOMING_TERM,
             APIC_COMPOUND_CONTEXTS,
@@ -99,7 +99,7 @@ class AttributePathTests {
     }
 
     @Test
-    fun `it should parse language tag from bracket notation`() = runTest {
+    fun `AttributePath should parse language tag from bracket notation`() = runTest {
         val attrPath = AttributePath("$INCOMING_TERM[en]", APIC_COMPOUND_CONTEXTS)
         assertEquals("en", attrPath.languageTag)
         assertEquals(listOf(INCOMING_IRI), attrPath.mainPath)
@@ -108,7 +108,7 @@ class AttributePathTests {
     }
 
     @Test
-    fun `it should expand trailing path terms when attribute is not in jsonKeys`() = runTest {
+    fun `AttributePath should expand trailing path terms when attribute is not in jsonKeys`() = runTest {
         val attrPath = AttributePath("$INCOMING_TERM[$TEMPERATURE_TERM.$NAME_TERM]", APIC_COMPOUND_CONTEXTS)
         assertFalse(attrPath.isJsonKeysAttribute)
         assertNull(attrPath.languageTag)
@@ -116,19 +116,19 @@ class AttributePathTests {
     }
 
     @Test
-    fun `it should build exists path for a simple attribute`() = runTest {
+    fun `buildJsonBExistsPath should build exists path for a simple attribute`() = runTest {
         val attrPath = AttributePath(INCOMING_TERM, APIC_COMPOUND_CONTEXTS)
         assertEquals("""$."$INCOMING_IRI"""", attrPath.buildJsonBExistsPath())
     }
 
     @Test
-    fun `it should build exists path for a composed attribute`() = runTest {
+    fun `buildJsonBExistsPath should build exists path for a composed attribute`() = runTest {
         val attrPath = AttributePath("$INCOMING_TERM.$NGSILD_MODIFIED_AT_TERM", APIC_COMPOUND_CONTEXTS)
         assertEquals("""$."$INCOMING_IRI"."$NGSILD_MODIFIED_AT_IRI"""", attrPath.buildJsonBExistsPath())
     }
 
     @Test
-    fun `it should build property path for a simple attribute`() = runTest {
+    fun `buildJsonBPropertyPath should build property path for a simple attribute`() = runTest {
         val attrPath = AttributePath(INCOMING_TERM, APIC_COMPOUND_CONTEXTS)
         assertEquals(
             """$."$INCOMING_IRI"."$NGSILD_PROPERTY_VALUE"."$JSONLD_VALUE_KW"""",
@@ -137,7 +137,7 @@ class AttributePathTests {
     }
 
     @Test
-    fun `it should build property path using a direct value access for a temporal attribute`() = runTest {
+    fun `buildJsonBPropertyPath should build a direct value access path for a temporal attribute`() = runTest {
         val attrPath = AttributePath("$INCOMING_TERM.$NGSILD_MODIFIED_AT_TERM", APIC_COMPOUND_CONTEXTS)
         assertEquals(
             """$."$INCOMING_IRI"."$NGSILD_MODIFIED_AT_IRI"."$JSONLD_VALUE_KW"""",
@@ -146,7 +146,7 @@ class AttributePathTests {
     }
 
     @Test
-    fun `it should build property path with wildcard traversal for a composed attribute`() = runTest {
+    fun `buildJsonBPropertyPath should build a wildcard traversal path for a composed attribute`() = runTest {
         val attrPath = AttributePath("$INCOMING_TERM.$TEMPERATURE_TERM", APIC_COMPOUND_CONTEXTS)
         assertEquals(
             """$."$INCOMING_IRI"."$TEMPERATURE_IRI".**{0 to 2}."$JSONLD_VALUE_KW"""",
@@ -155,7 +155,7 @@ class AttributePathTests {
     }
 
     @Test
-    fun `it should build property path with trailing path for bracket notation`() = runTest {
+    fun `buildJsonBPropertyPath should build property path with trailing path for bracket notation`() = runTest {
         val attrPath = AttributePath("$INCOMING_TERM[$TEMPERATURE_TERM]", APIC_COMPOUND_CONTEXTS)
         assertEquals(
             """$."$INCOMING_IRI"."$NGSILD_PROPERTY_VALUE"."$TEMPERATURE_IRI".**{0 to 1}."$JSONLD_VALUE_KW"""",
@@ -164,7 +164,7 @@ class AttributePathTests {
     }
 
     @Test
-    fun `it should build relationship path for a simple attribute`() = runTest {
+    fun `buildJsonBRelationshipPath should build relationship path for a simple attribute`() = runTest {
         val attrPath = AttributePath(INCOMING_TERM, APIC_COMPOUND_CONTEXTS)
         assertEquals(
             """$."$INCOMING_IRI"."$NGSILD_RELATIONSHIP_OBJECT"[*]."$JSONLD_ID_KW"""",
@@ -173,7 +173,7 @@ class AttributePathTests {
     }
 
     @Test
-    fun `it should build relationship path with wildcard traversal for a composed attribute`() = runTest {
+    fun `buildJsonBRelationshipPath should build a wildcard traversal path for a composed attribute`() = runTest {
         val attrPath = AttributePath("$INCOMING_TERM.$TEMPERATURE_TERM", APIC_COMPOUND_CONTEXTS)
         assertEquals(
             """$."$INCOMING_IRI"."$TEMPERATURE_IRI".**{0 to 2}."$NGSILD_RELATIONSHIP_OBJECT"[*]."$JSONLD_ID_KW"""",
@@ -182,7 +182,7 @@ class AttributePathTests {
     }
 
     @Test
-    fun `it should build vocab path for a simple attribute`() = runTest {
+    fun `buildJsonBVocabPath should build vocab path for a simple attribute`() = runTest {
         val attrPath = AttributePath(INCOMING_TERM, APIC_COMPOUND_CONTEXTS)
         assertEquals(
             """$."$INCOMING_IRI"."$NGSILD_VOCABPROPERTY_VOCAB"[*]."$JSONLD_ID_KW"""",
@@ -191,7 +191,7 @@ class AttributePathTests {
     }
 
     @Test
-    fun `it should build vocab path for a composed attribute`() = runTest {
+    fun `buildJsonBVocabPath should build vocab path for a composed attribute`() = runTest {
         val attrPath = AttributePath("$INCOMING_TERM.$TEMPERATURE_TERM", APIC_COMPOUND_CONTEXTS)
         assertEquals(
             """$."$INCOMING_IRI"."$TEMPERATURE_IRI".**{0 to 2}."$NGSILD_VOCABPROPERTY_VOCAB"[*]."$JSONLD_ID_KW"""",
@@ -200,7 +200,7 @@ class AttributePathTests {
     }
 
     @Test
-    fun `it should build language map path for a simple attribute`() = runTest {
+    fun `buildJsonBLanguageMapPath should build language map path for a simple attribute`() = runTest {
         val attrPath = AttributePath(INCOMING_TERM, APIC_COMPOUND_CONTEXTS)
         assertEquals(
             """$."$INCOMING_IRI"."$NGSILD_LANGUAGEPROPERTY_LANGUAGEMAP"[*]."$JSONLD_VALUE_KW"""",
@@ -209,7 +209,7 @@ class AttributePathTests {
     }
 
     @Test
-    fun `it should build language map path for a composed attribute`() = runTest {
+    fun `buildJsonBLanguageMapPath should build language map path for a composed attribute`() = runTest {
         val attrPath = AttributePath("$INCOMING_TERM.$TEMPERATURE_TERM", APIC_COMPOUND_CONTEXTS)
         assertEquals(
             """$."$INCOMING_IRI"."$TEMPERATURE_IRI".**{0 to 2}.""" +
@@ -219,7 +219,7 @@ class AttributePathTests {
     }
 
     @Test
-    fun `it should build language map filter path for a simple attribute`() = runTest {
+    fun `buildJsonBLanguageMapFilterPath should build language map filter path for a simple attribute`() = runTest {
         val attrPath = AttributePath(INCOMING_TERM, APIC_COMPOUND_CONTEXTS)
         assertEquals(
             """$."$INCOMING_IRI"."$NGSILD_LANGUAGEPROPERTY_LANGUAGEMAP"[*]""",
@@ -228,7 +228,7 @@ class AttributePathTests {
     }
 
     @Test
-    fun `it should build language map filter path for a composed attribute`() = runTest {
+    fun `buildJsonBLanguageMapFilterPath should build language map filter path for a composed attribute`() = runTest {
         val attrPath = AttributePath("$INCOMING_TERM.$TEMPERATURE_TERM", APIC_COMPOUND_CONTEXTS)
         assertEquals(
             """$."$INCOMING_IRI"."$TEMPERATURE_IRI".**{0 to 2}."$NGSILD_LANGUAGEPROPERTY_LANGUAGEMAP"[*]""",
@@ -237,7 +237,7 @@ class AttributePathTests {
     }
 
     @Test
-    fun `it should build json property path for a jsonKeys attribute`() = runTest {
+    fun `buildJsonBJsonPropertyPath should build json property path for a jsonKeys attribute`() = runTest {
         val attrPath = AttributePath(
             "$INCOMING_TERM[$TEMPERATURE_TERM]",
             APIC_COMPOUND_CONTEXTS,
@@ -250,7 +250,7 @@ class AttributePathTests {
     }
 
     @Test
-    fun `it should build json property path for a jsonKeys attribute with composed main path`() = runTest {
+    fun `buildJsonBJsonPropertyPath should build a path for a jsonKeys attribute with composed main path`() = runTest {
         val attrPath = AttributePath(
             "$INCOMING_TERM.$TEMPERATURE_TERM[$NAME_TERM]",
             APIC_COMPOUND_CONTEXTS,

--- a/shared/src/test/kotlin/com/egm/stellio/shared/model/AttributeProjectionTests.kt
+++ b/shared/src/test/kotlin/com/egm/stellio/shared/model/AttributeProjectionTests.kt
@@ -136,7 +136,7 @@ class AttributeProjectionTests {
     }
 
     @Test
-    fun `getRootAttributesToPick should get attributes at the root level`() {
+    fun `getRootAttributesToPick should return attributes at the root level`() {
         val (pick, _) = parsePickOmitParameters("temperature,humidity,servesDataset{title}", null)
             .shouldSucceedAndResult()
 
@@ -148,7 +148,7 @@ class AttributeProjectionTests {
     }
 
     @Test
-    fun `getAttributesToPickFor should get attributes at any level in the graph`() {
+    fun `getAttributesToPickFor should return attributes at any depth in the graph`() {
         val (pick, _) = parsePickOmitParameters(
             "servesDataset{title,description,catalog{publisher}},belongsTo{name,owner,servesDatatset{location}}",
             null
@@ -171,7 +171,7 @@ class AttributeProjectionTests {
     }
 
     @Test
-    fun `getRootAttributesToOmit should get root attributes to omit`() {
+    fun `getRootAttributesToOmit should return the root-level attributes to omit`() {
         val (_, omit) = parsePickOmitParameters(
             null,
             "temperature,humidity,servesDataset{title}"
@@ -185,7 +185,7 @@ class AttributeProjectionTests {
     }
 
     @Test
-    fun `getAttributesToOmitFor should get attributes to omit at any level in the graph`() {
+    fun `getAttributesToOmitFor should return attributes to omit at any depth in the graph`() {
         val (_, omit) = parsePickOmitParameters(
             null,
             "servesDataset{title,description,catalog{publisher}},belongsTo{name,owner,servesDatatset{location}}"

--- a/shared/src/test/kotlin/com/egm/stellio/shared/model/AttributeProjectionTests.kt
+++ b/shared/src/test/kotlin/com/egm/stellio/shared/model/AttributeProjectionTests.kt
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test
 class AttributeProjectionTests {
 
     @Test
-    fun `it should return empty sets when no pick or omit parameters are provided`() {
+    fun `parsePickOmitParameters should return empty sets when no pick or omit parameters are provided`() {
         val (pick, omit) = parsePickOmitParameters(null, null).shouldSucceedAndResult()
 
         assertThat(pick).isEmpty()
@@ -18,7 +18,7 @@ class AttributeProjectionTests {
     }
 
     @Test
-    fun `it should reject empty pick parameter`() {
+    fun `parsePickOmitParameters should reject empty pick parameter`() {
         parsePickOmitParameters("", null).shouldFailWith {
             it is BadRequestDataException &&
                 it.detail == "Value cannot be empty"
@@ -26,7 +26,7 @@ class AttributeProjectionTests {
     }
 
     @Test
-    fun `it should reject invalid attribute names`() {
+    fun `parsePickOmitParameters should reject invalid attribute names`() {
         parsePickOmitParameters("invalid%,temperature", null).shouldFailWith {
             it is BadRequestDataException &&
                 it.detail == "Invalid characters in the value (%)"
@@ -34,7 +34,7 @@ class AttributeProjectionTests {
     }
 
     @Test
-    fun `it should reject invalid attribute projection expression`() {
+    fun `parsePickOmitParameters should reject invalid attribute projection expression`() {
         parsePickOmitParameters("servesDataset{title", null).shouldFailWith {
             it is BadRequestDataException &&
                 it.detail == "Expression contains an unclosed brace"
@@ -42,7 +42,7 @@ class AttributeProjectionTests {
     }
 
     @Test
-    fun `it should reject invalid attribute projection expression missing a sub-parameter`() {
+    fun `parsePickOmitParameters should reject invalid attribute projection expression missing a sub-parameter`() {
         parsePickOmitParameters("servesDataset{}", null).shouldFailWith {
             it is BadRequestDataException &&
                 it.detail == "Expression contains an empty nested projection"
@@ -50,7 +50,7 @@ class AttributeProjectionTests {
     }
 
     @Test
-    fun `it should parse pick or omit parameters only including first level attributes`() {
+    fun `parsePickOmitParameters should parse pick or omit parameters only including first level attributes`() {
         val (pick, omit) = parsePickOmitParameters("temperature,humidity", "title,description")
             .shouldSucceedAndResult()
 
@@ -69,7 +69,7 @@ class AttributeProjectionTests {
     }
 
     @Test
-    fun `it should parse a pick parameter including attributes of a first level relationship`() {
+    fun `parsePickOmitParameters should parse a pick parameter including attributes of a first level relationship`() {
         val (pick, omit) = parsePickOmitParameters("temperature,servesDataset{title,description}", null)
             .shouldSucceedAndResult()
 
@@ -89,7 +89,7 @@ class AttributeProjectionTests {
     }
 
     @Test
-    fun `it should parse a pick parameter including attributes of a second level relationship`() {
+    fun `parsePickOmitParameters should parse a pick parameter including attributes of a second level relationship`() {
         val (pick, _) = parsePickOmitParameters(
             "temperature,servesDataset{title,description,catalog{publisher}}",
             null
@@ -116,7 +116,7 @@ class AttributeProjectionTests {
     }
 
     @Test
-    fun `it should ignore whitespaces in pick or omit parameters`() {
+    fun `parsePickOmitParameters should ignore whitespaces in pick or omit parameters`() {
         val (pick, _) = parsePickOmitParameters("temperature, humidity, servesDataset{ title, description}", null)
             .shouldSucceedAndResult()
 
@@ -136,7 +136,7 @@ class AttributeProjectionTests {
     }
 
     @Test
-    fun `it should get attributes at the root level`() {
+    fun `getRootAttributesToPick should get attributes at the root level`() {
         val (pick, _) = parsePickOmitParameters("temperature,humidity,servesDataset{title}", null)
             .shouldSucceedAndResult()
 
@@ -148,7 +148,7 @@ class AttributeProjectionTests {
     }
 
     @Test
-    fun `it should get attributes at any level in the graph`() {
+    fun `getAttributesToPickFor should get attributes at any level in the graph`() {
         val (pick, _) = parsePickOmitParameters(
             "servesDataset{title,description,catalog{publisher}},belongsTo{name,owner,servesDatatset{location}}",
             null
@@ -171,7 +171,7 @@ class AttributeProjectionTests {
     }
 
     @Test
-    fun `it should get root attributes to omit`() {
+    fun `getRootAttributesToOmit should get root attributes to omit`() {
         val (_, omit) = parsePickOmitParameters(
             null,
             "temperature,humidity,servesDataset{title}"
@@ -185,7 +185,7 @@ class AttributeProjectionTests {
     }
 
     @Test
-    fun `it should get attributes to omit at any level in the graph`() {
+    fun `getAttributesToOmitFor should get attributes to omit at any level in the graph`() {
         val (_, omit) = parsePickOmitParameters(
             null,
             "servesDataset{title,description,catalog{publisher}},belongsTo{name,owner,servesDatatset{location}}"
@@ -208,7 +208,7 @@ class AttributeProjectionTests {
     }
 
     @Test
-    fun `it should handle pipe separator in addition to comma`() {
+    fun `parsePickOmitParameters should handle pipe separator in addition to comma`() {
         val (pick, _) = parsePickOmitParameters("temperature|humidity|servesDataset{title|description}", null)
             .shouldSucceedAndResult()
 
@@ -228,7 +228,7 @@ class AttributeProjectionTests {
     }
 
     @Test
-    fun `it should handle mixed separators`() {
+    fun `parsePickOmitParameters should handle mixed separators`() {
         val (pick, _) = parsePickOmitParameters("temperature,humidity|servesDataset{title,description}", null)
             .shouldSucceedAndResult()
 
@@ -248,7 +248,7 @@ class AttributeProjectionTests {
     }
 
     @Test
-    fun `it should reject multiple consecutive separators`() {
+    fun `parsePickOmitParameters should reject multiple consecutive separators`() {
         parsePickOmitParameters("temperature,,humidity", null).shouldFailWith {
             it is BadRequestDataException &&
                 it.detail == "Expression cannot contain consecutive separators"
@@ -256,7 +256,7 @@ class AttributeProjectionTests {
     }
 
     @Test
-    fun `it should reject leading separators`() {
+    fun `parsePickOmitParameters should reject leading separators`() {
         parsePickOmitParameters(",temperature,humidity", null).shouldFailWith {
             it is BadRequestDataException &&
                 it.detail == "Expression cannot start with a brace, comma or pipe"
@@ -264,7 +264,7 @@ class AttributeProjectionTests {
     }
 
     @Test
-    fun `it should reject trailing separators`() {
+    fun `parsePickOmitParameters should reject trailing separators`() {
         parsePickOmitParameters("temperature,humidity,", null).shouldFailWith {
             it is BadRequestDataException &&
                 it.detail == "Expression cannot end with a separator"
@@ -272,7 +272,7 @@ class AttributeProjectionTests {
     }
 
     @Test
-    fun `it should reject unclosed nested braces`() {
+    fun `parsePickOmitParameters should reject unclosed nested braces`() {
         parsePickOmitParameters("observation{temperature,observedAt{location}", null).shouldFailWith {
             it is BadRequestDataException &&
                 it.detail == "Expression contains an unclosed brace"
@@ -280,7 +280,7 @@ class AttributeProjectionTests {
     }
 
     @Test
-    fun `it should reject a separator immediately following an opening brace`() {
+    fun `parsePickOmitParameters should reject a separator immediately following an opening brace`() {
         parsePickOmitParameters("observation{,temperature}", null).shouldFailWith {
             it is BadRequestDataException &&
                 it.detail == "Expression cannot contain a separator after an opening brace"
@@ -288,7 +288,7 @@ class AttributeProjectionTests {
     }
 
     @Test
-    fun `it should reject empty attribute names in nested projections`() {
+    fun `parsePickOmitParameters should reject empty attribute names in nested projections`() {
         parsePickOmitParameters("observation{temperature,,humidity}", null).shouldFailWith {
             it is BadRequestDataException &&
                 it.detail == "Expression cannot contain consecutive separators"
@@ -296,7 +296,7 @@ class AttributeProjectionTests {
     }
 
     @Test
-    fun `it should handle deeply nested projections`() {
+    fun `parsePickOmitParameters should handle deeply nested projections`() {
         val (pick, _) = parsePickOmitParameters(
             "observation{temperature,observedAt{location,accuracy}},humidity",
             null
@@ -323,7 +323,7 @@ class AttributeProjectionTests {
     }
 
     @Test
-    fun `it should handle complex real-world examples`() {
+    fun `parsePickOmitParameters should handle complex real-world examples`() {
         val (pick, _) = parsePickOmitParameters(
             """
                 temperature,humidity,pressure,

--- a/shared/src/test/kotlin/com/egm/stellio/shared/model/CompactedEntityLinkedTests.kt
+++ b/shared/src/test/kotlin/com/egm/stellio/shared/model/CompactedEntityLinkedTests.kt
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test
 class CompactedEntityLinkedTests {
 
     @Test
-    fun `it shoud extract a single-instance relationship`() {
+    fun `getRelationshipsNamesWithObjects should extract a single-instance relationship`() {
         val relationships = normalizedEntity.getRelationshipsNamesWithObjects()
 
         assertThat(relationships)
@@ -23,7 +23,7 @@ class CompactedEntityLinkedTests {
     }
 
     @Test
-    fun `it shoud extract a multi-instance relationship`() {
+    fun `getRelationshipsNamesWithObjects should extract a multi-instance relationship`() {
         val relationships = normalizedMultiAttributeEntity.getRelationshipsNamesWithObjects()
 
         assertThat(relationships)
@@ -32,7 +32,7 @@ class CompactedEntityLinkedTests {
     }
 
     @Test
-    fun `it should extract a multivalued relationship`() {
+    fun `getRelationshipsNamesWithObjects should extract a multivalued relationship`() {
         val compactedEntity = """
             {
                 "id": "urn:ngsi-ld:Entity:01",
@@ -58,7 +58,7 @@ class CompactedEntityLinkedTests {
     }
 
     @Test
-    fun `it should extract a multi-instance relationship with multivalued instances`() {
+    fun `getRelationshipsNamesWithObjects should extract a multi-instance relationship with multivalued instances`() {
         val compactedEntity = """
             {
                 "id": "urn:ngsi-ld:Entity:01",
@@ -106,7 +106,7 @@ class CompactedEntityLinkedTests {
     }
 
     @Test
-    fun `it shoud extract single and multi-instances of relationships`() {
+    fun `getRelationshipsNamesWithObjects should extract single and multi-instances of relationships`() {
         val compactedEntity = """
             {
                 "id": "urn:ngsi-ld:Entity:01",
@@ -145,7 +145,7 @@ class CompactedEntityLinkedTests {
     }
 
     @Test
-    fun `it shoud extract all relationships without merging duplicate objects`() {
+    fun `getRelationshipsNamesWithObjects should extract all relationships without merging duplicate objects`() {
         val compactedEntity = """
             {
                 "id": "urn:ngsi-ld:Entity:01",
@@ -174,7 +174,7 @@ class CompactedEntityLinkedTests {
     }
 
     @Test
-    fun `it shoud extract relationships from multiple entities`() {
+    fun `getRelationshipsNamesWithObjects should extract relationships from multiple entities`() {
         val compactedEntities = """
             [{
                 "id": "urn:ngsi-ld:Entity:01",
@@ -215,7 +215,7 @@ class CompactedEntityLinkedTests {
     }
 
     @Test
-    fun `it should inline an entity with two single instance relationhips`() = runTest {
+    fun `inlineLinkedEntities should inline an entity with two single instance relationhips`() = runTest {
         val linkingEntity = """
             {
                 "id": "urn:ngsi-ld:LinkingEntity:01",
@@ -278,7 +278,7 @@ class CompactedEntityLinkedTests {
     }
 
     @Test
-    fun `it should inline an entity with a multi-instance relationhip`() = runTest {
+    fun `inlineLinkedEntities should inline an entity with a multi-instance relationhip`() = runTest {
         val linkingEntity = """
             {
                 "id": "urn:ngsi-ld:LinkingEntity:01",
@@ -339,7 +339,7 @@ class CompactedEntityLinkedTests {
     }
 
     @Test
-    fun `it should inline an entity with a multivalued relationship`() = runTest {
+    fun `inlineLinkedEntities should inline an entity with a multivalued relationship`() = runTest {
         val linkingEntity = """
             {
                 "id": "urn:ngsi-ld:LinkingEntity:01",
@@ -402,7 +402,7 @@ class CompactedEntityLinkedTests {
     }
 
     @Test
-    fun `it should inline an entity with a multi-instance multivalued relationship`() = runTest {
+    fun `inlineLinkedEntities should inline an entity with a multi-instance multivalued relationship`() = runTest {
         val linkingEntity = """
             {
                 "id": "urn:ngsi-ld:LinkingEntity:01",
@@ -492,7 +492,7 @@ class CompactedEntityLinkedTests {
     }
 
     @Test
-    fun `it should inline two entities with their respective relationhips`() = runTest {
+    fun `inlineLinkedEntities should inline two entities with their respective relationhips`() = runTest {
         val linkingEntities = """
             [{
                 "id": "urn:ngsi-ld:LinkingEntity:01",
@@ -582,7 +582,7 @@ class CompactedEntityLinkedTests {
     }
 
     @Test
-    fun `it should remove sysAttrs from inlined entities`() = runTest {
+    fun `withoutSysAttrs should remove sysAttrs from inlined entities`() = runTest {
         val inlineLinkingEntity = """
             {
                 "id": "urn:ngsi-ld:LinkingEntity:01",
@@ -632,7 +632,7 @@ class CompactedEntityLinkedTests {
     }
 
     @Test
-    fun `it should filter language properties for inlined entities`() = runTest {
+    fun `toFilteredLanguageProperties should filter language properties for inlined entities`() = runTest {
         val inlineLinkingEntity = """
             {
                 "id": "urn:ngsi-ld:LinkingEntity:01",
@@ -694,7 +694,7 @@ class CompactedEntityLinkedTests {
     }
 
     @Test
-    fun `it should simplify relationships for inlined entities`() = runTest {
+    fun `toSimplifiedAttributes should simplify relationships for inlined entities`() = runTest {
         val inlineLinkingEntity = """
             {
                 "id": "urn:ngsi-ld:LinkingEntity:01",

--- a/shared/src/test/kotlin/com/egm/stellio/shared/model/CompactedEntityTests.kt
+++ b/shared/src/test/kotlin/com/egm/stellio/shared/model/CompactedEntityTests.kt
@@ -61,7 +61,7 @@ class CompactedEntityTests {
         """.trimIndent()
 
     @Test
-    fun `it should filter the entity members based on pick parameter`() = runTest {
+    fun `filterPickAndOmit should filter the entity members based on pick parameter`() = runTest {
         val entity = loadSampleData("beehive_with_single_attribute_instances.jsonld").deserializeAsMap()
 
         val expectedEntity = """
@@ -87,7 +87,7 @@ class CompactedEntityTests {
     }
 
     @Test
-    fun `it should filter the entity members based on omit parameter`() = runTest {
+    fun `filterPickAndOmit should filter the entity members based on omit parameter`() = runTest {
         val entity = loadSampleData("beehive_with_single_attribute_instances.jsonld").deserializeAsMap()
 
         val expectedEntity = """
@@ -110,7 +110,7 @@ class CompactedEntityTests {
     }
 
     @Test
-    fun `it should return an ResourceNotFound error when no entity member matches the pick parameter`() = runTest {
+    fun `filterPickAndOmit should return a ResourceNotFound error when no member matches pick`() = runTest {
         val entity = loadSampleData("beehive_with_single_attribute_instances.jsonld").deserializeAsMap()
 
         val pickAndOmitParams = parsePickOmitParameters("unknown", null)
@@ -126,7 +126,7 @@ class CompactedEntityTests {
     }
 
     @Test
-    fun `it should simplify a compacted entity`() {
+    fun `toSimplifiedAttributes should simplify a compacted entity`() {
         val simplifiedMap = simplifiedEntity.deserializeAsMap()
 
         val resultMap = normalizedEntity.toSimplifiedAttributes()
@@ -135,7 +135,7 @@ class CompactedEntityTests {
     }
 
     @Test
-    fun `it should simplify a compacted entity with multi-attributes`() {
+    fun `toSimplifiedAttributes should simplify a compacted entity with multi-attributes`() {
         val simplifiedMap = simplifiedMultiAttributeEntity.deserializeAsMap()
 
         val resultMap = normalizedMultiAttributeEntity.toSimplifiedAttributes()
@@ -144,7 +144,7 @@ class CompactedEntityTests {
     }
 
     @Test
-    fun `it should return the simplified representation of a JsonProperty having an object as value`() {
+    fun `toSimplifiedAttributes should simplify a JsonProperty having an object as value`() {
         val compactedEntity = """
             {
                 "id": "urn:ngsi-ld:Entity:01",
@@ -179,7 +179,7 @@ class CompactedEntityTests {
     }
 
     @Test
-    fun `it should return the simplified representation of a JsonProperty having an array as value`() {
+    fun `toSimplifiedAttributes should simplify a JsonProperty having an array as value`() {
         val compactedEntity = """
             {
                 "id": "urn:ngsi-ld:Entity:01",
@@ -212,7 +212,7 @@ class CompactedEntityTests {
     }
 
     @Test
-    fun `it should return a simplified entity with sysAttrs`() {
+    fun `toFinalRepresentation should return a simplified entity with sysAttrs`() {
         val inputEntity =
             """
             {
@@ -249,7 +249,7 @@ class CompactedEntityTests {
     }
 
     @Test
-    fun `it should return a simplified entity without sysAttrs`() {
+    fun `toFinalRepresentation should return a simplified entity without sysAttrs`() {
         val inputEntity =
             """
             {
@@ -284,7 +284,7 @@ class CompactedEntityTests {
     }
 
     @Test
-    fun `it should return a simplified entity with a multi-attribute Property`() {
+    fun `toFinalRepresentation should return a simplified entity with a multi-attribute Property`() {
         val inputEntity =
             """
             {
@@ -327,7 +327,7 @@ class CompactedEntityTests {
     }
 
     @Test
-    fun `it should return a simplified entity with a multi-attribute Relationship`() {
+    fun `toFinalRepresentation should return a simplified entity with a multi-attribute Relationship`() {
         val inputEntity =
             """
             {
@@ -371,7 +371,7 @@ class CompactedEntityTests {
     }
 
     @Test
-    fun `it should return a simplified entity with a multivalued Relationship`() {
+    fun `toFinalRepresentation should return a simplified entity with a multivalued Relationship`() {
         val inputEntity =
             """
             {
@@ -408,7 +408,7 @@ class CompactedEntityTests {
     }
 
     @Test
-    fun `it should return a simplified entity with a multi-attribute JsonProperty`() {
+    fun `toFinalRepresentation should return a simplified entity with a multi-attribute JsonProperty`() {
         val inputEntity =
             """
             {
@@ -463,7 +463,7 @@ class CompactedEntityTests {
     }
 
     @Test
-    fun `it should return a simplified entity with a multi-attribute GeoProperty`() {
+    fun `toFinalRepresentation should return a simplified entity with a multi-attribute GeoProperty`() {
         val inputEntity =
             """
             {
@@ -519,7 +519,7 @@ class CompactedEntityTests {
     }
 
     @Test
-    fun `it should return a simplified entity with a multi-Attribute having a default instance`() {
+    fun `toFinalRepresentation should return a simplified entity with a multi-Attribute having a default instance`() {
         val inputEntity =
             """
             {
@@ -581,7 +581,7 @@ class CompactedEntityTests {
     }
 
     @Test
-    fun `it should return the GeoJSON representation of a normalized entity on location attribute`() {
+    fun `toFinalRepresentation should return the GeoJSON of a normalized entity on its location`() {
         val expectedEntity =
             """
             {
@@ -639,7 +639,7 @@ class CompactedEntityTests {
     }
 
     @Test
-    fun `it should return the GeoJSON representation of a simplified entity on location attribute`() {
+    fun `toFinalRepresentation should return the GeoJSON of a simplified entity on its location`() {
         val expectedEntity =
             """
             {
@@ -680,7 +680,7 @@ class CompactedEntityTests {
     }
 
     @Test
-    fun `it should return the GeoJSON representation of an entity with a null geometry if it does not exist`() {
+    fun `toFinalRepresentation should return a GeoJSON entity with a null geometry when it does not exist`() {
         val inputEntity = """
             {
                 "id": "urn:ngsi-ld:Vehicle:A4567",
@@ -719,7 +719,7 @@ class CompactedEntityTests {
     }
 
     @Test
-    fun `it should return the GeoJSON representation of simplified entities`() {
+    fun `toFinalRepresentation should return the GeoJSON representation of simplified entities`() {
         val inputEntity = """
             {
                 "id": "urn:ngsi-ld:Vehicle:A4567",
@@ -776,7 +776,7 @@ class CompactedEntityTests {
     }
 
     @Test
-    fun `it should return the simplified representation of a LanguageProperty`() {
+    fun `toSimplifiedAttributes should return the simplified representation of a LanguageProperty`() {
         val compactedEntity = """
             {
                 "id": "urn:ngsi-ld:Entity:01",
@@ -810,7 +810,7 @@ class CompactedEntityTests {
     }
 
     @Test
-    fun `it should return the simplified representation of a VocabProperty - string value`() {
+    fun `toSimplifiedAttributes should return the simplified representation of a VocabProperty - string value`() {
         val compactedEntity = """
             {
                 "id": "urn:ngsi-ld:Entity:01",
@@ -838,7 +838,7 @@ class CompactedEntityTests {
     }
 
     @Test
-    fun `it should return the simplified representation of a VocabProperty - array of strings value`() {
+    fun `toSimplifiedAttributes should simplify a VocabProperty with an array of strings value`() {
         val compactedEntity = """
             {
                 "id": "urn:ngsi-ld:Entity:01",
@@ -866,7 +866,7 @@ class CompactedEntityTests {
     }
 
     @Test
-    fun `it should find the value of a property`() = runTest {
+    fun `getTypeAndValue should find the value of a property`() = runTest {
         val compactedAttributeInstance = mapOf(
             "type" to "Property",
             "value" to 12
@@ -879,7 +879,7 @@ class CompactedEntityTests {
     }
 
     @Test
-    fun `it should find the value of a language property`() = runTest {
+    fun `getTypeAndValue should find the value of a language property`() = runTest {
         val compactedAttributeInstance = mapOf(
             "type" to "LanguageProperty",
             "languageMap" to mapOf("fr" to "Tour Eiffel", "en" to "Eiffel Tower")

--- a/shared/src/test/kotlin/com/egm/stellio/shared/model/EntityTypeSelectorTests.kt
+++ b/shared/src/test/kotlin/com/egm/stellio/shared/model/EntityTypeSelectorTests.kt
@@ -27,7 +27,7 @@ class EntityTypeSelectorTests {
         "'type2,type5', 'type1,(type2;(type3|(type4;type5)))', false",
         "'type4,type5', 'type1,(type2;(type3|(type4;type5)))', false",
     )
-    fun `it should correctly find if a list of types matches an Entity Type Selection`(
+    fun `areTypesInSelection should correctly find if a list of types matches an Entity Type Selection`(
         typeString: String,
         entityTypeSelection: EntityTypeSelection,
         result: String

--- a/shared/src/test/kotlin/com/egm/stellio/shared/model/ExpandedEntityTests.kt
+++ b/shared/src/test/kotlin/com/egm/stellio/shared/model/ExpandedEntityTests.kt
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.fail
 
 class ExpandedEntityTests {
     @Test
-    fun `it should find an expanded attribute contained in the entity`() {
+    fun `checkContainsAnyOf should find an expanded attribute contained in the entity`() {
         val expandedEntity = ExpandedEntity(
             mapOf(INCOMING_IRI to "", OUTGOING_IRI to "")
         )
@@ -36,7 +36,7 @@ class ExpandedEntityTests {
     }
 
     @Test
-    fun `it should not find an expanded attribute not contained in the entity`() {
+    fun `checkContainsAnyOf should not find an expanded attribute not contained in the entity`() {
         val expandedEntity = ExpandedEntity(
             mapOf(INCOMING_IRI to "", OUTGOING_IRI to "", JSONLD_ID_KW to "urn:ngsi-ld:Entity:01".toUri())
         )
@@ -55,7 +55,7 @@ class ExpandedEntityTests {
     }
 
     @Test
-    fun `it should get the attributes from a JSON-LD entity`() = runTest {
+    fun `getAttributes should get the attributes from a JSON-LD entity`() = runTest {
         val entity = """
         {
             "id": "urn:ngsi-ld:Entity:01",
@@ -75,7 +75,7 @@ class ExpandedEntityTests {
     }
 
     @Test
-    fun `it should get an attribute by name without datasetId`() = runTest {
+    fun `getAttribute should get an attribute by name without datasetId`() = runTest {
         val entity = """
         {
             "id": "urn:ngsi-ld:Entity:01",
@@ -94,7 +94,7 @@ class ExpandedEntityTests {
     }
 
     @Test
-    fun `it should get an attribute by name with datasetId`() = runTest {
+    fun `getAttribute should get an attribute by name with datasetId`() = runTest {
         val entity = """
         {
             "id": "urn:ngsi-ld:Entity:01",
@@ -115,7 +115,7 @@ class ExpandedEntityTests {
     }
 
     @Test
-    fun `it should not get an attribute if name does not match`() = runTest {
+    fun `getAttribute should not get an attribute when name does not match`() = runTest {
         val entity = """
         {
             "id": "urn:ngsi-ld:Entity:01",
@@ -136,7 +136,7 @@ class ExpandedEntityTests {
     }
 
     @Test
-    fun `it should not get an attribute if datasetId does not match`() = runTest {
+    fun `getAttribute should not get an attribute when datasetId does not match`() = runTest {
         val entity = """
         {
             "id": "urn:ngsi-ld:Entity:01",
@@ -157,7 +157,7 @@ class ExpandedEntityTests {
     }
 
     @Test
-    fun `it should not get an attribute without datasetId if datasetId is provided`() = runTest {
+    fun `getAttribute should not get an attribute without datasetId when datasetId is provided`() = runTest {
         val entity = """
         {
             "id": "urn:ngsi-ld:Entity:01",
@@ -177,7 +177,7 @@ class ExpandedEntityTests {
     }
 
     @Test
-    fun `it should filter the attributes based on the attrs only`() = runTest {
+    fun `filterAttributes should filter the attributes based on the attrs only`() = runTest {
         val entity = loadAndExpandSampleData("beehive_with_multi_attribute_instances.jsonld")
 
         val expectedEntity = """
@@ -214,7 +214,7 @@ class ExpandedEntityTests {
     }
 
     @Test
-    fun `it should filter the attributes based on attrs and apply the datasetId view`() = runTest {
+    fun `applyDatasetView should filter the attributes based on attrs and apply the datasetId view`() = runTest {
         val entity = loadAndExpandSampleData("beehive_with_multi_attribute_instances.jsonld")
 
         val expectedEntity = """
@@ -240,7 +240,7 @@ class ExpandedEntityTests {
     }
 
     @Test
-    fun `it should apply the datasetIds view`() = runTest {
+    fun `applyDatasetView should apply the datasetIds view`() = runTest {
         val entity = loadAndExpandSampleData("beehive_with_multi_attribute_instances.jsonld")
 
         val expectedEntity = """
@@ -268,7 +268,7 @@ class ExpandedEntityTests {
     }
 
     @Test
-    fun `it should apply the datasetId view on the default instance if @none is asked`() = runTest {
+    fun `applyDatasetView should apply the view on the default instance when @none is asked`() = runTest {
         val entity = loadAndExpandSampleData("beehive_with_multi_attribute_instances.jsonld")
 
         val expectedEntity = """
@@ -293,7 +293,7 @@ class ExpandedEntityTests {
     }
 
     @Test
-    fun `it should filter attributes on attrs and apply the datasetId view on @none`() = runTest {
+    fun `applyDatasetView should filter on attrs and apply the view on @none`() = runTest {
         val entity = loadAndExpandSampleData("beehive_with_multi_attribute_instances.jsonld")
 
         val expectedEntity = """
@@ -317,7 +317,7 @@ class ExpandedEntityTests {
     }
 
     @Test
-    fun `it should apply the datasetId view on multiple datasetIds`() = runTest {
+    fun `applyDatasetView should apply the view on multiple datasetIds`() = runTest {
         val entity = loadAndExpandSampleData("beehive_with_multi_attribute_instances.jsonld")
 
         val expectedEntity = """
@@ -355,7 +355,7 @@ class ExpandedEntityTests {
     }
 
     @Test
-    fun `it should return no attributes if datasetIds and attrs don't match`() = runTest {
+    fun `applyDatasetView should return no attributes when datasetIds and attrs don't match`() = runTest {
         val entity = loadAndExpandSampleData("beehive_with_multi_attribute_instances.jsonld")
 
         val expectedEntity = """
@@ -376,7 +376,7 @@ class ExpandedEntityTests {
     }
 
     @Test
-    fun `it should get the scopes from a JSON-LD entity`() = runTest {
+    fun `getScopes should get the scopes from a JSON-LD entity`() = runTest {
         val entity = """
         {
             "id": "urn:ngsi-ld:Entity:01",
@@ -393,7 +393,7 @@ class ExpandedEntityTests {
     }
 
     @Test
-    fun `it should populate the createdAt information at root and attribute levels`() = runTest {
+    fun `populateCreationTimeDate should populate the createdAt information at root and attribute levels`() = runTest {
         val entity = """
         {
             "id": "urn:ngsi-ld:Entity:01",

--- a/shared/src/test/kotlin/com/egm/stellio/shared/model/ExpandedEntityTests.kt
+++ b/shared/src/test/kotlin/com/egm/stellio/shared/model/ExpandedEntityTests.kt
@@ -55,7 +55,7 @@ class ExpandedEntityTests {
     }
 
     @Test
-    fun `getAttributes should get the attributes from a JSON-LD entity`() = runTest {
+    fun `getAttributes should return all attributes of a JSON-LD entity`() = runTest {
         val entity = """
         {
             "id": "urn:ngsi-ld:Entity:01",
@@ -75,7 +75,7 @@ class ExpandedEntityTests {
     }
 
     @Test
-    fun `getAttribute should get an attribute by name without datasetId`() = runTest {
+    fun `getAttribute should return the matching attribute when no datasetId is specified`() = runTest {
         val entity = """
         {
             "id": "urn:ngsi-ld:Entity:01",
@@ -94,7 +94,7 @@ class ExpandedEntityTests {
     }
 
     @Test
-    fun `getAttribute should get an attribute by name with datasetId`() = runTest {
+    fun `getAttribute should return the attribute matching both name and datasetId`() = runTest {
         val entity = """
         {
             "id": "urn:ngsi-ld:Entity:01",
@@ -376,7 +376,7 @@ class ExpandedEntityTests {
     }
 
     @Test
-    fun `getScopes should get the scopes from a JSON-LD entity`() = runTest {
+    fun `getScopes should return the scopes from a JSON-LD entity`() = runTest {
         val entity = """
         {
             "id": "urn:ngsi-ld:Entity:01",

--- a/shared/src/test/kotlin/com/egm/stellio/shared/model/ExpandedMembersTests.kt
+++ b/shared/src/test/kotlin/com/egm/stellio/shared/model/ExpandedMembersTests.kt
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test
 class ExpandedMembersTests {
 
     @Test
-    fun `it should add createdAt information into an attribute`() {
+    fun `addSysAttrs should add createdAt information into an attribute`() {
         val attrPayload = mapOf("attribute" to buildExpandedPropertyValue(12.0))
 
         val attrPayloadWithSysAttrs = attrPayload.addSysAttrs(true, ngsiLdDateTime(), null)
@@ -31,7 +31,7 @@ class ExpandedMembersTests {
     }
 
     @Test
-    fun `it should add createdAt and modifiedAt information into an attribute`() {
+    fun `addSysAttrs should add createdAt and modifiedAt information into an attribute`() {
         val attrPayload = mapOf("attribute" to buildExpandedPropertyValue(12.0))
 
         val attrPayloadWithSysAttrs = attrPayload.addSysAttrs(true, ngsiLdDateTime(), ngsiLdDateTime())
@@ -43,7 +43,7 @@ class ExpandedMembersTests {
     }
 
     @Test
-    fun `it should add createdAt, modifiedAt and deletedAt information into an attribute`() {
+    fun `addSysAttrs should add createdAt, modifiedAt and deletedAt information into an attribute`() {
         val attrPayload = mapOf("attribute" to buildExpandedPropertyValue(12.0))
 
         val attrPayloadWithSysAttrs =
@@ -56,7 +56,7 @@ class ExpandedMembersTests {
     }
 
     @Test
-    fun `it should not find an unknown attribute instance in a list of attributes`() = runTest {
+    fun `getAttributeFromExpandedAttributes should not find an unknown attribute instance`() = runTest {
         val entityFragment =
             """
             {
@@ -71,7 +71,7 @@ class ExpandedMembersTests {
     }
 
     @Test
-    fun `it should find an attribute instance from a list of attributes without multi-attributes`() = runTest {
+    fun `getAttributeFromExpandedAttributes should find an instance without multi-attributes`() = runTest {
         val entityFragment =
             """
             {
@@ -95,7 +95,7 @@ class ExpandedMembersTests {
     }
 
     @Test
-    fun `it should find an attribute instance from a list of attributes with multi-attributes`() = runTest {
+    fun `getAttributeFromExpandedAttributes should find an instance with multi-attributes`() = runTest {
         val entityFragment =
             """
             {
@@ -133,7 +133,7 @@ class ExpandedMembersTests {
     }
 
     @Test
-    fun `it should return an error if a relationship has no object field`() {
+    fun `getRelationshipObjects should return an error if a relationship has no object field`() {
         val relationshipValues = buildExpandedPropertyValue("something")[0]
 
         val result = relationshipValues.getRelationshipObjects("isARelationship")
@@ -144,7 +144,7 @@ class ExpandedMembersTests {
     }
 
     @Test
-    fun `it should return an error if a relationship has an empty object`() {
+    fun `getRelationshipObjects should return an error if a relationship has an empty object`() {
         val relationshipValues = mapOf(
             NGSILD_RELATIONSHIP_OBJECT to emptyList<Any>()
         )
@@ -157,7 +157,7 @@ class ExpandedMembersTests {
     }
 
     @Test
-    fun `it should return an error if a relationship has an invalid object type`() {
+    fun `getRelationshipObjects should return an error if a relationship has an invalid object type`() {
         val relationshipValues = mapOf(
             NGSILD_RELATIONSHIP_OBJECT to listOf("invalid")
         )
@@ -173,7 +173,7 @@ class ExpandedMembersTests {
     }
 
     @Test
-    fun `it should return an error if a relationship has object without id`() {
+    fun `getRelationshipObjects should return an error if a relationship has object without id`() {
         val relationshipValues = mapOf(
             NGSILD_RELATIONSHIP_OBJECT to listOf(
                 mapOf("@value" to "urn:ngsi-ld:T:misplacedRelationshipObject")
@@ -187,7 +187,7 @@ class ExpandedMembersTests {
     }
 
     @Test
-    fun `it should extract the target object of a relationship`() {
+    fun `getRelationshipObjects should extract the target object of a relationship`() {
         val relationshipObjectId = "urn:ngsi-ld:T:1"
         val relationshipValues = buildExpandedRelationshipValue(relationshipObjectId.toUri())
 
@@ -198,7 +198,7 @@ class ExpandedMembersTests {
     }
 
     @Test
-    fun `it should extract the target objects of a multivalued relationship`() {
+    fun `getRelationshipObjects should extract the target objects of a multivalued relationship`() {
         val relationshipValues = mapOf(
             NGSILD_RELATIONSHIP_OBJECT to listOf(
                 mapOf(JSONLD_ID_KW to "urn:ngsi-ld:T:1"),

--- a/shared/src/test/kotlin/com/egm/stellio/shared/model/KeyValuePairTests.kt
+++ b/shared/src/test/kotlin/com/egm/stellio/shared/model/KeyValuePairTests.kt
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test
 class KeyValuePairTests {
 
     @Test
-    fun `it should correctly deserialize a key value pair`() {
+    fun `deserialize should correctly deserialize a key value pair`() {
         val input = """[{"key": "Authorization-token", "value": "Authorization-token-value"}]"""
         val info = KeyValuePair.deserialize(input)
 
@@ -17,7 +17,7 @@ class KeyValuePairTests {
     }
 
     @Test
-    fun `it should correctly deserialize a null a key value pair`() {
+    fun `deserialize should correctly deserialize a null key value pair`() {
         val input = null
         val info = KeyValuePair.deserialize(input)
 

--- a/shared/src/test/kotlin/com/egm/stellio/shared/model/KeyValuePairTests.kt
+++ b/shared/src/test/kotlin/com/egm/stellio/shared/model/KeyValuePairTests.kt
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test
 class KeyValuePairTests {
 
     @Test
-    fun `deserialize should correctly deserialize a key value pair`() {
+    fun `deserialize should parse a key-value pair`() {
         val input = """[{"key": "Authorization-token", "value": "Authorization-token-value"}]"""
         val info = KeyValuePair.deserialize(input)
 
@@ -17,7 +17,7 @@ class KeyValuePairTests {
     }
 
     @Test
-    fun `deserialize should correctly deserialize a null key value pair`() {
+    fun `deserialize should parse a null key value pair`() {
         val input = null
         val info = KeyValuePair.deserialize(input)
 

--- a/shared/src/test/kotlin/com/egm/stellio/shared/model/LanguageFilterTests.kt
+++ b/shared/src/test/kotlin/com/egm/stellio/shared/model/LanguageFilterTests.kt
@@ -93,7 +93,7 @@ class LanguageFilterTests {
 
     @ParameterizedTest
     @MethodSource("com.egm.stellio.shared.model.LanguageFilterTests#normalizedResultsProvider")
-    fun `it should return the normalized representation of a LanguageProperty with a language filter`(
+    fun `toFilteredLanguageProperties should return the normalized representation for a language filter`(
         languageFilter: String,
         expectedAttribute: String
     ) {
@@ -128,7 +128,7 @@ class LanguageFilterTests {
 
     @ParameterizedTest
     @MethodSource("com.egm.stellio.shared.model.LanguageFilterTests#simplifiedResultsProvider")
-    fun `it should return the simplfied representation of a LanguageProperty with a language filter`(
+    fun `toFinalRepresentation should return the simplified representation for a language filter`(
         languageFilter: String,
         expectedAttribute: String
     ) {
@@ -168,7 +168,7 @@ class LanguageFilterTests {
     }
 
     @Test
-    fun `it should filter language properties for sub attributes`() = runTest {
+    fun `toFilteredLanguageProperties should filter language properties for sub attributes`() = runTest {
         val entity = """
             {
                 "id": "urn:ngsi-ld:Beehive:01",
@@ -210,7 +210,7 @@ class LanguageFilterTests {
     }
 
     @Test
-    fun `it should filter language properties for an attribute and its sub attributes`() = runTest {
+    fun `toFilteredLanguageProperties should filter an attribute and its sub attributes`() = runTest {
         val entity = """
             {
                 "id": "urn:ngsi-ld:Beehive:01",
@@ -256,7 +256,7 @@ class LanguageFilterTests {
     }
 
     @Test
-    fun `it should filter language properties having other core attribute members`() = runTest {
+    fun `toFilteredLanguageProperties should filter language properties with other core members`() = runTest {
         val entity = """
             {
                 "id": "urn:ngsi-ld:Beehive:01",

--- a/shared/src/test/kotlin/com/egm/stellio/shared/model/NgsiLdDataRepresentationTests.kt
+++ b/shared/src/test/kotlin/com/egm/stellio/shared/model/NgsiLdDataRepresentationTests.kt
@@ -15,7 +15,7 @@ import org.springframework.util.LinkedMultiValueMap
 class NgsiLdDataRepresentationTests {
 
     @Test
-    fun `it should return the attribute representation from the format when both format and options exist`() {
+    fun `parseRepresentations should use the format over the options when both exist`() {
         val queryParams = LinkedMultiValueMap<String, String>()
         queryParams.add("timerel", "after")
         queryParams.add("timeAt", "2025-01-03T07:45:24Z")
@@ -29,7 +29,7 @@ class NgsiLdDataRepresentationTests {
     }
 
     @Test
-    fun `it should return the attribute representation in the options query param when no format is given`() {
+    fun `parseRepresentations should use the options when no format is given`() {
         val queryParams = LinkedMultiValueMap<String, String>()
         queryParams.add("timerel", "after")
         queryParams.add("timeAt", "2025-01-03T07:45:24Z")
@@ -42,7 +42,7 @@ class NgsiLdDataRepresentationTests {
     }
 
     @Test
-    fun `it should correctly parse the options query param when it contains more than one value`() {
+    fun `parseRepresentations should parse the options query param with more than one value`() {
         val queryParams = LinkedMultiValueMap<String, String>()
         queryParams.add("timerel", "after")
         queryParams.add("timeAt", "2025-01-03T07:45:24Z")
@@ -56,7 +56,7 @@ class NgsiLdDataRepresentationTests {
     }
 
     @Test
-    fun `it should return the attribute representation in the first format query param`() {
+    fun `parseRepresentations should use the first format query param`() {
         val queryParams = LinkedMultiValueMap<String, String>()
         queryParams.add("timerel", "after")
         queryParams.add("timeAt", "2025-01-03T07:45:24Z")
@@ -70,7 +70,7 @@ class NgsiLdDataRepresentationTests {
     }
 
     @Test
-    fun `it should return an exception if format query param is invalid`() {
+    fun `parseRepresentations should return an exception when the format query param is invalid`() {
         val queryParams = LinkedMultiValueMap<String, String>()
         queryParams.add("timerel", "after")
         queryParams.add("timeAt", "2025-01-03T07:45:24Z")
@@ -83,7 +83,7 @@ class NgsiLdDataRepresentationTests {
     }
 
     @Test
-    fun `it should return an exception if options query param is invalid`() {
+    fun `parseRepresentations should return an exception when the options query param is invalid`() {
         val queryParams = LinkedMultiValueMap<String, String>()
         queryParams.add("timerel", "after")
         queryParams.add("timeAt", "2025-01-03T07:45:24Z")
@@ -96,7 +96,7 @@ class NgsiLdDataRepresentationTests {
     }
 
     @Test
-    fun `it should return an exception if at least one value in options query param is invalid`() {
+    fun `parseRepresentations should return an exception when one options value is invalid`() {
         val queryParams = LinkedMultiValueMap<String, String>()
         queryParams.add("timerel", "after")
         queryParams.add("timeAt", "2025-01-03T07:45:24Z")

--- a/shared/src/test/kotlin/com/egm/stellio/shared/model/NgsiLdEntityTests.kt
+++ b/shared/src/test/kotlin/com/egm/stellio/shared/model/NgsiLdEntityTests.kt
@@ -19,7 +19,7 @@ import java.time.ZonedDateTime
 class NgsiLdEntityTests {
 
     @Test
-    fun `it should parse a minimal entity`() = runTest {
+    fun `expandJsonLdEntity should parse a minimal entity`() = runTest {
         val rawEntity =
             """
             {
@@ -35,7 +35,7 @@ class NgsiLdEntityTests {
     }
 
     @Test
-    fun `it should not parse an entity without an id`() = runTest {
+    fun `toNgsiLdEntity should not parse an entity without an id`() = runTest {
         val rawEntity =
             """
             {
@@ -50,7 +50,7 @@ class NgsiLdEntityTests {
     }
 
     @Test
-    fun `it should not parse an entity without a type`() = runTest {
+    fun `toNgsiLdEntity should not parse an entity without a type`() = runTest {
         val rawEntity =
             """
             {
@@ -69,7 +69,7 @@ class NgsiLdEntityTests {
     }
 
     @Test
-    fun `it should not parse an entity without an unknown attribute type`() = runTest {
+    fun `toNgsiLdEntity should not parse an entity without an unknown attribute type`() = runTest {
         val rawEntity =
             """
             {
@@ -93,7 +93,7 @@ class NgsiLdEntityTests {
     }
 
     @Test
-    fun `it should not parse an entity with a datasetId having an NGSI-LD Null value`() = runTest {
+    fun `toNgsiLdEntity should not parse an entity with a datasetId having an NGSI-LD Null value`() = runTest {
         val rawEntity =
             """
             {
@@ -119,7 +119,7 @@ class NgsiLdEntityTests {
     }
 
     @Test
-    fun `it should parse an entity with a minimal property`() = runTest {
+    fun `toNgsiLdEntity should parse an entity with a minimal property`() = runTest {
         val rawEntity =
             """
             {
@@ -144,7 +144,7 @@ class NgsiLdEntityTests {
     }
 
     @Test
-    fun `it should parse an entity with a property having a JSON object value`() = runTest {
+    fun `toNgsiLdEntity should parse an entity with a property having a JSON object value`() = runTest {
         val rawEntity =
             """
             {
@@ -185,7 +185,7 @@ class NgsiLdEntityTests {
     }
 
     @Test
-    fun `it should parse an entity with a property having all core fields`() = runTest {
+    fun `toNgsiLdEntity should parse an entity with a property having all core fields`() = runTest {
         val rawEntity =
             """
             {
@@ -212,7 +212,7 @@ class NgsiLdEntityTests {
     }
 
     @Test
-    fun `it should not parse an entity with a property without a value`() = runTest {
+    fun `toNgsiLdEntity should not parse an entity with a property without a value`() = runTest {
         val rawEntity =
             """
             {
@@ -234,7 +234,7 @@ class NgsiLdEntityTests {
     }
 
     @Test
-    fun `it should parse an entity with a multi-attribute property`() = runTest {
+    fun `toNgsiLdEntity should parse an entity with a multi-attribute property`() = runTest {
         val rawEntity =
             """
             {
@@ -266,7 +266,7 @@ class NgsiLdEntityTests {
     }
 
     @Test
-    fun `it should not parse a property with different type instances`() = runTest {
+    fun `toNgsiLdAttributes should not parse a property with different type instances`() = runTest {
         val rawProperty =
             """
             {
@@ -292,7 +292,7 @@ class NgsiLdEntityTests {
     }
 
     @Test
-    fun `it should not parse a property with a duplicated datasetId`() = runTest {
+    fun `toNgsiLdAttributes should not parse a property with a duplicated datasetId`() = runTest {
         val rawProperty =
             """
             {
@@ -331,7 +331,7 @@ class NgsiLdEntityTests {
     }
 
     @Test
-    fun `it should not parse a property with more than one default instance`() = runTest {
+    fun `toNgsiLdAttributes should not parse a property with more than one default instance`() = runTest {
         val rawProperty =
             """
             {
@@ -363,7 +363,7 @@ class NgsiLdEntityTests {
     }
 
     @Test
-    fun `it should parse a property with a datasetId`() = runTest {
+    fun `toNgsiLdAttributes should parse a property with a datasetId`() = runTest {
         val rawProperty =
             """
             {
@@ -389,7 +389,7 @@ class NgsiLdEntityTests {
     }
 
     @Test
-    fun `it should parse an entity with a minimal relationship`() = runTest {
+    fun `toNgsiLdEntity should parse an entity with a minimal relationship`() = runTest {
         val rawEntity =
             """
             {
@@ -417,7 +417,7 @@ class NgsiLdEntityTests {
     }
 
     @Test
-    fun `it should parse an entity with a relationship having all core fields`() = runTest {
+    fun `toNgsiLdEntity should parse an entity with a relationship having all core fields`() = runTest {
         val rawEntity =
             """
             {
@@ -445,7 +445,7 @@ class NgsiLdEntityTests {
     }
 
     @Test
-    fun `it should parse an entity with a multi-attribute relationship`() = runTest {
+    fun `toNgsiLdEntity should parse an entity with a multi-attribute relationship`() = runTest {
         val rawEntity =
             """
             {
@@ -475,7 +475,7 @@ class NgsiLdEntityTests {
     }
 
     @Test
-    fun `it should parse an entity with a multivalued relationship`() = runTest {
+    fun `toNgsiLdEntity should parse an entity with a multivalued relationship`() = runTest {
         val rawEntity =
             """
             {
@@ -510,7 +510,7 @@ class NgsiLdEntityTests {
     }
 
     @Test
-    fun `it should not parse a relationship with more than one default instance`() = runTest {
+    fun `toNgsiLdAttributes should not parse a relationship with more than one default instance`() = runTest {
         val rawRelationship =
             """
             {
@@ -539,7 +539,7 @@ class NgsiLdEntityTests {
     }
 
     @Test
-    fun `it should not parse a relationship with a duplicated datasetId`() = runTest {
+    fun `toNgsiLdAttributes should not parse a relationship with a duplicated datasetId`() = runTest {
         val rawRelationship =
             """
             {
@@ -569,7 +569,7 @@ class NgsiLdEntityTests {
     }
 
     @Test
-    fun `it should not parse an attribute with different type instances`() = runTest {
+    fun `toNgsiLdAttributes should not parse an attribute with different type instances`() = runTest {
         val rawRelationship =
             """
             {
@@ -602,7 +602,7 @@ class NgsiLdEntityTests {
     }
 
     @Test
-    fun `it should parse an entity with a Polygon location`() = runTest {
+    fun `toNgsiLdEntity should parse an entity with a Polygon location`() = runTest {
         val rawEntity =
             """
             {
@@ -636,7 +636,7 @@ class NgsiLdEntityTests {
     }
 
     @Test
-    fun `it should parse an entity with a MultiPolygon location`() = runTest {
+    fun `toNgsiLdEntity should parse an entity with a MultiPolygon location`() = runTest {
         val rawEntity =
             """
             {
@@ -687,7 +687,7 @@ class NgsiLdEntityTests {
     }
 
     @Test
-    fun `it should parse an entity with a Point location`() = runTest {
+    fun `toNgsiLdEntity should parse an entity with a Point location`() = runTest {
         val rawEntity =
             """
             {
@@ -718,7 +718,7 @@ class NgsiLdEntityTests {
     }
 
     @Test
-    fun `it should parse an entity with a JsonProperty having a JSON object as a value`() = runTest {
+    fun `toNgsiLdEntity should parse an entity with a JsonProperty having a JSON object as a value`() = runTest {
         val rawEntity =
             """
             {
@@ -752,7 +752,7 @@ class NgsiLdEntityTests {
     }
 
     @Test
-    fun `it should parse an entity with a JsonProperty having an array of JSON objects as a value`() = runTest {
+    fun `toNgsiLdEntity should parse a JsonProperty having an array of JSON objects as value`() = runTest {
         val rawEntity =
             """
             {
@@ -786,7 +786,7 @@ class NgsiLdEntityTests {
     }
 
     @Test
-    fun `it should parse an entity with a multi-attribute JsonProperty`() = runTest {
+    fun `toNgsiLdEntity should parse an entity with a multi-attribute JsonProperty`() = runTest {
         val rawEntity =
             """
             {
@@ -818,7 +818,7 @@ class NgsiLdEntityTests {
     }
 
     @Test
-    fun `it should parse an entity with a JsonProperty having JSON-LD reserved names as keys`() = runTest {
+    fun `toNgsiLdEntity should parse an entity with a JsonProperty having JSON-LD reserved names as keys`() = runTest {
         val rawEntity =
             """
             {
@@ -848,7 +848,7 @@ class NgsiLdEntityTests {
     }
 
     @Test
-    fun `it should parse an entity with a JsonProperty having a null value in its JSON map`() = runTest {
+    fun `toNgsiLdEntity should parse an entity with a JsonProperty having a null value in its JSON map`() = runTest {
         val rawEntity =
             """
             {
@@ -878,7 +878,7 @@ class NgsiLdEntityTests {
     }
 
     @Test
-    fun `it should not parse an entity with a JsonProperty without a json member`() = runTest {
+    fun `toNgsiLdEntity should not parse an entity with a JsonProperty without a json member`() = runTest {
         val rawEntity =
             """
             {
@@ -904,7 +904,7 @@ class NgsiLdEntityTests {
     }
 
     @Test
-    fun `it should not parse an entity with a JsonProperty having a forbidden JSON type as value`() = runTest {
+    fun `toNgsiLdEntity should not parse a JsonProperty with a forbidden JSON type value`() = runTest {
         val rawEntity =
             """
             {
@@ -929,7 +929,7 @@ class NgsiLdEntityTests {
     }
 
     @Test
-    fun `it should parse an entity with a LanguageProperty`() = runTest {
+    fun `toNgsiLdEntity should parse an entity with a LanguageProperty`() = runTest {
         val rawEntity =
             """
             {
@@ -977,7 +977,7 @@ class NgsiLdEntityTests {
     }
 
     @Test
-    fun `it should not parse an entity with a LanguageProperty without a languageMap member`() = runTest {
+    fun `toNgsiLdEntity should not parse an entity with a LanguageProperty without a languageMap member`() = runTest {
         val rawEntity =
             """
             {
@@ -1004,7 +1004,7 @@ class NgsiLdEntityTests {
     }
 
     @Test
-    fun `it should not parse an entity with a LanguageProperty with an invalid languageMap member`() = runTest {
+    fun `toNgsiLdEntity should not parse a LanguageProperty with an invalid languageMap member`() = runTest {
         val rawEntity =
             """
             {
@@ -1031,7 +1031,7 @@ class NgsiLdEntityTests {
     }
 
     @Test
-    fun `it should not parse an entity with a LanguageProperty with an invalid language tag`() = runTest {
+    fun `toNgsiLdEntity should not parse an entity with a LanguageProperty with an invalid language tag`() = runTest {
         val rawEntity =
             """
             {
@@ -1057,7 +1057,7 @@ class NgsiLdEntityTests {
     }
 
     @Test
-    fun `it should not parse an entity with a LanguageProperty with an invalid value for a language`() = runTest {
+    fun `expandJsonLdEntity should fail on a LanguageProperty with an invalid value for a language`() = runTest {
         val rawEntity =
             """
             {
@@ -1080,7 +1080,7 @@ class NgsiLdEntityTests {
     }
 
     @Test
-    fun `it should parse an entity with a VocabProperty - array of strings value`() = runTest {
+    fun `toNgsiLdEntity should parse an entity with a VocabProperty - array of strings value`() = runTest {
         val rawEntity =
             """
             {
@@ -1111,7 +1111,7 @@ class NgsiLdEntityTests {
     }
 
     @Test
-    fun `it should parse an entity with a VocabProperty - string value`() = runTest {
+    fun `toNgsiLdEntity should parse an entity with a VocabProperty - string value`() = runTest {
         val rawEntity =
             """
             {
@@ -1141,7 +1141,7 @@ class NgsiLdEntityTests {
     }
 
     @Test
-    fun `it should not parse an entity with a VocabProperty without a vocab member`() = runTest {
+    fun `toNgsiLdEntity should not parse an entity with a VocabProperty without a vocab member`() = runTest {
         val rawEntity =
             """
             {
@@ -1166,7 +1166,7 @@ class NgsiLdEntityTests {
     }
 
     @Test
-    fun `it should not parse an entity with a VocabProperty with an invalid vocab member`() = runTest {
+    fun `toNgsiLdEntity should not parse an entity with a VocabProperty with an invalid vocab member`() = runTest {
         val rawEntity =
             """
             {

--- a/shared/src/test/kotlin/com/egm/stellio/shared/queryparameter/QNodeSqlTranslatorTests.kt
+++ b/shared/src/test/kotlin/com/egm/stellio/shared/queryparameter/QNodeSqlTranslatorTests.kt
@@ -57,7 +57,7 @@ class QNodeSqlTranslatorTests {
         """jsonb_path_exists(entity_payload.payload, '$path ? ($filter)', '$params')"""
 
     @Test
-    fun `it should generate EXISTS check against entity_payload for a simple attribute`() {
+    fun `toSqlJsonPath should generate EXISTS check against entity_payload for a simple attribute`() {
         assertEquals(
             exists("""$."$INCOMING_IRI""""),
             buildSql(INCOMING_TERM)
@@ -65,7 +65,7 @@ class QNodeSqlTranslatorTests {
     }
 
     @Test
-    fun `it should generate NOT EXISTS for negated attribute`() {
+    fun `toSqlJsonPath should generate NOT EXISTS for negated attribute`() {
         assertEquals(
             """NOT (${exists("""$."$INCOMING_IRI"""")})""",
             buildSql("!$INCOMING_TERM")
@@ -73,7 +73,7 @@ class QNodeSqlTranslatorTests {
     }
 
     @Test
-    fun `it should generate AND clause for semicolon operator`() {
+    fun `toSqlJsonPath should generate AND clause for semicolon operator`() {
         val incomingOpenSql = """
             (${existsWhere(incomingPropertyPath, """@ == $valuePh""", """{"value": "open"}""")} OR
                 ${existsWhere(incomingLangMapPath, """@ == $valuePh""", """{"value": "open"}""")})
@@ -86,7 +86,7 @@ class QNodeSqlTranslatorTests {
     }
 
     @Test
-    fun `it should generate OR clause for pipe operator`() {
+    fun `toSqlJsonPath should generate OR clause for pipe operator`() {
         val incomingOpenSql = """
             (${existsWhere(incomingPropertyPath, """@ == $valuePh""", """{"value": "open"}""")} OR
                 ${existsWhere(incomingLangMapPath, """@ == $valuePh""", """{"value": "open"}""")})
@@ -99,7 +99,7 @@ class QNodeSqlTranslatorTests {
     }
 
     @Test
-    fun `it should generate numeric comparison using hasValue`() {
+    fun `toSqlJsonPath should generate numeric comparison using hasValue`() {
         assertEquals(
             existsWhere(temperaturePropertyPath, """@ == $valuePh""", """{"value": 42}"""),
             buildSql("$TEMPERATURE_TERM==42")
@@ -107,7 +107,7 @@ class QNodeSqlTranslatorTests {
     }
 
     @Test
-    fun `it should generate string comparison targeting both hasValue and language map`() {
+    fun `toSqlJsonPath should generate string comparison targeting both hasValue and language map`() {
         val expected = """
             (${existsWhere(incomingPropertyPath, """@ == $valuePh""", """{"value": "open"}""")} OR
                 ${existsWhere(incomingLangMapPath, """@ == $valuePh""", """{"value": "open"}""")})
@@ -116,7 +116,7 @@ class QNodeSqlTranslatorTests {
     }
 
     @Test
-    fun `it should generate URI comparison targeting relationship, property, and vocab paths`() {
+    fun `toSqlJsonPath should generate URI comparison targeting relationship, property, and vocab paths`() {
         val uri = "urn:ngsi-ld:BeeHive:001"
         val params = """{"value": "$uri"}"""
         val expected = """
@@ -129,7 +129,7 @@ class QNodeSqlTranslatorTests {
     }
 
     @Test
-    fun `it should generate range comparison`() {
+    fun `toSqlJsonPath should generate range comparison`() {
         assertEquals(
             existsWhere(
                 temperaturePropertyPath,
@@ -141,7 +141,7 @@ class QNodeSqlTranslatorTests {
     }
 
     @Test
-    fun `it should generate boolean comparison`() {
+    fun `toSqlJsonPath should generate boolean comparison`() {
         val activePath =
             """$."https://uri.etsi.org/ngsi-ld/default-context/active"."$NGSILD_PROPERTY_VALUE"."$JSONLD_VALUE_KW""""
         assertEquals(
@@ -151,7 +151,7 @@ class QNodeSqlTranslatorTests {
     }
 
     @Test
-    fun `it should generate list comparison using inline filter`() {
+    fun `toSqlJsonPath should generate list comparison using inline filter`() {
         assertEquals(
             exists("""$temperaturePropertyPath ? (@ == 10 || @ == 20 || @ == 30)"""),
             buildSql("$TEMPERATURE_TERM==10,20,30")
@@ -159,7 +159,7 @@ class QNodeSqlTranslatorTests {
     }
 
     @Test
-    fun `it should generate NEQ range as outside-bounds filter`() {
+    fun `toSqlJsonPath should generate NEQ range as outside-bounds filter`() {
         assertEquals(
             existsWhere(
                 temperaturePropertyPath,
@@ -171,7 +171,7 @@ class QNodeSqlTranslatorTests {
     }
 
     @Test
-    fun `it should generate language tag comparison using hasLanguageMap path`() {
+    fun `toSqlJsonPath should generate language tag comparison using hasLanguageMap path`() {
         assertEquals(
             existsWhere(
                 incomingLangFilterPath,
@@ -183,7 +183,7 @@ class QNodeSqlTranslatorTests {
     }
 
     @Test
-    fun `it should not expand trailing path for jsonKeys attributes`() {
+    fun `toSqlJsonPath should not expand trailing path for jsonKeys attributes`() {
         assertEquals(
             existsWhere(incomingJsonKeyPath, """@ == $valuePh""", """{"value": 42}"""),
             buildSql("$INCOMING_TERM[$TEMPERATURE_TERM]==42", jsonKeys = setOf(INCOMING_TERM))
@@ -191,7 +191,7 @@ class QNodeSqlTranslatorTests {
     }
 
     @Test
-    fun `it should expand comparison value for expandValues attributes`() {
+    fun `toSqlJsonPath should expand comparison value for expandValues attributes`() {
         val params = """{"value": "$BEEHIVE_IRI"}"""
         val expected = """
             (${existsWhere(incomingRelPath, """@ == $valuePh""", params)} OR
@@ -206,14 +206,14 @@ class QNodeSqlTranslatorTests {
     }
 
     @Test
-    fun `it should generate like_regex comparison for LIKE_REGEX operator`() {
+    fun `toSqlJsonPath should generate like_regex comparison for LIKE_REGEX operator`() {
         val expected = """(${exists("""$incomingPropertyPath ? (@ like_regex "test.*")""")} OR """ +
             """${exists("""$incomingLangMapPath ? (@ like_regex "test.*")""")})"""
         assertEquals(expected.removeNoise(), buildSql("""$INCOMING_TERM~="test.*"""").removeNoise())
     }
 
     @Test
-    fun `it should generate NOT like_regex for NOT_LIKE_REGEX operator`() {
+    fun `toSqlJsonPath should generate NOT like_regex for NOT_LIKE_REGEX operator`() {
         val expected = """
             NOT ((${exists("""$incomingPropertyPath ? (@ like_regex "test.*")""")} OR
                 ${exists("""$incomingLangMapPath ? (@ like_regex "test.*")""")}))
@@ -222,7 +222,7 @@ class QNodeSqlTranslatorTests {
     }
 
     @Test
-    fun `it should generate NEQ range filter for jsonKeys attribute with bracket key`() {
+    fun `toSqlJsonPath should generate NEQ range filter for jsonKeys attribute with bracket key`() {
         assertEquals(
             existsWhere(incomingJsonKeyPath, """@ < $minPh || @ > $maxPh""", """{"min": 10, "max": 20}"""),
             buildSql("$INCOMING_TERM[$TEMPERATURE_TERM]!=10..20", jsonKeys = setOf(INCOMING_TERM))

--- a/shared/src/test/kotlin/com/egm/stellio/shared/queryparameter/QParserTests.kt
+++ b/shared/src/test/kotlin/com/egm/stellio/shared/queryparameter/QParserTests.kt
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test
 class QParserTests {
 
     @Test
-    fun `it should parse a simple attribute existence check`() {
+    fun `parseQQuery should parse a simple attribute existence check`() {
         parseQQuery("temperature").shouldSucceedWith { node ->
             assertInstanceOf(ExistsNode::class.java, node)
             assertEquals("temperature", (node as ExistsNode).rawPath)
@@ -18,7 +18,7 @@ class QParserTests {
     }
 
     @Test
-    fun `it should parse a negated existence check`() {
+    fun `parseQQuery should parse a negated existence check`() {
         parseQQuery("!temperature").shouldSucceedWith { node ->
             assertInstanceOf(NotExistsNode::class.java, node)
             assertEquals("temperature", (node as NotExistsNode).rawPath)
@@ -26,7 +26,7 @@ class QParserTests {
     }
 
     @Test
-    fun `it should parse a simple equality comparison`() {
+    fun `parseQQuery should parse a simple equality comparison`() {
         parseQQuery("temperature==42").shouldSucceedWith { node ->
             assertInstanceOf(ComparisonNode::class.java, node)
             node as ComparisonNode
@@ -40,7 +40,7 @@ class QParserTests {
     }
 
     @Test
-    fun `it should parse an AND expression`() {
+    fun `parseQQuery should parse an AND expression`() {
         parseQQuery("temperature==42;humidity>10").shouldSucceedWith { node ->
             assertInstanceOf(AndNode::class.java, node)
             node as AndNode
@@ -50,7 +50,7 @@ class QParserTests {
     }
 
     @Test
-    fun `it should parse an OR expression`() {
+    fun `parseQQuery should parse an OR expression`() {
         parseQQuery("temperature==42|humidity>10").shouldSucceedWith { node ->
             assertInstanceOf(OrNode::class.java, node)
             node as OrNode
@@ -60,7 +60,7 @@ class QParserTests {
     }
 
     @Test
-    fun `it should parse a grouped expression in parentheses`() {
+    fun `parseQQuery should parse a grouped expression in parentheses`() {
         parseQQuery("(temperature==42|humidity>10);status==\"active\"").shouldSucceedWith { node ->
             assertInstanceOf(AndNode::class.java, node)
             node as AndNode
@@ -69,7 +69,7 @@ class QParserTests {
     }
 
     @Test
-    fun `it should parse NEQ operator`() {
+    fun `parseQQuery should parse NEQ operator`() {
         parseQQuery("temperature!=42").shouldSucceedWith { node ->
             node as ComparisonNode
             assertEquals(ComparisonOperator.NEQ, node.operator)
@@ -77,7 +77,7 @@ class QParserTests {
     }
 
     @Test
-    fun `it should parse GTE operator`() {
+    fun `parseQQuery should parse GTE operator`() {
         parseQQuery("temperature>=42").shouldSucceedWith { node ->
             node as ComparisonNode
             assertEquals(ComparisonOperator.GTE, node.operator)
@@ -85,7 +85,7 @@ class QParserTests {
     }
 
     @Test
-    fun `it should parse GT operator`() {
+    fun `parseQQuery should parse GT operator`() {
         parseQQuery("temperature>42").shouldSucceedWith { node ->
             node as ComparisonNode
             assertEquals(ComparisonOperator.GT, node.operator)
@@ -93,7 +93,7 @@ class QParserTests {
     }
 
     @Test
-    fun `it should parse LTE operator`() {
+    fun `parseQQuery should parse LTE operator`() {
         parseQQuery("temperature<=42").shouldSucceedWith { node ->
             node as ComparisonNode
             assertEquals(ComparisonOperator.LTE, node.operator)
@@ -101,7 +101,7 @@ class QParserTests {
     }
 
     @Test
-    fun `it should parse LT operator`() {
+    fun `parseQQuery should parse LT operator`() {
         parseQQuery("temperature<42").shouldSucceedWith { node ->
             node as ComparisonNode
             assertEquals(ComparisonOperator.LT, node.operator)
@@ -109,7 +109,7 @@ class QParserTests {
     }
 
     @Test
-    fun `it should parse LIKE_REGEX operator`() {
+    fun `parseQQuery should parse LIKE_REGEX operator`() {
         parseQQuery("name~=\"foo.*\"").shouldSucceedWith { node ->
             node as ComparisonNode
             assertEquals(ComparisonOperator.LIKE_REGEX, node.operator)
@@ -117,7 +117,7 @@ class QParserTests {
     }
 
     @Test
-    fun `it should parse NOT_LIKE_REGEX operator`() {
+    fun `parseQQuery should parse NOT_LIKE_REGEX operator`() {
         parseQQuery("name!~=\"foo.*\"").shouldSucceedWith { node ->
             node as ComparisonNode
             assertEquals(ComparisonOperator.NOT_LIKE_REGEX, node.operator)
@@ -125,7 +125,7 @@ class QParserTests {
     }
 
     @Test
-    fun `it should parse a range value`() {
+    fun `parseQQuery should parse a range value`() {
         parseQQuery("temperature==10..20").shouldSucceedWith { node ->
             node as ComparisonNode
             assertInstanceOf(RangeValue::class.java, node.value)
@@ -136,7 +136,7 @@ class QParserTests {
     }
 
     @Test
-    fun `it should parse a list value`() {
+    fun `parseQQuery should parse a list value`() {
         parseQQuery("temperature==10,20,30").shouldSucceedWith { node ->
             node as ComparisonNode
             assertInstanceOf(ListValue::class.java, node.value)
@@ -149,7 +149,7 @@ class QParserTests {
     }
 
     @Test
-    fun `it should parse a string value in double quotes`() {
+    fun `parseQQuery should parse a string value in double quotes`() {
         parseQQuery("name==\"BeeHive\"").shouldSucceedWith { node ->
             node as ComparisonNode
             val sv = node.value as SingleValue
@@ -159,7 +159,7 @@ class QParserTests {
     }
 
     @Test
-    fun `it should detect boolean value type`() {
+    fun `parseQQuery should detect boolean value type`() {
         parseQQuery("active==true").shouldSucceedWith { node ->
             node as ComparisonNode
             val sv = node.value as SingleValue
@@ -168,7 +168,7 @@ class QParserTests {
     }
 
     @Test
-    fun `it should detect datetime value type`() {
+    fun `parseQQuery should detect datetime value type`() {
         parseQQuery("observedAt==\"2023-01-01T00:00:00Z\"").shouldSucceedWith { node ->
             node as ComparisonNode
             val sv = node.value as SingleValue
@@ -177,7 +177,7 @@ class QParserTests {
     }
 
     @Test
-    fun `it should parse attribute path with dot notation`() {
+    fun `parseQQuery should parse attribute path with dot notation`() {
         parseQQuery("incoming.observedAt>\"2023-01-01T00:00:00Z\"").shouldSucceedWith { node ->
             node as ComparisonNode
             assertEquals("incoming.observedAt", node.rawPath)
@@ -185,7 +185,7 @@ class QParserTests {
     }
 
     @Test
-    fun `it should parse attribute path with bracket notation`() {
+    fun `parseQQuery should parse attribute path with bracket notation`() {
         parseQQuery("incoming[temperature]==42").shouldSucceedWith { node ->
             node as ComparisonNode
             assertEquals("incoming[temperature]", node.rawPath)
@@ -193,35 +193,35 @@ class QParserTests {
     }
 
     @Test
-    fun `it should return BadRequest for empty query`() {
+    fun `parseQQuery should return BadRequest for empty query`() {
         parseQQuery("").shouldFail { ex ->
             assertInstanceOf(BadRequestDataException::class.java, ex)
         }
     }
 
     @Test
-    fun `it should return BadRequest for unbalanced parentheses`() {
+    fun `parseQQuery should return BadRequest for unbalanced parentheses`() {
         parseQQuery("(temperature==42").shouldFail { ex ->
             assertInstanceOf(BadRequestDataException::class.java, ex)
         }
     }
 
     @Test
-    fun `it should return BadRequest for trailing semicolon`() {
+    fun `parseQQuery should return BadRequest for trailing semicolon`() {
         parseQQuery("temperature==42;").shouldFail { ex ->
             assertInstanceOf(BadRequestDataException::class.java, ex)
         }
     }
 
     @Test
-    fun `it should return BadRequest for unclosed string value`() {
+    fun `parseQQuery should return BadRequest for unclosed string value`() {
         parseQQuery("temperature==\"unclosed").shouldFail { ex ->
             assertInstanceOf(BadRequestDataException::class.java, ex)
         }
     }
 
     @Test
-    fun `it should parse complex nested expression`() {
+    fun `parseQQuery should parse complex nested expression`() {
         parseQQuery("(temperature>10;humidity<90)|status==\"active\"").shouldSucceedWith { node ->
             assertInstanceOf(OrNode::class.java, node)
             node as OrNode

--- a/shared/src/test/kotlin/com/egm/stellio/shared/util/ApiUtilsTests.kt
+++ b/shared/src/test/kotlin/com/egm/stellio/shared/util/ApiUtilsTests.kt
@@ -135,13 +135,13 @@ class ApiUtilsTests {
     }
 
     @Test
-    fun `it should not find a value if there is no options query param`() {
+    fun `hasValueInOptionsParam should not find a value when there is no options query param`() {
         val result = hasValueInOptionsParam(Optional.empty(), TEMPORAL_VALUES).shouldSucceedAndResult()
         assertFalse(result)
     }
 
     @Test
-    fun `it should return an exception if it is given an invalid options query param`() {
+    fun `hasValueInOptionsParam should return an exception when given an invalid options query param`() {
         hasValueInOptionsParam(Optional.of("one"), TEMPORAL_VALUES).shouldFail {
             assertInstanceOf(InvalidRequestException::class.java, it)
             assertEquals("'one' is not a valid value for the options query parameter", it.message)
@@ -149,7 +149,7 @@ class ApiUtilsTests {
     }
 
     @Test
-    fun `it should return an exception if it is given an invalid multi value options query param`() {
+    fun `hasValueInOptionsParam should return an exception when given invalid multi value options`() {
         hasValueInOptionsParam(Optional.of("one,two"), TEMPORAL_VALUES).shouldFail {
             assertInstanceOf(InvalidRequestException::class.java, it)
             assertEquals("'one' is not a valid value for the options query parameter", it.message)
@@ -157,13 +157,13 @@ class ApiUtilsTests {
     }
 
     @Test
-    fun `it should find a value if it is in a single value options query param`() {
+    fun `hasValueInOptionsParam should find a value when it is in a single value options query param`() {
         val result = hasValueInOptionsParam(Optional.of("temporalValues"), TEMPORAL_VALUES).shouldSucceedAndResult()
         assertTrue(result)
     }
 
     @Test
-    fun `it should return an exception if it is given at least one invalid value in options query param`() {
+    fun `hasValueInOptionsParam should return an exception for at least one invalid options value`() {
         hasValueInOptionsParam(Optional.of("one,temporalValues"), TEMPORAL_VALUES).shouldFail {
             assertInstanceOf(InvalidRequestException::class.java, it)
             assertEquals("'one' is not a valid value for the options query parameter", it.message)
@@ -171,12 +171,12 @@ class ApiUtilsTests {
     }
 
     @Test
-    fun `it should return an empty list if no attrs param is provided`() {
+    fun `parseAttrsParameter should return an empty list when no attrs param is provided`() {
         assertTrue(parseAttrsParameter(null, emptyList()).shouldSucceedAndResult().isEmpty())
     }
 
     @Test
-    fun `it should return an singleton list if there is one provided attrs param`() {
+    fun `parseAttrsParameter should return a singleton list when one attrs param is provided`() {
         assertEquals(
             1,
             parseAttrsParameter("attr1", NGSILD_TEST_CORE_CONTEXTS).shouldSucceedAndResult().size
@@ -184,7 +184,7 @@ class ApiUtilsTests {
     }
 
     @Test
-    fun `it should return a list with two elements if there are two provided attrs param`() {
+    fun `parseAttrsParameter should return a list with two elements when two attrs params are provided`() {
         assertEquals(
             2,
             parseAttrsParameter("attr1, attr2", NGSILD_TEST_CORE_CONTEXTS).shouldSucceedAndResult().size
@@ -192,7 +192,7 @@ class ApiUtilsTests {
     }
 
     @Test
-    fun `it should return a BadRequestData error if attrs params contains an entity core member`() {
+    fun `parseAttrsParameter should return a BadRequestData error when attrs contains a core member`() {
         parseAttrsParameter("id", NGSILD_TEST_CORE_CONTEXTS).shouldFailWith {
             it is BadRequestDataException &&
                 it.message == "Entity core members cannot be present in 'attrs' parameter"
@@ -200,7 +200,7 @@ class ApiUtilsTests {
     }
 
     @Test
-    fun `it should return 411 if Content-Length is null`() {
+    fun `POST should return 411 when Content-Length is null`() {
         webClient.post()
             .uri("/router/mockkedroute")
             .header(HttpHeaders.CONTENT_TYPE, "application/json")
@@ -210,7 +210,7 @@ class ApiUtilsTests {
     }
 
     @Test
-    fun `it should support Mime-type with parameters`() {
+    fun `POST should support Mime-type with parameters`() {
         webClient.post()
             .uri("/router/mockkedroute")
             .header(HttpHeaders.CONTENT_TYPE, "application/ld+json;charset=UTF-8")
@@ -220,7 +220,7 @@ class ApiUtilsTests {
     }
 
     @Test
-    fun `it should extract a @context from a valid Link header`() = runTest {
+    fun `getContextFromLinkHeader should extract a @context from a valid Link header`() = runTest {
         getContextFromLinkHeader(listOf(APIC_HEADER_LINK)).shouldSucceedWith {
             assertNotNull(it)
             assertEquals(APIC_COMPOUND_CONTEXT, it)
@@ -228,14 +228,14 @@ class ApiUtilsTests {
     }
 
     @Test
-    fun `it should return a null @context if no Link header was provided`() = runTest {
+    fun `getContextFromLinkHeader should return a null @context when no Link header is provided`() = runTest {
         getContextFromLinkHeader(emptyList()).shouldSucceedWith {
             assertNull(it)
         }
     }
 
     @Test
-    fun `it should return a BadRequestData error if @context provided in Link header is invalid`() = runTest {
+    fun `getContextFromLinkHeader should fail when the @context in the Link header is invalid`() = runTest {
         getContextFromLinkHeader(APIC_COMPOUND_CONTEXTS).shouldFail {
             assertInstanceOf(BadRequestDataException::class.java, it)
             assertEquals(
@@ -246,7 +246,7 @@ class ApiUtilsTests {
     }
 
     @Test
-    fun `it should return the default @context if no Link header was provided and default is asked`() = runTest {
+    fun `getContextFromLinkHeaderOrDefault should return the default @context when none is provided`() = runTest {
         val httpHeaders = HttpHeaders()
         getContextFromLinkHeaderOrDefault(httpHeaders, applicationProperties.contexts.core).shouldSucceedWith {
             assertEquals(listOf(applicationProperties.contexts.core), it)
@@ -254,7 +254,7 @@ class ApiUtilsTests {
     }
 
     @Test
-    fun `it should get a single @context from a JSON-LD input`() = runTest {
+    fun `checkAndGetContext should get a single @context from a JSON-LD input`() = runTest {
         val httpHeaders = HttpHeaders().apply {
             set("Content-Type", "application/ld+json")
         }
@@ -271,7 +271,7 @@ class ApiUtilsTests {
     }
 
     @Test
-    fun `it should get a list of @context from a JSON-LD input`() = runTest {
+    fun `checkAndGetContext should get a list of @context from a JSON-LD input`() = runTest {
         val httpHeaders = HttpHeaders().apply {
             set("Content-Type", "application/ld+json")
         }
@@ -298,7 +298,7 @@ class ApiUtilsTests {
     }
 
     @Test
-    fun `it should throw an exception if a JSON-LD input has no @context`() = runTest {
+    fun `checkAndGetContext should throw an exception when a JSON-LD input has no @context`() = runTest {
         val httpHeaders = HttpHeaders().apply {
             set("Content-Type", "application/ld+json")
         }
@@ -317,7 +317,7 @@ class ApiUtilsTests {
     }
 
     @Test
-    fun `it should find a JSON-LD @context in an input map`() {
+    fun `extractContexts should find a JSON-LD @context in an input map`() {
         val input = mapOf(
             "id" to "urn:ngsi-ld:Entity:1",
             "@context" to "https://some.context"
@@ -327,7 +327,7 @@ class ApiUtilsTests {
     }
 
     @Test
-    fun `it should find a list of JSON-LD @contexts in an input map`() {
+    fun `extractContexts should find a list of JSON-LD @contexts in an input map`() {
         val input = mapOf(
             "id" to "urn:ngsi-ld:Entity:1",
             "@context" to listOf("https://some.context", "https://some.context.2")
@@ -337,7 +337,7 @@ class ApiUtilsTests {
     }
 
     @Test
-    fun `it should return an empty list if no JSON-LD @context was found an input map`() {
+    fun `extractContexts should return an empty list when no @context is in the input map`() {
         val input = mapOf(
             "id" to "urn:ngsi-ld:Entity:1"
         )
@@ -346,14 +346,14 @@ class ApiUtilsTests {
     }
 
     @Test
-    fun `it should return the core context if the list of contexts is empty`() {
+    fun `addCoreContextIfMissing should return the core context when the list of contexts is empty`() {
         val contexts = addCoreContextIfMissing(emptyList(), applicationProperties.contexts.core)
         assertEquals(1, contexts.size)
         assertEquals(listOf(applicationProperties.contexts.core), contexts)
     }
 
     @Test
-    fun `it should move the core context at last position if it is not last in the list of contexts`() {
+    fun `addCoreContextIfMissing should move the core context to last position when not last`() {
         val contexts = addCoreContextIfMissing(
             listOf(applicationProperties.contexts.core).plus(APIC_COMPOUND_CONTEXTS),
             applicationProperties.contexts.core
@@ -363,14 +363,14 @@ class ApiUtilsTests {
     }
 
     @Test
-    fun `it should add the core context at last position if it is not in the list of contexts`() {
+    fun `addCoreContextIfMissing should add the core context at last position if not in the list`() {
         val contexts = addCoreContextIfMissing(listOf(APIC_CONTEXT), applicationProperties.contexts.core)
         assertEquals(2, contexts.size)
         assertEquals(listOf(APIC_CONTEXT, applicationProperties.contexts.core), contexts)
     }
 
     @Test
-    fun `it should not add the core context if it resolvable from the provided contexts`() {
+    fun `addCoreContextIfMissing should not add the core context if resolvable from provided contexts`() {
         val contexts = addCoreContextIfMissing(
             listOf("https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.4.jsonld"),
             applicationProperties.contexts.core
@@ -380,7 +380,7 @@ class ApiUtilsTests {
     }
 
     @Test
-    fun `it should parse and expand entity type selection query`() {
+    fun `expandTypeSelection should parse and expand entity type selection query`() {
         val query = "(TypeA|TypeB);(TypeC,TypeD)"
         val defaultExpand = "https://uri.etsi.org/ngsi-ld/default-context/"
         val expandedQuery = expandTypeSelection(query, NGSILD_TEST_CORE_CONTEXTS)
@@ -390,7 +390,7 @@ class ApiUtilsTests {
     }
 
     @Test
-    fun `it should parse a conform datetime parameter`() {
+    fun `parseTimeParameter should parse a conform datetime parameter`() {
         val parseResult = "2023-10-16T16:18:00Z".parseTimeParameter("Invalid date time")
         parseResult.onLeft {
             fail("it should have parsed the date time")
@@ -398,7 +398,7 @@ class ApiUtilsTests {
     }
 
     @Test
-    fun `it should return an error if datetime parameter is not conform`() {
+    fun `parseTimeParameter should return an error when datetime parameter is not conform`() {
         val parseResult = "16/10/2023".parseTimeParameter("Invalid date time")
         parseResult.fold(
             { assertEquals("Invalid date time", it) }
@@ -408,7 +408,7 @@ class ApiUtilsTests {
     }
 
     @Test
-    fun `it should validate a correct idPattern`() {
+    fun `validateIdPattern should validate a correct idPattern`() {
         val validationResult = validateIdPattern("urn:ngsi-ld:Entity:*")
         validationResult.onLeft {
             fail("it should have parsed the date time")
@@ -416,7 +416,7 @@ class ApiUtilsTests {
     }
 
     @Test
-    fun `it should not validate an incorrect idPattern`() {
+    fun `validateIdPattern should not validate an incorrect idPattern`() {
         val validationResult = validateIdPattern("(?x)urn:ngsi-ld:Entity:{*}2")
         validationResult.fold(
             {

--- a/shared/src/test/kotlin/com/egm/stellio/shared/util/AuthUtilsTests.kt
+++ b/shared/src/test/kotlin/com/egm/stellio/shared/util/AuthUtilsTests.kt
@@ -12,7 +12,7 @@ import java.net.URI
 class AuthUtilsTests {
 
     @Test
-    fun `it should extract sub from an entity URI`() {
+    fun `extractSub should extract sub from an entity URI`() {
         assertEquals(
             "3693C62A-D5B2-4F9E-9D3A-F82814984D5C",
             URI.create("urn:ngsi-ld:Entity:3693C62A-D5B2-4F9E-9D3A-F82814984D5C").extractSub()
@@ -20,7 +20,7 @@ class AuthUtilsTests {
     }
 
     @Test
-    fun `it should extract sub from a string version of an entity URI`() {
+    fun `extractSub should extract sub from a string version of an entity URI`() {
         assertEquals(
             "3693C62A-D5B2-4F9E-9D3A-F82814984D5C",
             "urn:ngsi-ld:Entity:3693C62A-D5B2-4F9E-9D3A-F82814984D5C".extractSub()
@@ -28,18 +28,18 @@ class AuthUtilsTests {
     }
 
     @Test
-    fun `it should extract the compact form of an authorization term`() {
+    fun `toCompactTerm should extract the compact form of an authorization term`() {
         assertEquals("serviceAccountId", AUTH_TERM_SID.toCompactTerm())
     }
 
     @Test
-    fun `it should find the global role with a given key`() {
+    fun `forKey should find the global role with a given key`() {
         assertEquals(Some(GlobalRole.STELLIO_ADMIN), GlobalRole.forKey("stellio-admin"))
         assertEquals(Some(GlobalRole.STELLIO_CREATOR), GlobalRole.forKey("stellio-creator"))
     }
 
     @Test
-    fun `it should not find the global role for an unknown key`() {
+    fun `forKey should not find the global role for an unknown key`() {
         assertEquals(None, GlobalRole.forKey("unknown-role"))
     }
 }

--- a/shared/src/test/kotlin/com/egm/stellio/shared/util/DataRepresentationUtilsTests.kt
+++ b/shared/src/test/kotlin/com/egm/stellio/shared/util/DataRepresentationUtilsTests.kt
@@ -12,7 +12,7 @@ import org.junit.jupiter.params.provider.CsvSource
 class DataRepresentationUtilsTests {
 
     @Test
-    fun `it should not validate an entity with an invalid type name`() = runTest {
+    fun `checkNamesAreNgsiLdSupported should reject an invalid type name`() = runTest {
         val rawEntity =
             """
             {
@@ -32,7 +32,7 @@ class DataRepresentationUtilsTests {
     }
 
     @Test
-    fun `it should not validate an entity with one invalid type name in a list of many`() = runTest {
+    fun `checkNamesAreNgsiLdSupported should reject one invalid type name in a list of many`() = runTest {
         val rawEntity =
             """
             {
@@ -52,7 +52,7 @@ class DataRepresentationUtilsTests {
     }
 
     @Test
-    fun `it should validate an entity with allowed characters for attribute name`() = runTest {
+    fun `checkNamesAreNgsiLdSupported should accept allowed characters in an attribute name`() = runTest {
         val rawEntity =
             """
             {
@@ -69,7 +69,7 @@ class DataRepresentationUtilsTests {
     }
 
     @Test
-    fun `it should validate an entity with special characters in the value of a property`() = runTest {
+    fun `checkNamesAreNgsiLdSupported should accept special characters in the value of a property`() = runTest {
         val rawEntity =
             """
             {
@@ -89,7 +89,7 @@ class DataRepresentationUtilsTests {
     }
 
     @Test
-    fun `it should validate an entity with special characters in the value of a JsonProperty`() = runTest {
+    fun `checkNamesAreNgsiLdSupported should accept special characters in the value of a JsonProperty`() = runTest {
         val rawEntity =
             """
             {
@@ -109,7 +109,7 @@ class DataRepresentationUtilsTests {
     }
 
     @Test
-    fun `it should not validate an entity with an invalid attribute name`() = runTest {
+    fun `checkNamesAreNgsiLdSupported should reject an invalid attribute name`() = runTest {
         val rawEntity =
             """
             {
@@ -133,7 +133,7 @@ class DataRepresentationUtilsTests {
     }
 
     @Test
-    fun `it should not validate an entity with an invalid sub-attribute name`() = runTest {
+    fun `checkNamesAreNgsiLdSupported should reject an invalid sub-attribute name`() = runTest {
         val rawEntity =
             """
             {
@@ -161,7 +161,7 @@ class DataRepresentationUtilsTests {
     }
 
     @Test
-    fun `it should not validate an entity with an invalid sub-attribute name in a multi-attribute`() = runTest {
+    fun `checkNamesAreNgsiLdSupported should reject an invalid sub-attribute name in a multi-attribute`() = runTest {
         val rawEntity =
             """
             {
@@ -201,7 +201,7 @@ class DataRepresentationUtilsTests {
         "/3Scope",
         "/Scope#Another"
     )
-    fun `it should not validate an invalid scope name`(scope: String) = runTest {
+    fun `checkScopesNamesAreNgsiLdSupported should reject an invalid scope name`(scope: String) = runTest {
         scope.checkScopesNamesAreNgsiLdSupported().shouldFail {
             assertInstanceOf(BadRequestDataException::class.java, it)
             assertEquals(
@@ -212,7 +212,7 @@ class DataRepresentationUtilsTests {
     }
 
     @Test
-    fun `it should not validate invalid scopes names`() = runTest {
+    fun `checkScopesNamesAreNgsiLdSupported should reject invalid scopes names`() = runTest {
         listOf("/Scope/#Scope", "/A,/B").checkScopesNamesAreNgsiLdSupported().shouldFail {
             assertInstanceOf(BadRequestDataException::class.java, it)
             assertEquals(
@@ -233,17 +233,17 @@ class DataRepresentationUtilsTests {
         "/Scope/Sub_scope",
         "/Scope/Subscope/Subsubscope"
     )
-    fun `it should validate valid scope name`(scope: String) = runTest {
+    fun `checkScopesNamesAreNgsiLdSupported should accept a valid scope name`(scope: String) = runTest {
         scope.checkScopesNamesAreNgsiLdSupported().shouldSucceed()
     }
 
     @Test
-    fun `it should validate valid scopes names`() = runTest {
+    fun `checkScopesNamesAreNgsiLdSupported should accept valid scopes names`() = runTest {
         listOf("/A/B", "A/B", "A/B_C").checkScopesNamesAreNgsiLdSupported().shouldSucceed()
     }
 
     @Test
-    fun `it should not validate an entity with an invalid scope name`() = runTest {
+    fun `checkContentIsNgsiLdSupported should reject an entity with an invalid scope name`() = runTest {
         val rawEntity =
             """
             {
@@ -264,7 +264,7 @@ class DataRepresentationUtilsTests {
     }
 
     @Test
-    fun `it should not validate an entity with invalid scopes names`() = runTest {
+    fun `checkContentIsNgsiLdSupported should reject an entity with invalid scopes names`() = runTest {
         val rawEntity =
             """
             {
@@ -285,7 +285,7 @@ class DataRepresentationUtilsTests {
     }
 
     @Test
-    fun `it should not validate an entity with a null value`() = runTest {
+    fun `checkContentIsNgsiLdSupported should reject an entity with a null value`() = runTest {
         val rawEntity =
             """
             {

--- a/shared/src/test/kotlin/com/egm/stellio/shared/util/DateUtilsTests.kt
+++ b/shared/src/test/kotlin/com/egm/stellio/shared/util/DateUtilsTests.kt
@@ -9,25 +9,25 @@ import java.time.ZonedDateTime
 class DateUtilsTests {
 
     @Test
-    fun `it should render a datetime with milliseconds at zero`() {
+    fun `toNgsiLdFormat should render a datetime with milliseconds at zero`() {
         val datetime = ZonedDateTime.parse("2020-12-26T10:54:00.000Z")
         assertEquals("2020-12-26T10:54:00Z", datetime.toNgsiLdFormat())
     }
 
     @Test
-    fun `it should render a datetime with milliseconds`() {
+    fun `toNgsiLdFormat should render a datetime with milliseconds`() {
         val datetime = ZonedDateTime.parse("2020-12-26T10:54:00.123Z")
         assertEquals("2020-12-26T10:54:00.123Z", datetime.toNgsiLdFormat())
     }
 
     @Test
-    fun `it should render a datetime with nanoseconds`() {
+    fun `toNgsiLdFormat should render a datetime with nanoseconds`() {
         val datetime = ZonedDateTime.parse("2020-12-26T10:54:00.000111Z")
         assertEquals("2020-12-26T10:54:00.000111Z", datetime.toNgsiLdFormat())
     }
 
     @Test
-    fun `it shoud return true if the dates or times are correct`() {
+    fun `isDateTime, isDate and isTime should return whether the value matches the expected format`() {
         assertTrue("2020-12-26T10:54:00.000Z".isDateTime())
         assertFalse("2020-12-26U10:54:00.000Z".isDateTime())
 

--- a/shared/src/test/kotlin/com/egm/stellio/shared/util/GeoQueryUtilsTests.kt
+++ b/shared/src/test/kotlin/com/egm/stellio/shared/util/GeoQueryUtilsTests.kt
@@ -17,7 +17,7 @@ import org.springframework.test.context.ActiveProfiles
 class GeoQueryUtilsTests {
 
     @Test
-    fun `it should parse geo query parameters`() = runTest {
+    fun `parseGeoQueryParameters should parse geo query parameters`() = runTest {
         val requestParams = gimmeFullParamsMap()
         val geoQueryParams =
             parseGeoQueryParameters(requestParams, NGSILD_TEST_CORE_CONTEXTS).shouldSucceedAndResult()
@@ -33,7 +33,7 @@ class GeoQueryUtilsTests {
     }
 
     @Test
-    fun `it should parse URL encoded geo query parameters`() = runTest {
+    fun `parseGeoQueryParameters should parse URL encoded geo query parameters`() = runTest {
         val requestParams = gimmeFullParamsMap(
             georel = "near%3BmaxDistance%3D%3D1500"
         ).plus("coordinates" to "[57.5522%2C%20-20.3484]")
@@ -51,7 +51,7 @@ class GeoQueryUtilsTests {
     }
 
     @Test
-    fun `it should parse geo query parameters with geoproperty operation space`() = runTest {
+    fun `parseGeoQueryParameters should parse geo query parameters with geoproperty operation space`() = runTest {
         val requestParams = gimmeFullParamsMap("operationSpace")
 
         val geoQueryParams =
@@ -68,7 +68,7 @@ class GeoQueryUtilsTests {
     }
 
     @Test
-    fun `it should fail to create a geoquery if georel has an invalid near clause`() = runTest {
+    fun `parseGeoQueryParameters should fail to create a geoquery if georel has an invalid near clause`() = runTest {
         val requestParams = gimmeFullParamsMap(georel = "near;distance<100")
         parseGeoQueryParameters(requestParams, NGSILD_TEST_CORE_CONTEXTS).shouldFail {
             assertInstanceOf(BadRequestDataException::class.java, it)
@@ -77,7 +77,7 @@ class GeoQueryUtilsTests {
     }
 
     @Test
-    fun `it should fail to create a geoquery if georel is not recognized`() = runTest {
+    fun `parseGeoQueryParameters should fail to create a geoquery if georel is not recognized`() = runTest {
         val requestParams = gimmeFullParamsMap(georel = "unrecognized")
         parseGeoQueryParameters(requestParams, NGSILD_TEST_CORE_CONTEXTS).shouldFail {
             assertInstanceOf(BadRequestDataException::class.java, it)
@@ -86,7 +86,7 @@ class GeoQueryUtilsTests {
     }
 
     @Test
-    fun `it should fail to create a geoquery if geometry is not recognized`() = runTest {
+    fun `parseGeoQueryParameters should fail to create a geoquery if geometry is not recognized`() = runTest {
         val requestParams = gimmeFullParamsMap(geometry = "Unrecognized")
         parseGeoQueryParameters(requestParams, NGSILD_TEST_CORE_CONTEXTS).shouldFail {
             assertInstanceOf(BadRequestDataException::class.java, it)
@@ -95,7 +95,7 @@ class GeoQueryUtilsTests {
     }
 
     @Test
-    fun `it should fail to create a geoquery if a required parameter is missing`() = runTest {
+    fun `parseGeoQueryParameters should fail to create a geoquery if a required parameter is missing`() = runTest {
         val geoQueryParameters = mapOf(
             "geometry" to "Point",
             "coordinates" to "[57.5522,%20-20.3484]"
@@ -110,7 +110,7 @@ class GeoQueryUtilsTests {
     }
 
     @Test
-    fun `it should fail to create a geoquery if coordinates are invalid`() = runTest {
+    fun `parseGeoQueryParameters should fail to create a geoquery if coordinates are invalid`() = runTest {
         val geoQueryParameters = mapOf(
             "georel" to "within",
             "geometry" to "Polygon",
@@ -131,7 +131,7 @@ class GeoQueryUtilsTests {
     }
 
     @Test
-    fun `it should create a disjoint geoquery statement`() = runTest {
+    fun `buildSqlFilter should create a disjoint geoquery statement`() = runTest {
         val geoQuery = GeoQuery(
             "disjoint",
             GeometryType.POLYGON,
@@ -155,7 +155,7 @@ class GeoQueryUtilsTests {
     }
 
     @Test
-    fun `it should create a maxDistance geoquery statement`() = runTest {
+    fun `buildSqlFilter should create a maxDistance geoquery statement`() = runTest {
         val geoQuery = GeoQuery(
             "near;maxDistance==2000",
             GeometryType.POINT,
@@ -179,7 +179,7 @@ class GeoQueryUtilsTests {
     }
 
     @Test
-    fun `it should create a minDistance geoquery statement`() = runTest {
+    fun `buildSqlFilter should create a minDistance geoquery statement`() = runTest {
         val geoQuery = GeoQuery(
             "near;minDistance==15",
             GeometryType.POINT,

--- a/shared/src/test/kotlin/com/egm/stellio/shared/util/JsonLdUtilsTests.kt
+++ b/shared/src/test/kotlin/com/egm/stellio/shared/util/JsonLdUtilsTests.kt
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.extension.RegisterExtension
 class JsonLdUtilsTests {
 
     @Test
-    fun `it should throw a LdContextNotAvailable exception if the provided JSON-LD context is not available`() =
+    fun `expandJsonLdFragment should throw a LdContextNotAvailable exception when the context is not available`() =
         runTest {
             val rawEntity =
                 """
@@ -69,7 +69,7 @@ class JsonLdUtilsTests {
         }
 
     @Test
-    fun `it should throw a BadRequestData exception if the expanded JSON-LD fragment is empty`() = runTest {
+    fun `expandJsonLdFragment should throw a BadRequestData exception when the expanded fragment is empty`() = runTest {
         val rawEntity =
             """
             {
@@ -89,7 +89,7 @@ class JsonLdUtilsTests {
     }
 
     @Test
-    fun `it should compact and return an entity`() = runTest {
+    fun `compactEntity should compact and return an entity`() = runTest {
         val entity =
             """
             {
@@ -113,7 +113,7 @@ class JsonLdUtilsTests {
     }
 
     @Test
-    fun `it should compact and return a list of one entity`() = runTest {
+    fun `compactEntities should compact and return a list of one entity`() = runTest {
         val entity =
             """
             {
@@ -137,7 +137,7 @@ class JsonLdUtilsTests {
     }
 
     @Test
-    fun `it should compact and return a list of entities`() = runTest {
+    fun `compactEntities should compact and return a list of entities`() = runTest {
         val entity =
             """
             {
@@ -165,7 +165,7 @@ class JsonLdUtilsTests {
     }
 
     @Test
-    fun `it should expand an attribute from a fragment`() = runTest {
+    fun `expandAttribute should expand an attribute from a fragment`() = runTest {
         val fragment =
             """
                 {
@@ -182,7 +182,7 @@ class JsonLdUtilsTests {
     }
 
     @Test
-    fun `it should expand an attribute from a name and a string payload`() = runTest {
+    fun `expandAttribute should expand an attribute from a name and a string payload`() = runTest {
         val payload =
             """
                 {
@@ -197,7 +197,7 @@ class JsonLdUtilsTests {
     }
 
     @Test
-    fun `it should expand an attribute from a name and a map payload`() = runTest {
+    fun `expandAttribute should expand an attribute from a name and a map payload`() = runTest {
         val payload = mapOf(
             "type" to "Property",
             "value" to "something"
@@ -209,7 +209,7 @@ class JsonLdUtilsTests {
     }
 
     @Test
-    fun `it should correctly transform core geoproperties`() = runTest {
+    fun `expandJsonLdEntitySafe should correctly transform core geoproperties`() = runTest {
         val payload =
             """
                 {
@@ -258,7 +258,7 @@ class JsonLdUtilsTests {
     }
 
     @Test
-    fun `it should correctly transform and restore core geoproperties`() = runTest {
+    fun `compactEntity should correctly transform and restore core geoproperties`() = runTest {
         val payload =
             """
                 {
@@ -298,7 +298,7 @@ class JsonLdUtilsTests {
     }
 
     @Test
-    fun `it should correctly transform and restore a user defined geoproperty`() = runTest {
+    fun `compactEntity should correctly transform and restore a user defined geoproperty`() = runTest {
         val payload =
             """
                 {
@@ -334,7 +334,7 @@ class JsonLdUtilsTests {
     }
 
     @Test
-    fun `it should correctly compact a term if it is in the provided contexts`() = runTest {
+    fun `compactTerm should correctly compact a term when it is in the provided contexts`() = runTest {
         assertEquals(
             INCOMING_TERM,
             compactTerm(INCOMING_IRI, APIC_COMPOUND_CONTEXTS)
@@ -342,7 +342,7 @@ class JsonLdUtilsTests {
     }
 
     @Test
-    fun `it should return the input term if it was not able to compact it`() = runTest {
+    fun `compactTerm should return the input term when it cannot compact it`() = runTest {
         assertEquals(
             INCOMING_IRI,
             compactTerm(INCOMING_IRI, NGSILD_TEST_CORE_CONTEXTS)
@@ -350,7 +350,7 @@ class JsonLdUtilsTests {
     }
 
     @Test
-    fun `it should correctly compact a Property attribute`() = runTest {
+    fun `compactAttribute should correctly compact a Property attribute`() = runTest {
         val expandedProperty = mapOf(
             INCOMING_IRI to listOf(
                 mapOf(
@@ -375,7 +375,7 @@ class JsonLdUtilsTests {
     }
 
     @Test
-    fun `it should correctly compact a JsonProperty attribute`() = runTest {
+    fun `compactAttribute should correctly compact a JsonProperty attribute`() = runTest {
         val expandedAttribute = mapOf(
             LUMINOSITY_IRI to listOf(
                 mapOf(
@@ -411,7 +411,7 @@ class JsonLdUtilsTests {
     }
 
     @Test
-    fun `it should return a ResourceNotFound exception if a context is not found into the cache`() = runTest {
+    fun `deleteAndReload should return a ResourceNotFound exception when a context is not in the cache`() = runTest {
         val contextUrl = "http://localhost:8094/jsonld-contexts/never-encountered-context.jsonld"
         deleteAndReload(contextUrl.toUri(), false).shouldFail {
             assertInstanceOf(ResourceNotFoundException::class.java, it)
@@ -423,7 +423,7 @@ class JsonLdUtilsTests {
     }
 
     @Test
-    fun `it should delete and reload a context from the cache`() = runTest {
+    fun `deleteAndReload should delete and reload a context from the cache`() = runTest {
         val contextUrl = "http://localhost:8094/jsonld-contexts/ngsi-ld-core-context-v1.8.jsonld"
 
         // expand a term to populate the cache
@@ -438,7 +438,7 @@ class JsonLdUtilsTests {
     }
 
     @Test
-    fun `it should delete a context from the cache and use the refreshed one`() = runTest {
+    fun `deleteAndReload should delete a context from the cache and use the refreshed one`() = runTest {
         val contextUrl = "http://localhost:8094/jsonld-contexts/apic.jsonld"
 
         assertEquals(

--- a/shared/src/test/kotlin/com/egm/stellio/shared/util/JsonUtilsTests.kt
+++ b/shared/src/test/kotlin/com/egm/stellio/shared/util/JsonUtilsTests.kt
@@ -73,19 +73,19 @@ class JsonUtilsTests {
         """.trimIndent().replace(" ", "").replace("\n", "")
 
     @Test
-    fun `it should parse an event of type ENTITY_CREATE`() {
+    fun `deserializeAs should parse an event of type ENTITY_CREATE`() {
         val parsedEvent = deserializeAs<EntityEvent>(loadSampleData("events/entity/entityCreateEvent.json"))
         Assertions.assertTrue(parsedEvent is EntityCreateEvent)
     }
 
     @Test
-    fun `it should parse an event of type ENTITY_DELETE`() {
+    fun `deserializeAs should parse an event of type ENTITY_DELETE`() {
         val parsedEvent = deserializeAs<EntityEvent>(loadSampleData("events/entity/entityDeleteEvent.json"))
         Assertions.assertTrue(parsedEvent is EntityDeleteEvent)
     }
 
     @Test
-    fun `it should parse an event of type ATTRIBUTE_UPDATE`() {
+    fun `deserializeAs should parse an event of type ATTRIBUTE_UPDATE`() {
         val parsedEvent = deserializeAs<EntityEvent>(
             loadSampleData("events/entity/attributeUpdateTextPropEvent.json")
         )
@@ -93,13 +93,13 @@ class JsonUtilsTests {
     }
 
     @Test
-    fun `it should parse an event of type ATTRIBUTE_DELETE`() {
+    fun `deserializeAs should parse an event of type ATTRIBUTE_DELETE`() {
         val parsedEvent = deserializeAs<EntityEvent>(loadSampleData("events/entity/attributeDeleteEvent.json"))
         Assertions.assertTrue(parsedEvent is AttributeDeleteEvent)
     }
 
     @Test
-    fun `it should serialize an event of type ENTITY_CREATE`() = runTest {
+    fun `mapper should serialize an event of type ENTITY_CREATE`() = runTest {
         val event = mapper.writeValueAsString(
             EntityCreateEvent(
                 "0123456789-1234-5678-987654321",
@@ -113,7 +113,7 @@ class JsonUtilsTests {
     }
 
     @Test
-    fun `it should serialize an event of type ENTITY_DELETE`() = runTest {
+    fun `mapper should serialize an event of type ENTITY_DELETE`() = runTest {
         val event = mapper.writeValueAsString(
             EntityDeleteEvent(
                 null,
@@ -134,7 +134,7 @@ class JsonUtilsTests {
     }
 
     @Test
-    fun `it should throw an InvalidRequest exception if the JSON-LD fragment is not a valid JSON document`() {
+    fun `deserializeAsMap should throw an InvalidRequest exception for an invalid JSON document`() {
         val rawEntity =
             """
             {

--- a/shared/src/test/kotlin/com/egm/stellio/shared/util/PagingUtilsTests.kt
+++ b/shared/src/test/kotlin/com/egm/stellio/shared/util/PagingUtilsTests.kt
@@ -9,7 +9,7 @@ class PagingUtilsTests {
     private val subscriptionResourceUrl = "/ngsi-ld/v1/subscriptions"
 
     @Test
-    fun `it should not return the links`() {
+    fun `getPagingLinks should not return the links`() {
         val links = PagingUtils.getPagingLinks(
             subscriptionResourceUrl,
             LinkedMultiValueMap(),
@@ -22,7 +22,7 @@ class PagingUtilsTests {
     }
 
     @Test
-    fun `it should return the prev link`() {
+    fun `getPagingLinks should return the prev link`() {
         val links = PagingUtils.getPagingLinks(
             subscriptionResourceUrl,
             LinkedMultiValueMap(),
@@ -38,7 +38,7 @@ class PagingUtilsTests {
     }
 
     @Test
-    fun `it should return the next link`() {
+    fun `getPagingLinks should return the next link`() {
         val links = PagingUtils.getPagingLinks(
             subscriptionResourceUrl,
             LinkedMultiValueMap(),
@@ -54,7 +54,7 @@ class PagingUtilsTests {
     }
 
     @Test
-    fun `it should return the prev and the next links`() {
+    fun `getPagingLinks should return the prev and the next links`() {
         val links = PagingUtils.getPagingLinks(
             subscriptionResourceUrl,
             LinkedMultiValueMap(),

--- a/shared/src/test/kotlin/com/egm/stellio/shared/util/UriUtilsTests.kt
+++ b/shared/src/test/kotlin/com/egm/stellio/shared/util/UriUtilsTests.kt
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.assertThrows
 class UriUtilsTests {
 
     @Test
-    fun `it should throw a BadRequestData exception if input string is not an absolute URI`() {
+    fun `toUri should throw a BadRequestData exception if the input string is not an absolute URI`() {
         val uri = "justAString"
 
         val exception = assertThrows<BadRequestDataException> {
@@ -21,7 +21,7 @@ class UriUtilsTests {
     }
 
     @Test
-    fun `it should throw a BadRequestData exception if input string has an invalid syntax`() {
+    fun `toUri should throw a BadRequestData exception if the input string has an invalid syntax`() {
         val uri = "https://just\\AString"
 
         val exception = assertThrows<BadRequestDataException> {

--- a/shared/src/test/kotlin/com/egm/stellio/shared/web/ExceptionHandlerTests.kt
+++ b/shared/src/test/kotlin/com/egm/stellio/shared/web/ExceptionHandlerTests.kt
@@ -13,7 +13,7 @@ class ExceptionHandlerTests {
     ).build()
 
     @Test
-    fun `it should raise an error of type BadRequestData if the request payload is not a valid JSON fragment`() {
+    fun `POST should return a BadRequestData error when the payload is not a valid JSON fragment`() {
         val invalidJsonLdPayload =
             """
             {
@@ -35,7 +35,7 @@ class ExceptionHandlerTests {
     }
 
     @Test
-    fun `it should raise an error of type LdContextNotAvailable if the context is not resolvable`() {
+    fun `POST should return an LdContextNotAvailable error when the context is not resolvable`() {
         val invalidJsonPayload =
             """
             {

--- a/shared/src/test/kotlin/com/egm/stellio/shared/web/ExceptionHandlerTests.kt
+++ b/shared/src/test/kotlin/com/egm/stellio/shared/web/ExceptionHandlerTests.kt
@@ -13,7 +13,7 @@ class ExceptionHandlerTests {
     ).build()
 
     @Test
-    fun `POST should return a BadRequestData error when the payload is not a valid JSON fragment`() {
+    fun `POST requests should return a BadRequestData error when the payload is not a valid JSON fragment`() {
         val invalidJsonLdPayload =
             """
             {
@@ -35,7 +35,7 @@ class ExceptionHandlerTests {
     }
 
     @Test
-    fun `POST should return an LdContextNotAvailable error when the context is not resolvable`() {
+    fun `POST requests should return an LdContextNotAvailable error when the context is not resolvable`() {
         val invalidJsonPayload =
             """
             {

--- a/shared/src/test/kotlin/com/egm/stellio/shared/web/TenantWebFilterTests.kt
+++ b/shared/src/test/kotlin/com/egm/stellio/shared/web/TenantWebFilterTests.kt
@@ -35,7 +35,7 @@ class TenantWebFilterTests {
     }
 
     @Test
-    fun `it should return a NonexistentTenant error if the tenant does not exist`() {
+    fun `GET should return a NonexistentTenant error when the tenant does not exist`() {
         webClient.get()
             .uri("/router/mockkedroute/ok")
             .header(NGSILD_TENANT_HEADER, "urn:ngsi-ld:tenant:02")
@@ -48,7 +48,7 @@ class TenantWebFilterTests {
     }
 
     @Test
-    fun `it should find a non-default tenant and add the NGSILD-Tenant header in the response`() {
+    fun `GET should add the NGSILD-Tenant header when the tenant is non-default`() {
         webClient.get()
             .uri("/router/mockkedroute/ok")
             .header(NGSILD_TENANT_HEADER, "urn:ngsi-ld:tenant:01")
@@ -59,7 +59,7 @@ class TenantWebFilterTests {
     }
 
     @Test
-    fun `it should fallback to the default tenant if none was provided in the request`() {
+    fun `GET should fall back to the default tenant when none is provided`() {
         webClient.get()
             .uri("/router/mockkedroute/ok")
             .exchange()

--- a/shared/src/test/kotlin/com/egm/stellio/shared/web/TenantWebFilterTests.kt
+++ b/shared/src/test/kotlin/com/egm/stellio/shared/web/TenantWebFilterTests.kt
@@ -35,7 +35,7 @@ class TenantWebFilterTests {
     }
 
     @Test
-    fun `GET should return a NonexistentTenant error when the tenant does not exist`() {
+    fun `GET requests should return a NonexistentTenant error when the tenant does not exist`() {
         webClient.get()
             .uri("/router/mockkedroute/ok")
             .header(NGSILD_TENANT_HEADER, "urn:ngsi-ld:tenant:02")
@@ -48,7 +48,7 @@ class TenantWebFilterTests {
     }
 
     @Test
-    fun `GET should add the NGSILD-Tenant header when the tenant is non-default`() {
+    fun `GET requests should add the NGSILD-Tenant header when the tenant is non-default`() {
         webClient.get()
             .uri("/router/mockkedroute/ok")
             .header(NGSILD_TENANT_HEADER, "urn:ngsi-ld:tenant:01")
@@ -59,7 +59,7 @@ class TenantWebFilterTests {
     }
 
     @Test
-    fun `GET should fall back to the default tenant when none is provided`() {
+    fun `GET requests should fall back to the default tenant when none is provided`() {
         webClient.get()
             .uri("/router/mockkedroute/ok")
             .exchange()

--- a/subscription-service/config/detekt/baseline.xml
+++ b/subscription-service/config/detekt/baseline.xml
@@ -2,7 +2,7 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
-    <ID>CyclomaticComplexMethod:SubscriptionServiceTests.kt$SubscriptionServiceTests$@Test fun `it should load a subscription with all possible members`()</ID>
+    <ID>CyclomaticComplexMethod:SubscriptionServiceTests.kt$SubscriptionServiceTests$@Test fun `upsert should load a subscription with all possible members`()</ID>
     <ID>LongMethod:SubscriptionService.kt$SubscriptionService$@Transactional suspend fun upsert(subscription: Subscription, sub: Sub): Either&lt;APIException, Unit&gt;</ID>
     <ID>LongParameterList:FixtureUtils.kt$( withQueryAndGeoQuery: Pair&lt;Boolean, Boolean&gt; = Pair(true, true), withEndpointReceiverInfo: Boolean = true, withNotifParams: Pair&lt;FormatType, List&lt;String&gt;&gt; = Pair(FormatType.NORMALIZED, emptyList()), georel: String = "within", geometry: String = "Polygon", coordinates: String = "[[[100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0]]]", timeInterval: Int? = null, contexts: List&lt;String&gt; = listOf(NGSILD_TEST_CORE_CONTEXT) )</ID>
     <ID>LongParameterList:NotificationService.kt$NotificationService$( entityId: URI, compactedEntities: List&lt;Map&lt;String, Any?&gt;&gt;, updatedAttribute: Pair&lt;ExpandedTerm, URI?&gt;?, previousPayload: Map&lt;String, List&lt;Any&gt;&gt;?, notificationTrigger: NotificationTrigger, contexts: List&lt;String&gt; )</ID>

--- a/subscription-service/src/test/kotlin/com/egm/stellio/subscription/job/TimeIntervalNotificationJobTest.kt
+++ b/subscription-service/src/test/kotlin/com/egm/stellio/subscription/job/TimeIntervalNotificationJobTest.kt
@@ -57,7 +57,7 @@ class TimeIntervalNotificationJobTest {
     private lateinit var applicationProperties: ApplicationProperties
 
     @Test
-    fun `it should compose the query string used to get matching entities`() {
+    fun `prepareQueryParams should compose the query string used to get matching entities`() {
         val entities = setOf(
             EntitySelector(
                 id = "urn:ngsi-ld:FishContainment:1234567890".toUri(),
@@ -109,7 +109,7 @@ class TimeIntervalNotificationJobTest {
     }
 
     @Test
-    fun `it should not return twice the same entity if there is overlap between 2 entity infos`() {
+    fun `getEntitiesToNotify should not return twice the same entity when there is overlap between 2 entity infos`() {
         val subscription = gimmeRawSubscription(withEndpointReceiverInfo = false).copy(
             entities = setOf(
                 EntitySelector(
@@ -148,7 +148,7 @@ class TimeIntervalNotificationJobTest {
     }
 
     @Test
-    fun `it should call 'notificationService' once`() = runTest {
+    fun `sendNotification should call 'notificationService' once`() = runTest {
         val compactedEntity = mapOf("id" to "urn:ngsi-ld:Entity:01")
         val subscription = mockkClass(Subscription::class)
 
@@ -163,7 +163,7 @@ class TimeIntervalNotificationJobTest {
     }
 
     @Test
-    fun `it should notify the recurring subscriptions that have reached the time interval`() = runTest {
+    fun `sendTimeIntervalNotification should notify recurring subscriptions that reached their interval`() = runTest {
         val entity = loadSampleData("beehive.jsonld")
         val subscription = gimmeRawSubscription(withEndpointReceiverInfo = false).copy(
             entities = setOf(

--- a/subscription-service/src/test/kotlin/com/egm/stellio/subscription/listener/EntityEventListenerServiceTests.kt
+++ b/subscription-service/src/test/kotlin/com/egm/stellio/subscription/listener/EntityEventListenerServiceTests.kt
@@ -34,7 +34,7 @@ class EntityEventListenerServiceTests {
     private val entityId = "urn:ngsi-ld:BeeHive:01".toUri()
 
     @Test
-    fun `it should parse and transmit an entity create event`() = runTest {
+    fun `dispatchEntityEvent should parse and transmit an entity create event`() = runTest {
         val entityCreateEvent = loadSampleData("events/entity/entityCreateEvent.json")
 
         mockNotificationService()
@@ -56,7 +56,7 @@ class EntityEventListenerServiceTests {
     }
 
     @Test
-    fun `it should parse and transmit an entity delete event`() = runTest {
+    fun `dispatchEntityEvent should parse and transmit an entity delete event`() = runTest {
         val entityDeleteEvent = loadSampleData("events/entity/entityDeleteEvent.json")
 
         mockNotificationService()
@@ -76,7 +76,7 @@ class EntityEventListenerServiceTests {
     }
 
     @Test
-    fun `it should parse and transmit an attribute create event`() = runTest {
+    fun `dispatchEntityEvent should parse and transmit an attribute create event`() = runTest {
         val attributeCreateEvent = loadSampleData("events/entity/attributeAppendTextPropEvent.json")
 
         mockNotificationService()
@@ -98,7 +98,7 @@ class EntityEventListenerServiceTests {
     }
 
     @Test
-    fun `it should parse and transmit an attribute update event`() = runTest {
+    fun `dispatchEntityEvent should parse and transmit an attribute update event`() = runTest {
         val attributeUpdateEvent = loadSampleData("events/entity/attributeUpdateTextPropEvent.json")
 
         mockNotificationService()
@@ -120,7 +120,7 @@ class EntityEventListenerServiceTests {
     }
 
     @Test
-    fun `it should parse and transmit an attribute delete event`() = runTest {
+    fun `dispatchEntityEvent should parse and transmit an attribute delete event`() = runTest {
         val attributeDeleteEvent = loadSampleData("events/entity/attributeDeleteEvent.json")
 
         mockNotificationService()

--- a/subscription-service/src/test/kotlin/com/egm/stellio/subscription/model/SubscriptionTests.kt
+++ b/subscription-service/src/test/kotlin/com/egm/stellio/subscription/model/SubscriptionTests.kt
@@ -83,7 +83,7 @@ class SubscriptionTests {
     )
 
     @Test
-    fun `it should correctly deserialize a subscription`() = runTest {
+    fun `deserialize should correctly deserialize a subscription`() = runTest {
         val subscription = mapOf(
             "id" to beehiveId,
             "type" to "Subscription",
@@ -97,7 +97,7 @@ class SubscriptionTests {
     }
 
     @Test
-    fun `it should not validate a subscription with an empty id`() = runTest {
+    fun `validate should reject a subscription with an empty id`() = runTest {
         val payload = mapOf(
             "id" to "",
             "type" to NGSILD_SUBSCRIPTION_TERM,
@@ -114,7 +114,7 @@ class SubscriptionTests {
     }
 
     @Test
-    fun `it should not validate a subscription with an invalid id`() = runTest {
+    fun `validate should reject a subscription with an invalid id`() = runTest {
         val payload = mapOf(
             "id" to "invalidId",
             "type" to NGSILD_SUBSCRIPTION_TERM,
@@ -131,7 +131,7 @@ class SubscriptionTests {
     }
 
     @Test
-    fun `it should not validate a subscription with an invalid q`() = runTest {
+    fun `validate should reject a subscription with an invalid q`() = runTest {
         val payload = mapOf(
             "id" to beehiveId,
             "type" to NGSILD_SUBSCRIPTION_TERM,
@@ -149,7 +149,7 @@ class SubscriptionTests {
     }
 
     @Test
-    fun `it should not validate a subscription with an invalid idPattern`() = runTest {
+    fun `validate should reject a subscription with an invalid idPattern`() = runTest {
         val payload = mapOf(
             "id" to "urn:ngsi-ld:Beehive:1234567890".toUri(),
             "type" to NGSILD_SUBSCRIPTION_TERM,
@@ -166,7 +166,7 @@ class SubscriptionTests {
     }
 
     @Test
-    fun `it should not validate a subscription without entities and watchedAttributes`() = runTest {
+    fun `validate should reject a subscription without entities and watchedAttributes`() = runTest {
         val payload = mapOf(
             "id" to "urn:ngsi-ld:Beehive:1234567890".toUri(),
             "type" to NGSILD_SUBSCRIPTION_TERM,
@@ -182,7 +182,7 @@ class SubscriptionTests {
     }
 
     @Test
-    fun `it should not validate a subscription with timeInterval and watchedAttributes`() = runTest {
+    fun `validate should reject a subscription with timeInterval and watchedAttributes`() = runTest {
         val payload = mapOf(
             "id" to "urn:ngsi-ld:Beehive:1234567890".toUri(),
             "type" to NGSILD_SUBSCRIPTION_TERM,
@@ -200,7 +200,7 @@ class SubscriptionTests {
     }
 
     @Test
-    fun `it should not validate a subscription with timeInterval and throttling`() = runTest {
+    fun `validate should reject a subscription with timeInterval and throttling`() = runTest {
         val payload = mapOf(
             "id" to "urn:ngsi-ld:Beehive:1234567890".toUri(),
             "type" to NGSILD_SUBSCRIPTION_TERM,
@@ -219,7 +219,7 @@ class SubscriptionTests {
     }
 
     @Test
-    fun `it should not validate a subscription with a negative throttling`() = runTest {
+    fun `validate should reject a subscription with a negative throttling`() = runTest {
         val payload = mapOf(
             "id" to "urn:ngsi-ld:Beehive:1234567890".toUri(),
             "type" to NGSILD_SUBSCRIPTION_TERM,
@@ -237,7 +237,7 @@ class SubscriptionTests {
     }
 
     @Test
-    fun `it should not validate a subscription with a negative timeInterval`() = runTest {
+    fun `validate should reject a subscription with a negative timeInterval`() = runTest {
         val payload = mapOf(
             "id" to "urn:ngsi-ld:Beehive:1234567890".toUri(),
             "type" to NGSILD_SUBSCRIPTION_TERM,
@@ -255,7 +255,7 @@ class SubscriptionTests {
     }
 
     @Test
-    fun `it should not validate a subscription with an expiresAt in the past`() = runTest {
+    fun `validate should reject a subscription with an expiresAt in the past`() = runTest {
         val payload = mapOf(
             "id" to "urn:ngsi-ld:Beehive:1234567890".toUri(),
             "type" to NGSILD_SUBSCRIPTION_TERM,
@@ -273,7 +273,7 @@ class SubscriptionTests {
     }
 
     @Test
-    fun `it should not validate a subscription with an unknown notification trigger`() = runTest {
+    fun `validate should reject a subscription with an unknown notification trigger`() = runTest {
         val payload = mapOf(
             "id" to "urn:ngsi-ld:Beehive:1234567890".toUri(),
             "type" to NGSILD_SUBSCRIPTION_TERM,
@@ -291,7 +291,7 @@ class SubscriptionTests {
     }
 
     @Test
-    fun `it should not validate a subscription with an invalid endpoint URI`() = runTest {
+    fun `validate should reject a subscription with an invalid endpoint URI`() = runTest {
         val payload = mapOf(
             "id" to "urn:ngsi-ld:Beehive:1234567890".toUri(),
             "type" to NGSILD_SUBSCRIPTION_TERM,
@@ -308,7 +308,7 @@ class SubscriptionTests {
     }
 
     @Test
-    fun `it should not allow a subscription if remote JSON-LD @context cannot be retrieved`() = runTest {
+    fun `deserialize should fail when the remote JSON-LD @context cannot be retrieved`() = runTest {
         val contextNonExisting = "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-non-existing.jsonld"
         val subscription = mapOf(
             "id" to "urn:ngsi-ld:BeeHive:01",
@@ -337,7 +337,7 @@ class SubscriptionTests {
     }
 
     @Test
-    fun `it should not validate a subscription when jsonldContext is not a URI`() = runTest {
+    fun `validate should reject a subscription when jsonldContext is not a URI`() = runTest {
         val rawSubscription =
             """
                 {
@@ -368,7 +368,7 @@ class SubscriptionTests {
     }
 
     @Test
-    fun `it should not validate a subscription when jsonldContext is not available`() = runTest {
+    fun `validate should reject a subscription when jsonldContext is not available`() = runTest {
         val rawSubscription =
             """
                 {
@@ -399,7 +399,7 @@ class SubscriptionTests {
     }
 
     @Test
-    fun `it should not validate a subscription with an invalid join level when join is flat or inline`() = runTest {
+    fun `validate should reject a subscription with an invalid join level when join is flat or inline`() = runTest {
         val rawSubscription =
             """
                 {
@@ -430,7 +430,7 @@ class SubscriptionTests {
     }
 
     @Test
-    fun `it should not validate a subscription with simplified format and showChanges`() = runTest {
+    fun `validate should reject a subscription with simplified format and showChanges`() = runTest {
         val rawSubscription =
             """
                 {
@@ -461,7 +461,7 @@ class SubscriptionTests {
     }
 
     @Test
-    fun `it should not validate a subscription with attributes and pick or omit`() = runTest {
+    fun `validate should reject a subscription with attributes and pick or omit`() = runTest {
         val rawSubscription =
             """
                 {
@@ -492,7 +492,7 @@ class SubscriptionTests {
     }
 
     @Test
-    fun `it should not validate a subscription with an intersection between pick and omit`() = runTest {
+    fun `validate should reject a subscription with an intersection between pick and omit`() = runTest {
         val rawSubscription =
             """
                 {
@@ -523,7 +523,7 @@ class SubscriptionTests {
     }
 
     @Test
-    fun `it should not validate a subscription with a negative cooldown`() = runTest {
+    fun `validate should reject a subscription with a negative cooldown`() = runTest {
         val payload = mapOf(
             "id" to "urn:ngsi-ld:Beehive:1234567890".toUri(),
             "type" to NGSILD_SUBSCRIPTION_TERM,
@@ -545,7 +545,7 @@ class SubscriptionTests {
     }
 
     @Test
-    fun `it should not validate a subscription with a negative timeout`() = runTest {
+    fun `validate should reject a subscription with a negative timeout`() = runTest {
         val payload = mapOf(
             "id" to "urn:ngsi-ld:Beehive:1234567890".toUri(),
             "type" to NGSILD_SUBSCRIPTION_TERM,
@@ -567,7 +567,7 @@ class SubscriptionTests {
     }
 
     @Test
-    fun `it should expand a subscription`() {
+    fun `expand should expand a subscription`() {
         val subscription = subscription.copy().expand(APIC_COMPOUND_CONTEXTS)
 
         assertThat(subscription)
@@ -583,7 +583,7 @@ class SubscriptionTests {
     }
 
     @Test
-    fun `it should expand a subscription with a complex type selection`() {
+    fun `expand should expand a subscription with a complex type selection`() {
         val subscription = subscription.copy(
             entities = setOf(
                 EntitySelector(
@@ -600,7 +600,7 @@ class SubscriptionTests {
     }
 
     @Test
-    fun `it should compact a subscription`() {
+    fun `compact should compact a subscription`() {
         val subscription = subscription.copy().expand(APIC_COMPOUND_CONTEXTS)
 
         val compactedSubscription = subscription.compact(APIC_COMPOUND_CONTEXTS)
@@ -618,7 +618,7 @@ class SubscriptionTests {
     }
 
     @Test
-    fun `it should prepare a subscription as JSON and add the status attribute`() {
+    fun `prepareForRendering should prepare a subscription as JSON and add the status attribute`() {
         val subscription = subscription.copy().expand(APIC_COMPOUND_CONTEXTS)
 
         val serializedSub = subscription.prepareForRendering(NGSILD_TEST_CORE_CONTEXT, includeSysAttrs = false)
@@ -630,7 +630,7 @@ class SubscriptionTests {
     }
 
     @Test
-    fun `it should prepare a subscription as JSON without createdAt and modifiedAt if not specified`() {
+    fun `prepareForRendering should prepare JSON without createdAt and modifiedAt when not specified`() {
         val subscription = subscription.copy().expand(APIC_COMPOUND_CONTEXTS)
 
         val serializedSub = subscription.prepareForRendering(NGSILD_TEST_CORE_CONTEXT, includeSysAttrs = false)
@@ -642,7 +642,7 @@ class SubscriptionTests {
     }
 
     @Test
-    fun `it should prepare a subscription as JSON with createdAt and modifiedAt if specified`() {
+    fun `prepareForRendering should prepare a subscription as JSON with createdAt and modifiedAt if specified`() {
         val subscription = subscription.copy().expand(APIC_COMPOUND_CONTEXTS)
 
         val serializedSub = subscription.prepareForRendering(NGSILD_TEST_CORE_CONTEXT, includeSysAttrs = true)
@@ -653,7 +653,7 @@ class SubscriptionTests {
     }
 
     @Test
-    fun `it should prepare a subscription with a context if JSON-LD media type is asked`() {
+    fun `prepareForRendering should prepare a subscription with a context if JSON-LD media type is asked`() {
         val subscription = subscription.copy().expand(APIC_COMPOUND_CONTEXTS)
 
         val serializedSub = subscription.prepareForRendering(NGSILD_TEST_CORE_CONTEXT, mediaType = JSON_LD_MEDIA_TYPE)
@@ -664,7 +664,7 @@ class SubscriptionTests {
     }
 
     @Test
-    fun `it should prepare a subscription without context if JSON media type is asked`() {
+    fun `prepareForRendering should prepare a subscription without context if JSON media type is asked`() {
         val subscription = subscription.copy().expand(APIC_COMPOUND_CONTEXTS)
 
         val serializedSub = subscription.prepareForRendering(
@@ -678,7 +678,7 @@ class SubscriptionTests {
     }
 
     @Test
-    fun `it should prepare a list of subscriptions as JSON-LD with sysAttrs`() {
+    fun `prepareForRendering should prepare a list of subscriptions as JSON-LD with sysAttrs`() {
         val subscription = subscription.copy()
         val otherSubscription = subscription.copy(id = "urn:ngsi-ld:Subscription:02".toUri())
 
@@ -699,7 +699,7 @@ class SubscriptionTests {
     }
 
     @Test
-    fun `it should prepare a list of subscriptions as JSON without sysAttrs`() {
+    fun `prepareForRendering should prepare a list of subscriptions as JSON without sysAttrs`() {
         val subscription = subscription.copy()
         val otherSubscription = subscription.copy(id = "urn:ngsi-ld:Subscription:02".toUri())
 

--- a/subscription-service/src/test/kotlin/com/egm/stellio/subscription/model/SubscriptionTests.kt
+++ b/subscription-service/src/test/kotlin/com/egm/stellio/subscription/model/SubscriptionTests.kt
@@ -83,7 +83,7 @@ class SubscriptionTests {
     )
 
     @Test
-    fun `deserialize should correctly deserialize a subscription`() = runTest {
+    fun `deserialize should parse a complete subscription payload`() = runTest {
         val subscription = mapOf(
             "id" to beehiveId,
             "type" to "Subscription",
@@ -567,7 +567,7 @@ class SubscriptionTests {
     }
 
     @Test
-    fun `expand should expand a subscription`() {
+    fun `expand should return an expanded subscription`() {
         val subscription = subscription.copy().expand(APIC_COMPOUND_CONTEXTS)
 
         assertThat(subscription)
@@ -583,7 +583,7 @@ class SubscriptionTests {
     }
 
     @Test
-    fun `expand should expand a subscription with a complex type selection`() {
+    fun `expand should handle a complex type selection`() {
         val subscription = subscription.copy(
             entities = setOf(
                 EntitySelector(
@@ -600,7 +600,7 @@ class SubscriptionTests {
     }
 
     @Test
-    fun `compact should compact a subscription`() {
+    fun `compact should return a compacted subscription`() {
         val subscription = subscription.copy().expand(APIC_COMPOUND_CONTEXTS)
 
         val compactedSubscription = subscription.compact(APIC_COMPOUND_CONTEXTS)

--- a/subscription-service/src/test/kotlin/com/egm/stellio/subscription/service/CoreAPIServiceAuthTests.kt
+++ b/subscription-service/src/test/kotlin/com/egm/stellio/subscription/service/CoreAPIServiceAuthTests.kt
@@ -59,7 +59,7 @@ class CoreAPIServiceAuthTests {
     }
 
     @Test
-    fun `it should attach bearer token for tenant when calling entity service`() {
+    fun `getEntities should attach bearer token for tenant when calling entity service`() {
         // stub token endpoint for tenant 01
         stubFor(
             post(urlEqualTo("/realms/default/protocol/openid-connect/token"))
@@ -101,7 +101,7 @@ class CoreAPIServiceAuthTests {
     }
 
     @Test
-    fun `it should raise error when tenant is unknown`() {
+    fun `getEntities should raise an error when tenant is unknown`() {
         // stub entity service endpoint (but no token endpoint for unknown tenant)
         stubFor(
             get(urlEqualTo("/ngsi-ld/v1/entities?type=BeeHive"))

--- a/subscription-service/src/test/kotlin/com/egm/stellio/subscription/service/CoreAPIServiceNoAuthTests.kt
+++ b/subscription-service/src/test/kotlin/com/egm/stellio/subscription/service/CoreAPIServiceNoAuthTests.kt
@@ -47,7 +47,7 @@ class CoreAPIServiceNoAuthTests {
     }
 
     @Test
-    fun `it should not attach bearer token when authentication is disabled`() {
+    fun `getEntities should not attach bearer token when authentication is disabled`() {
         // stub entity service endpoint only (no token endpoint needed)
         stubFor(
             get(urlEqualTo("/ngsi-ld/v1/entities?type=BeeHive"))

--- a/subscription-service/src/test/kotlin/com/egm/stellio/subscription/service/CoreAPIServiceTests.kt
+++ b/subscription-service/src/test/kotlin/com/egm/stellio/subscription/service/CoreAPIServiceTests.kt
@@ -47,7 +47,7 @@ class CoreAPIServiceTests {
     private val beehiveTestCId = "urn:ngsi-ld:BeeHive:TESTC".toUri()
 
     @Test
-    fun `it should return one entity if the query sent to entity service matches one entity`() {
+    fun `getEntities should return one entity when the query sent to entity service matches one entity`() {
         val encodedQuery = "?type=BeeHive&id=urn:ngsi-ld:BeeHive:TESTC&q=speed%3E50%3BfoodName%3D%3Ddietary+fibres"
         stubFor(
             get(urlEqualTo("/ngsi-ld/v1/entities$encodedQuery"))
@@ -73,7 +73,7 @@ class CoreAPIServiceTests {
     }
 
     @Test
-    fun `it should return a list of 2 entities if the query sent to entity service matches two entities`() {
+    fun `getEntities should return a list of 2 entities when the query sent to entity service matches two entities`() {
         stubFor(
             get(urlEqualTo("/ngsi-ld/v1/entities?type=BeeHive"))
                 .willReturn(
@@ -99,7 +99,7 @@ class CoreAPIServiceTests {
     }
 
     @Test
-    fun `it should ask to retrieve linked entitiies using the notification parameters from the subscription`() {
+    fun `retrieveLinkedEntities should use the notification parameters from the subscription`() {
         stubFor(
             get(urlPathEqualTo("/ngsi-ld/v1/entities/$beehiveTestCId"))
                 .willReturn(

--- a/subscription-service/src/test/kotlin/com/egm/stellio/subscription/service/NotificationServiceTests.kt
+++ b/subscription-service/src/test/kotlin/com/egm/stellio/subscription/service/NotificationServiceTests.kt
@@ -142,7 +142,7 @@ class NotificationServiceTests {
     ).second[0]
 
     @Test
-    fun `it should notify the subscriber and update the subscription`() = runTest {
+    fun `notifyMatchingSubscribers should notify the subscriber and update the subscription`() = runTest {
         val subscription = gimmeRawSubscription()
         val expandedEntity = expandJsonLdEntity(rawEntity)
 
@@ -181,7 +181,7 @@ class NotificationServiceTests {
     }
 
     @Test
-    fun `it should call entity service to get linked entities if join is asked`() = runTest {
+    fun `notifyMatchingSubscribers should call entity service to get linked entities when join is asked`() = runTest {
         val subscription = gimmeRawSubscription(contexts = APIC_COMPOUND_CONTEXTS)
             .copy(
                 notification = NotificationParams(
@@ -229,7 +229,7 @@ class NotificationServiceTests {
     }
 
     @Test
-    fun `it should notify the subscriber and only keep the expected attributes`() = runTest {
+    fun `notifyMatchingSubscribers should notify the subscriber and only keep the expected attributes`() = runTest {
         val subscription = gimmeRawSubscription(
             withNotifParams = Pair(
                 FormatType.NORMALIZED,
@@ -273,7 +273,7 @@ class NotificationServiceTests {
     }
 
     @Test
-    fun `it should notify the subscriber and use subscription contexts to compact`() = runTest {
+    fun `notifyMatchingSubscribers should notify the subscriber and use subscription contexts to compact`() = runTest {
         val subscription = gimmeRawSubscription().copy(
             notification = NotificationParams(
                 attributes = emptyList(),
@@ -315,7 +315,7 @@ class NotificationServiceTests {
     }
 
     @Test
-    fun `it should notify the subscriber and use jsonldContext to compact when it is provided`() = runTest {
+    fun `notifyMatchingSubscribers should compact with jsonldContext when it is provided`() = runTest {
         val subscription = gimmeRawSubscription().copy(
             notification = NotificationParams(
                 attributes = emptyList(),
@@ -354,7 +354,7 @@ class NotificationServiceTests {
     }
 
     @Test
-    fun `it should send a simplified payload when format is keyValues and include only the specified attributes`() =
+    fun `notifyMatchingSubscribers should send only the specified attributes when format is keyValues`() =
         runTest {
             val subscription = gimmeRawSubscription(
                 withNotifParams = Pair(FormatType.KEY_VALUES, listOf(NGSILD_LOCATION_TERM))
@@ -396,7 +396,7 @@ class NotificationServiceTests {
         }
 
     @Test
-    fun `it should send a concise payload when format is concise`() = runTest {
+    fun `notifyMatchingSubscribers should send a concise payload when format is concise`() = runTest {
         val subscription = gimmeRawSubscription(
             withNotifParams = Pair(FormatType.CONCISE, emptyList()),
             contexts = APIC_COMPOUND_CONTEXTS
@@ -445,7 +445,7 @@ class NotificationServiceTests {
     }
 
     @Test
-    fun `it should notify the two subscribers`() = runTest {
+    fun `notifyMatchingSubscribers should notify the two subscribers`() = runTest {
         val subscription1 = gimmeRawSubscription()
         val subscription2 = gimmeRawSubscription()
         val expandedEntity = expandJsonLdEntity(rawEntity)
@@ -482,7 +482,7 @@ class NotificationServiceTests {
     }
 
     @Test
-    fun `it should notify the second subscriber even if the first notification has failed`() = runTest {
+    fun `notifyMatchingSubscribers should notify the second subscriber after the first one failed`() = runTest {
         // the notification for this one is expected to fail as we don't listen on port 8088
         val subscription1 = gimmeRawSubscription()
             .copy(
@@ -536,7 +536,7 @@ class NotificationServiceTests {
     }
 
     @Test
-    fun `it should fail if it cannot contact the subscriber after the configured timeout`() = runTest {
+    fun `notifyMatchingSubscribers should fail when the subscriber is unreachable within the timeout`() = runTest {
         val subscription = gimmeRawSubscription()
             .copy(
                 notification = NotificationParams(
@@ -572,7 +572,7 @@ class NotificationServiceTests {
     }
 
     @Test
-    fun `it should add a Link header containing the context of the subscription`() = runTest {
+    fun `callSubscriber should add a Link header containing the context of the subscription`() = runTest {
         val subscription = gimmeRawSubscription().copy(
             notification = NotificationParams(
                 attributes = emptyList(),
@@ -602,7 +602,7 @@ class NotificationServiceTests {
     }
 
     @Test
-    fun `it should add a Link header containing the jsonldContext of the subscription when provided`() = runTest {
+    fun `callSubscriber should add a Link header with the subscription jsonldContext when provided`() = runTest {
         val subscription = gimmeRawSubscription().copy(
             notification = NotificationParams(
                 attributes = emptyList(),
@@ -633,7 +633,7 @@ class NotificationServiceTests {
     }
 
     @Test
-    fun `it should add an NGSILD-Tenant header if the subscription is not from the default context`() = runTest {
+    fun `callSubscriber should add an NGSILD-Tenant header for a non-default context`() = runTest {
         val subscription = gimmeRawSubscription().copy(
             notification = NotificationParams(
                 attributes = emptyList(),
@@ -666,7 +666,7 @@ class NotificationServiceTests {
     }
 
     @Test
-    fun `it should call the subscriber`() = runTest {
+    fun `callSubscriber should call the subscriber`() = runTest {
         val subscription = gimmeRawSubscription()
 
         coEvery { subscriptionService.updateSubscriptionNotification(any(), any(), any()) } returns 1
@@ -693,7 +693,7 @@ class NotificationServiceTests {
     }
 
     @Test
-    fun `it should notify the subscriber and return entities without sysAttrs if sysAttrs is false`() = runTest {
+    fun `notifyMatchingSubscribers should return entities without sysAttrs when sysAttrs is false`() = runTest {
         val subscription = gimmeRawSubscription()
         val expandedEntity = expandJsonLdEntity(entityWithSysAttrs)
 
@@ -727,7 +727,7 @@ class NotificationServiceTests {
     }
 
     @Test
-    fun `it should notify the subscriber with sysAttrs if sysAttrs is true`() = runTest {
+    fun `notifyMatchingSubscribers should notify the subscriber with sysAttrs when sysAttrs is true`() = runTest {
         val subscription = gimmeRawSubscription().copy(
             notification = NotificationParams(
                 attributes = emptyList(),
@@ -771,7 +771,7 @@ class NotificationServiceTests {
     }
 
     @Test
-    fun `it should notify the subscriber with language filter applied if lang is provided`() = runTest {
+    fun `notifyMatchingSubscribers should apply the language filter when lang is provided`() = runTest {
         val subscription = gimmeRawSubscription().copy(
             notification = NotificationParams(
                 attributes = emptyList(),
@@ -833,7 +833,7 @@ class NotificationServiceTests {
 
     @ParameterizedTest
     @MethodSource("com.egm.stellio.subscription.service.AttributeChangesInjectionSource#showChangesDataProvider")
-    fun `it should update an attribute with its previous value`(
+    fun `addChangesInNotifiedEntity should update an attribute with its previous value`(
         compactedEntitiesPayload: String,
         isMultiInstancesAttribute: Boolean,
         compactedPreviousAttribute: String,
@@ -861,7 +861,7 @@ class NotificationServiceTests {
 
     @ParameterizedTest
     @MethodSource("com.egm.stellio.subscription.service.EntityChangesInjectionSource#showChangesDataProvider")
-    fun `it should add the previous values of an entity`(
+    fun `addChangesInNotifiedEntity should add the previous values of an entity`(
         compactedEntitiesPayload: String,
         compactedPreviousEntity: String,
         expectedOutputEntity: String
@@ -884,7 +884,7 @@ class NotificationServiceTests {
     }
 
     @Test
-    fun `callSuscriber should ask mqttNotifier if the endpoint uri startWith mqtt`() = runTest {
+    fun `callSubscriber should ask mqttNotifier if the endpoint uri startWith mqtt`() = runTest {
         val subscription = gimmeRawSubscription().copy(
             notification = NotificationParams(
                 attributes = emptyList(),
@@ -906,7 +906,7 @@ class NotificationServiceTests {
     }
 
     @Test
-    fun `callSuscriber should generate headers for mqtt notification`() = runTest {
+    fun `callSubscriber should generate headers for mqtt notification`() = runTest {
         val infoKey = "hello"
         val infoValue = "world"
         val subscription = gimmeRawSubscription().copy(

--- a/subscription-service/src/test/kotlin/com/egm/stellio/subscription/service/SubscriptionServiceTests.kt
+++ b/subscription-service/src/test/kotlin/com/egm/stellio/subscription/service/SubscriptionServiceTests.kt
@@ -101,7 +101,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should not allow a subscription with an invalid join value`() = runTest {
+    fun `deserialize should reject a subscription with an invalid join value`() = runTest {
         val rawSubscription =
             """
                 {
@@ -128,7 +128,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should load a subscription with minimal required info - entities`() = runTest {
+    fun `upsert should load a subscription with minimal required info - entities`() = runTest {
         val subscription = loadAndDeserializeSubscription("subscription_minimal_entities.json")
         subscriptionService.upsert(subscription, mockUserSub).shouldSucceed()
 
@@ -149,7 +149,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should load a subscription with minimal required info - watchedAttributes`() = runTest {
+    fun `upsert should load a subscription with minimal required info - watchedAttributes`() = runTest {
         val subscription = loadAndDeserializeSubscription("subscription_minimal_watched_attributes.json")
         subscriptionService.upsert(subscription, mockUserSub).shouldSucceed()
 
@@ -167,7 +167,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should load a subscription with all possible members`() = runTest {
+    fun `upsert should load a subscription with all possible members`() = runTest {
         val subscription = loadAndDeserializeSubscription("subscription_full.json")
         subscriptionService.upsert(subscription, mockUserSub).shouldSucceed()
 
@@ -219,7 +219,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should load a subscription with extra info on last notification`() = runTest {
+    fun `updateSubscriptionNotification should load a subscription with extra info on last notification`() = runTest {
         val subscription = gimmeSubscriptionFromMembers(
             mapOf(
                 "entities" to listOf(
@@ -250,7 +250,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should delete an existing subscription`() = runTest {
+    fun `delete should delete an existing subscription`() = runTest {
         val subscription = loadAndDeserializeSubscription("subscription_minimal_entities.json")
         subscriptionService.upsert(subscription, mockUserSub).shouldSucceed()
 
@@ -258,13 +258,13 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should not fail when trying to delete an unknown subscription`() = runTest {
+    fun `delete should not fail when trying to delete an unknown subscription`() = runTest {
         subscriptionService.delete("urn:ngsi-ld:Subscription:UnknownSubscription".toUri())
             .shouldSucceed()
     }
 
     @Test
-    fun `it should not retrieve an expired subscription`() = runTest {
+    fun `getMatchingSubscriptions should not retrieve an expired subscription`() = runTest {
         val subscription = gimmeSubscriptionFromMembers(
             mapOf(
                 "entities" to listOf(mapOf("id" to "urn:ngsi-ld:Beekeeper:01", "type" to BEEKEEPER_TERM)),
@@ -288,7 +288,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should retrieve a subscription whose expiration date has not been reached`() = runTest {
+    fun `getMatchingSubscriptions should retrieve a subscription before its expiration date`() = runTest {
         val subscription = gimmeSubscriptionFromMembers(
             mapOf(
                 "entities" to listOf(mapOf("id" to "urn:ngsi-ld:Beekeeper:01", "type" to BEEKEEPER_TERM)),
@@ -307,7 +307,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should retrieve a subscription matching an idPattern`() = runTest {
+    fun `getMatchingSubscriptions should retrieve a subscription matching an idPattern`() = runTest {
         val subscription = gimmeSubscriptionFromMembers(
             mapOf(
                 "entities" to listOf(
@@ -328,7 +328,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should not retrieve a subscription if idPattern does not match`() = runTest {
+    fun `getMatchingSubscriptions should not retrieve a subscription if idPattern does not match`() = runTest {
         val subscription = gimmeSubscriptionFromMembers(
             mapOf(
                 "entities" to listOf(
@@ -349,7 +349,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should retrieve a subscription matching an exact type`() = runTest {
+    fun `getMatchingSubscriptions should retrieve a subscription matching an exact type`() = runTest {
         val subscription = gimmeSubscriptionFromMembers(
             mapOf(
                 "entities" to listOf(
@@ -370,7 +370,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should retrieve a subscription matching a type selection`() = runTest {
+    fun `getMatchingSubscriptions should retrieve a subscription matching a type selection`() = runTest {
         val subscription = gimmeSubscriptionFromMembers(
             mapOf(
                 "entities" to listOf(
@@ -391,7 +391,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should retrieve a subscription matching a type and an id`() = runTest {
+    fun `getMatchingSubscriptions should retrieve a subscription matching a type and an id`() = runTest {
         val subscription = gimmeSubscriptionFromMembers(
             mapOf(
                 "entities" to listOf(
@@ -412,7 +412,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should retrieve a subscription matching a type and id pattern`() = runTest {
+    fun `getMatchingSubscriptions should retrieve a subscription matching a type and id pattern`() = runTest {
         val subscription = gimmeSubscriptionFromMembers(
             mapOf("entities" to listOf(mapOf("idPattern" to "urn:ngsi-ld:Beehive:*", "type" to BEEHIVE_TERM)))
         )
@@ -429,7 +429,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should not retrieve a subscription if type does not match`() = runTest {
+    fun `getMatchingSubscriptions should not retrieve a subscription if type does not match`() = runTest {
         val subscription = gimmeSubscriptionFromMembers(
             mapOf(
                 "entities" to listOf(
@@ -450,7 +450,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should not retrieve a deactivated subscription matching an id`() = runTest {
+    fun `getMatchingSubscriptions should not retrieve a deactivated subscription matching an id`() = runTest {
         val subscription = gimmeSubscriptionFromMembers(
             mapOf(
                 "entities" to listOf(
@@ -472,7 +472,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should retrieve a subscription matching one of the watched attributes`() = runTest {
+    fun `getMatchingSubscriptions should retrieve a subscription matching one of the watched attributes`() = runTest {
         val subscription = gimmeSubscriptionFromMembers(
             mapOf(
                 "watchedAttributes" to listOf(INCOMING_TERM, OUTGOING_TERM)
@@ -491,7 +491,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should not retrieve a subscription not matching one of the watched attributes`() = runTest {
+    fun `getMatchingSubscriptions should not retrieve when no watched attribute matches`() = runTest {
         val subscription = gimmeSubscriptionFromMembers(
             mapOf(
                 "watchedAttributes" to listOf(INCOMING_TERM, OUTGOING_TERM)
@@ -510,7 +510,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should not retrieve a subscription matching on type and not on one of the watched attributes`() = runTest {
+    fun `getMatchingSubscriptions should not retrieve when type matches but no watched attribute does`() = runTest {
         val subscription = gimmeSubscriptionFromMembers(
             mapOf(
                 "entities" to listOf(mapOf("type" to BEEHIVE_TERM)),
@@ -530,7 +530,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should retrieve a subscription with exact match on the notification trigger`() = runTest {
+    fun `getMatchingSubscriptions should retrieve on exact notification trigger match`() = runTest {
         val subscription = gimmeSubscriptionFromMembers(
             mapOf(
                 "entities" to listOf(mapOf("type" to BEEHIVE_TERM)),
@@ -550,7 +550,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should not fail to match a subscription if the input entity contains a single quote`() = runTest {
+    fun `getMatchingSubscriptions should match when the input entity contains a single quote`() = runTest {
         val subscription = gimmeSubscriptionFromMembers(
             mapOf(
                 "entities" to listOf(mapOf("type" to BEEHIVE_TERM)),
@@ -570,7 +570,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should retrieve a subscription with entityUpdated trigger matched with an attribute event`() = runTest {
+    fun `getMatchingSubscriptions should match an entityUpdated trigger on an attribute event`() = runTest {
         val subscription = gimmeSubscriptionFromMembers(
             mapOf(
                 "entities" to listOf(mapOf("type" to BEEHIVE_TERM)),
@@ -590,7 +590,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should not retrieve a subscription with entityUpdated trigger matched with an entity delete event`() =
+    fun `getMatchingSubscriptions should not match an entityUpdated trigger on an entity delete event`() =
         runTest {
             val subscription = gimmeSubscriptionFromMembers(
                 mapOf(
@@ -611,7 +611,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
         }
 
     @Test
-    fun `it should retrieve a subscription with entityDeleted trigger matched with an entity delete event`() =
+    fun `getMatchingSubscriptions should match an entityDeleted trigger on an entity delete event`() =
         runTest {
             val subscription = gimmeSubscriptionFromMembers(
                 mapOf(
@@ -632,7 +632,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
         }
 
     @Test
-    fun `it should update a subscription`() = runTest {
+    fun `upsert should update a subscription`() = runTest {
         val subscription = loadAndDeserializeSubscription("subscription_minimal_entities.json")
         subscriptionService.upsert(subscription, mockUserSub).shouldSucceed()
 
@@ -675,7 +675,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should update a subscription entities`() = runTest {
+    fun `upsert should update a subscription entities`() = runTest {
         val subscription = loadAndDeserializeSubscription("subscription_minimal_entities.json")
         subscriptionService.upsert(subscription, mockUserSub).shouldSucceed()
 
@@ -719,7 +719,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should activate a subscription`() = runTest {
+    fun `upsert should activate a subscription`() = runTest {
         val subscription = gimmeSubscriptionFromMembers(
             mapOf(
                 "entities" to listOf(mapOf("id" to "urn:ngsi-ld:Beekeeper:01", "type" to BEEKEEPER_TERM)),
@@ -741,7 +741,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should deactivate a subscription`() = runTest {
+    fun `upsert should deactivate a subscription`() = runTest {
         val subscription = gimmeSubscriptionFromMembers(
             mapOf(
                 "entities" to listOf(mapOf("id" to "urn:ngsi-ld:Beekeeper:01", "type" to BEEKEEPER_TERM))
@@ -763,7 +763,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should update and expand watched attributes of a subscription`() = runTest {
+    fun `upsert should update and expand watched attributes of a subscription`() = runTest {
         val subscription = gimmeSubscriptionFromMembers(
             mapOf(
                 "watchedAttributes" to arrayListOf(INCOMING_TERM)
@@ -790,7 +790,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should update notification trigger of a subscription`() = runTest {
+    fun `upsert should update notification trigger of a subscription`() = runTest {
         val subscription = gimmeSubscriptionFromMembers(
             mapOf(
                 "entities" to listOf(mapOf("id" to "urn:ngsi-ld:Beekeeper:01", "type" to BEEKEEPER_TERM)),
@@ -821,7 +821,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should return a BadRequestData exception if the subscription has an unknown attribute`() = runTest {
+    fun `mergeWithFragment should return a BadRequestData exception on an unknown attribute`() = runTest {
         val subscription = loadAndDeserializeSubscription("subscription_minimal_entities.json")
         subscriptionService.upsert(subscription, mockUserSub).shouldSucceed()
 
@@ -834,7 +834,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should return a NotImplemented exception if the subscription has an unsupported attribute`() = runTest {
+    fun `mergeWithFragment should return a NotImplemented exception on an unsupported attribute`() = runTest {
         val subscription = loadAndDeserializeSubscription("subscription_minimal_entities.json")
         subscriptionService.upsert(subscription, mockUserSub).shouldSucceed()
 
@@ -859,7 +859,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
         "'($BEEKEEPER_IRI;$APIARY_IRI),$DEVICE_IRI', '$BEEKEEPER_IRI,$APIARY_IRI,$BEEHIVE_IRI', 1",
         "'($BEEKEEPER_IRI;$APIARY_IRI),$DEVICE_IRI', '$BEEKEEPER_IRI,$BEEHIVE_IRI', 0"
     )
-    fun `it should return result according types selection languages`(
+    fun `getMatchingSubscriptions should return result according types selection languages`(
         typesQuery: String,
         types: String,
         expectedSize: Int
@@ -878,7 +878,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should not return a subscription if q query is invalid`() = runTest {
+    fun `getMatchingSubscriptions should not return a subscription if q query is invalid`() = runTest {
         val expandedEntity = expandJsonLdEntity(entity, APIC_COMPOUND_CONTEXTS)
         val subscription = gimmeSubscriptionFromMembers(
             mapOf(
@@ -896,7 +896,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should return a subscription if entity matches q query`() = runTest {
+    fun `getMatchingSubscriptions should return a subscription if entity matches q query`() = runTest {
         val expandedEntity = expandJsonLdEntity(entity, APIC_COMPOUND_CONTEXTS)
         val subscription = gimmeSubscriptionFromMembers(
             mapOf(
@@ -914,7 +914,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should not return a subscription if entity doesn't match q query`() = runTest {
+    fun `getMatchingSubscriptions should not return a subscription if entity doesn't match q query`() = runTest {
         val expandedEntity = expandJsonLdEntity(entity, APIC_COMPOUND_CONTEXTS)
         val subscription = gimmeSubscriptionFromMembers(
             mapOf(
@@ -932,7 +932,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should return a subscription if entity matches a complex q query`() = runTest {
+    fun `getMatchingSubscriptions should return a subscription if entity matches a complex q query`() = runTest {
         val expandedEntity = expandJsonLdEntity(entity, APIC_COMPOUND_CONTEXTS)
         val subscription = gimmeSubscriptionFromMembers(
             mapOf(
@@ -950,7 +950,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should return a subscription if entity matches a complex q query with AND logical operator`() = runTest {
+    fun `getMatchingSubscriptions should match a complex q query with an AND operator`() = runTest {
         val expandedEntity = expandJsonLdEntity(entity, APIC_COMPOUND_CONTEXTS)
         val subscription = gimmeSubscriptionFromMembers(
             mapOf(
@@ -968,7 +968,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should return a subscription if entity matches a complex q query with OR logical operator`() = runTest {
+    fun `getMatchingSubscriptions should match a complex q query with an OR operator`() = runTest {
         val expandedEntity = expandJsonLdEntity(entity, APIC_COMPOUND_CONTEXTS)
         val subscription = gimmeSubscriptionFromMembers(
             mapOf(
@@ -986,7 +986,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should return a subscription if entity matched a q query with a boolean inequality`() = runTest {
+    fun `getMatchingSubscriptions should match a q query with a boolean inequality`() = runTest {
         val expandedEntity = expandJsonLdEntity(entity, APIC_COMPOUND_CONTEXTS)
         val subscription = gimmeSubscriptionFromMembers(
             mapOf(
@@ -1004,7 +1004,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should return a subscription if entity matched a q query with a boolean equality`() = runTest {
+    fun `getMatchingSubscriptions should match a q query with a boolean equality`() = runTest {
         val expandedEntity = expandJsonLdEntity(entity, APIC_COMPOUND_CONTEXTS)
         val subscription = gimmeSubscriptionFromMembers(
             mapOf(
@@ -1022,7 +1022,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should return a subscription if entity matches a scope query`() = runTest {
+    fun `getMatchingSubscriptions should return a subscription if entity matches a scope query`() = runTest {
         val expandedEntity = expandJsonLdEntity(entity, APIC_COMPOUND_CONTEXTS)
         val subscription = gimmeSubscriptionFromMembers(
             mapOf(
@@ -1040,7 +1040,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should not return a subscription if entity does not match a scope query`() = runTest {
+    fun `getMatchingSubscriptions should not return a subscription if entity does not match a scope query`() = runTest {
         val expandedEntity = expandJsonLdEntity(entity, APIC_COMPOUND_CONTEXTS)
         val subscription = gimmeSubscriptionFromMembers(
             mapOf(
@@ -1058,7 +1058,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should return a subscription if entity matched a q query with a regular expression`() = runTest {
+    fun `getMatchingSubscriptions should match a q query with a regular expression`() = runTest {
         val expandedEntity = expandJsonLdEntity(entity, APIC_COMPOUND_CONTEXTS)
         val subscription = gimmeSubscriptionFromMembers(
             mapOf(
@@ -1076,7 +1076,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should return a subscription if entity matched a q query with a NOT EXISTS filter`() = runTest {
+    fun `getMatchingSubscriptions should match a q query with a NOT EXISTS filter`() = runTest {
         val expandedEntity = expandJsonLdEntity(entity, APIC_COMPOUND_CONTEXTS)
         val subscription = gimmeSubscriptionFromMembers(
             mapOf(
@@ -1094,7 +1094,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should not return a subscription if entity has the attribute excluded by a NOT EXISTS filter`() = runTest {
+    fun `getMatchingSubscriptions should not match when an attribute is excluded by a NOT EXISTS filter`() = runTest {
         val expandedEntity = expandJsonLdEntity(entity, APIC_COMPOUND_CONTEXTS)
         val subscription = gimmeSubscriptionFromMembers(
             mapOf(
@@ -1112,7 +1112,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should handle jsonKeys when matching subscriptions`() = runTest {
+    fun `getMatchingSubscriptions should handle jsonKeys when matching subscriptions`() = runTest {
         val subscription = gimmeSubscriptionFromMembers(
             mapOf(
                 "watchedAttributes" to listOf(NGSILD_LOCATION_TERM),
@@ -1146,7 +1146,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should handle expandValues when matching subscriptions`() = runTest {
+    fun `getMatchingSubscriptions should handle expandValues when matching subscriptions`() = runTest {
         val subscription = gimmeSubscriptionFromMembers(
             mapOf(
                 "watchedAttributes" to listOf(NGSILD_LOCATION_TERM),
@@ -1180,7 +1180,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should not return a subscription if throttling has not elapsed yet`() = runTest {
+    fun `getMatchingSubscriptions should not return a subscription if throttling has not elapsed yet`() = runTest {
         val expandedEntity = expandJsonLdEntity(entity, APIC_COMPOUND_CONTEXTS)
 
         val payload = mapOf(
@@ -1212,7 +1212,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should return a subscription if throttling has elapsed`() = runTest {
+    fun `getMatchingSubscriptions should return a subscription if throttling has elapsed`() = runTest {
         val expandedEntity = expandJsonLdEntity(entity, APIC_COMPOUND_CONTEXTS)
 
         val payload = mapOf(
@@ -1249,7 +1249,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should return a subscription if throttling is not null and last_notification is null`() = runTest {
+    fun `getMatchingSubscriptions should match when throttling is set and last_notification is null`() = runTest {
         val expandedEntity = expandJsonLdEntity(entity, APIC_COMPOUND_CONTEXTS)
 
         val payload = mapOf(
@@ -1275,7 +1275,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should not return a subscription if cooldown has not elapsed after a failure`() = runTest {
+    fun `getMatchingSubscriptions should not match when cooldown has not elapsed after a failure`() = runTest {
         val expandedEntity = expandJsonLdEntity(entity, APIC_COMPOUND_CONTEXTS)
 
         val payload = mapOf(
@@ -1309,7 +1309,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should return a subscription if cooldown has elapsed`() = runTest {
+    fun `getMatchingSubscriptions should return a subscription if cooldown has elapsed`() = runTest {
         val expandedEntity = expandJsonLdEntity(entity, APIC_COMPOUND_CONTEXTS)
 
         val payload = mapOf(
@@ -1348,7 +1348,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should return a subscription if cooldown is not null and last notification was not failed`() = runTest {
+    fun `getMatchingSubscriptions should match when cooldown is set and last notification did not fail`() = runTest {
         val expandedEntity = expandJsonLdEntity(entity, APIC_COMPOUND_CONTEXTS)
 
         val payload = mapOf(
@@ -1394,7 +1394,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
         "disjoint, Point, '[101.0, 0.0]', 1",
         "disjoint, Polygon, '[[[100.0, 0.0], [101.0, 0.0], [101.0, -1.0], [100.0, 0.0]]]', 0"
     )
-    fun `it shoud correctly matches the geoquery provided with a subscription`(
+    fun `getMatchingSubscriptions should correctly matches the geoquery provided with a subscription`(
         georel: String,
         geometry: String,
         coordinates: String,
@@ -1421,7 +1421,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should return all subscriptions whose 'timeInterval' is reached `() = runTest {
+    fun `getRecurringSubscriptionsToNotify should return subscriptions whose timeInterval is reached`() = runTest {
         val subscription = gimmeSubscriptionFromMembers(
             mapOf(
                 "entities" to listOf(mapOf("type" to BEEKEEPER_TERM)),
@@ -1452,7 +1452,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should return all subscriptions whose 'timeInterval' is reached with a time of 5s`() = runTest {
+    fun `getRecurringSubscriptionsToNotify should return subscriptions reached after a 5s delay`() = runTest {
         val subscription = gimmeSubscriptionFromMembers(
             mapOf(
                 "entities" to listOf(mapOf("type" to BEEKEEPER_TERM)),
@@ -1491,7 +1491,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should retrieve the JSON-LD contexts of subscription`() = runTest {
+    fun `getContextsForSubscription should retrieve the JSON-LD contexts of subscription`() = runTest {
         val subscription = loadAndDeserializeSubscription("subscription.jsonld")
         subscriptionService.upsert(subscription, mockUserSub).shouldSucceed()
 
@@ -1502,7 +1502,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `it should return a link to contexts endpoint if subscription has more than one context`() = runTest {
+    fun `getContextsLink should return a link when the subscription has more than one context`() = runTest {
         val subscription = loadAndDeserializeSubscription("subscription_minimal_entities.json").copy(
             contexts = APIC_COMPOUND_CONTEXTS.plus(NGSILD_TEST_CORE_CONTEXT)
         )

--- a/subscription-service/src/test/kotlin/com/egm/stellio/subscription/service/SubscriptionServiceTests.kt
+++ b/subscription-service/src/test/kotlin/com/egm/stellio/subscription/service/SubscriptionServiceTests.kt
@@ -219,7 +219,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `updateSubscriptionNotification should load a subscription with extra info on last notification`() = runTest {
+    fun `updateSubscriptionNotification should persist last notification info on the subscription`() = runTest {
         val subscription = gimmeSubscriptionFromMembers(
             mapOf(
                 "entities" to listOf(
@@ -250,7 +250,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `delete should delete an existing subscription`() = runTest {
+    fun `delete should remove an existing subscription`() = runTest {
         val subscription = loadAndDeserializeSubscription("subscription_minimal_entities.json")
         subscriptionService.upsert(subscription, mockUserSub).shouldSucceed()
 
@@ -1394,7 +1394,7 @@ class SubscriptionServiceTests : WithTimescaleContainer, WithKafkaContainer() {
         "disjoint, Point, '[101.0, 0.0]', 1",
         "disjoint, Polygon, '[[[100.0, 0.0], [101.0, 0.0], [101.0, -1.0], [100.0, 0.0]]]', 0"
     )
-    fun `getMatchingSubscriptions should correctly matches the geoquery provided with a subscription`(
+    fun `getMatchingSubscriptions should correctly match the geoquery provided with a subscription`(
         georel: String,
         geometry: String,
         coordinates: String,


### PR DESCRIPTION
  ## What

  Renames the test suite to a consistent naming convention and documents it, replacing
  the inconsistent mix of subject-less `it should …` names with names that state the
  unit under test.

  - **Unit / service / util tests** → `<functionUnderTest> should <behavior> [when <condition>]`
    (e.g. `mergeTemporalEntities should merge instances when datasetIds match`).
    The prefix is the literal Kotlin function, so tests are greppable from the production symbol.
  - **Controller / integration tests** → `<operation> should <result>`
    (e.g. `query temporal entity should return 400 if timerel is present without time`).

  The convention is codified in `.claude/rules/testing.md`; the old forms (`it should …`,
  `shouldn't`, names without `should`) are now banned "migrate on sight".

  ## Why

  Test names had drifted into several incompatible styles across modules (subject-less
  `it should …`, prose-prefixed, and a few function-prefixed), plus typos (`shoud`,
  `callSuscriber`) and a few names with no `should` clause at all. The function-prefixed
  form makes it trivial to jump from a production symbol to its tests and reads consistently.

  ## Scope

  - ~890 test renames across **67 test files** in all three modules
    (`subscription-service`, `shared`, `search-service`).
  - Fixes incidental typos surfaced along the way (`shoud`, `callSuscriber`, `simplfied`, `entiy`).
  - Where a long function prefix pushed a declaration past the 120-char Detekt limit, the
    predicate was tightened while preserving meaning.
  - Updated **7 Detekt baseline entries** whose keys referenced the old test-function names
    (otherwise previously-suppressed complexity/length findings resurface).

  No production code changes — tests only (plus the rules doc and baselines).

  ## Verification

  - `./gradlew :shared:test` and `./gradlew :search-service:test` pass in full.
  - `subscription-service` compiles and all non-container tests pass.
  - `detekt` is green on all three modules.
  - Repo-wide check: zero `it should …` / `shouldn't` / no-`should` test names remain.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)
