### PR TITLE
refactor: rewrite entity attribute write path to improve performance

### DIFF
--- a/.claude/rules/kotlin-spring.md
+++ b/.claude/rules/kotlin-spring.md
@@ -8,6 +8,19 @@
 - Imports: Grouped and sorted (Kotlin stdlib first, then Java)
 - Detekt: All code must pass Detekt; suppress only with documented rationale and update module baseline
 
+## Comments
+
+- Default to no comments. Add one only when it captures a non-obvious WHY (a hidden constraint, an
+  invariant, a workaround) that a future reader could not derive from the code itself.
+- Cap comments at ~5 lines. Do not narrate design deliberation — alternatives considered and rejected,
+  benchmark numbers, the history of how a bug was found — in code; that belongs in the PR description
+  or an ADR, not inline.
+- If the same invariant applies to multiple call sites (e.g. a concurrency-safety pattern reused
+  across several SQL statements), explain it once at the primary site and reference it from the others
+  with a short pointer (e.g., `// see EntityService.patchEntityPayload`) instead of restating it.
+- Never reference a file not committed to the repository (a local plan/notes/scratch doc) — the
+  comment must be self-contained for whoever reads it later.
+
 ## Naming Conventions
 
 - Packages: `lowercase.with.dots` (e.g., `com.egm.stellio.search`)

--- a/search-service/src/main/kotlin/com/egm/stellio/search/entity/model/UpdateResult.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/entity/model/UpdateResult.kt
@@ -4,6 +4,8 @@ import com.egm.stellio.shared.model.EXPANDED_ENTITY_CORE_MEMBERS
 import com.egm.stellio.shared.model.ExpandedAttributeInstance
 import com.fasterxml.jackson.annotation.JsonIgnore
 import java.net.URI
+import java.time.ZonedDateTime
+import java.util.UUID
 
 /**
  * UpdateResult datatype as defined in 5.2.18
@@ -83,6 +85,17 @@ enum class OperationStatus {
 fun List<AttributeOperationResult>.hasSuccessfulResult(): Boolean =
     this.any { it is SucceededAttributeOperationResult }
 
-fun List<AttributeOperationResult>.getSucceededAttributesOperations(): List<SucceededAttributeOperationResult> =
+fun List<AttributeOperationResult>.getSucceededOperations(
+    onlyAttributes: Boolean = true
+): List<SucceededAttributeOperationResult> =
     this.filterIsInstance<SucceededAttributeOperationResult>()
-        .filter { it.attributeName !in EXPANDED_ENTITY_CORE_MEMBERS }
+        .let {
+            if (onlyAttributes)
+                it.filter { result -> result.attributeName !in EXPANDED_ENTITY_CORE_MEMBERS }
+            else it
+        }
+
+/**
+ * Result of an attribute upsert conveying the DB-generated UUID and timestamps to use when updating the entity payload
+ */
+internal data class AttributeUpsertResult(val id: UUID, val createdAt: ZonedDateTime, val modifiedAt: ZonedDateTime)

--- a/search-service/src/main/kotlin/com/egm/stellio/search/entity/service/EntityAttributeService.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/entity/service/EntityAttributeService.kt
@@ -22,6 +22,7 @@ import com.egm.stellio.search.common.util.toZonedDateTime
 import com.egm.stellio.search.entity.model.Attribute
 import com.egm.stellio.search.entity.model.AttributeMetadata
 import com.egm.stellio.search.entity.model.AttributeOperationResult
+import com.egm.stellio.search.entity.model.AttributeUpsertResult
 import com.egm.stellio.search.entity.model.FailedAttributeOperationResult
 import com.egm.stellio.search.entity.model.OperationStatus
 import com.egm.stellio.search.entity.model.SucceededAttributeOperationResult
@@ -104,7 +105,7 @@ class EntityAttributeService(
      * Called when doing a creation or replacement of an attribute.
      */
     @Transactional
-    suspend fun upsert(attribute: Attribute): Either<APIException, UUID> =
+    internal suspend fun upsert(attribute: Attribute): Either<APIException, AttributeUpsertResult> =
         databaseClient.sql(
             """
             INSERT INTO temporal_entity_attribute
@@ -120,7 +121,7 @@ class EntityAttributeService(
                     modified_at = :created_at,
                     expires_at = :expires_at,
                     payload = :payload
-            RETURNING id
+            RETURNING id, created_at, modified_at
             """.trimIndent()
         )
             .bind("id", attribute.id)
@@ -132,7 +133,13 @@ class EntityAttributeService(
             .bind("dataset_id", attribute.datasetId)
             .bind("expires_at", attribute.expiresAt)
             .bind("payload", attribute.payload)
-            .oneToResult { row -> toUuid(row["id"]) }
+            .oneToResult { row ->
+                AttributeUpsertResult(
+                    toUuid(row["id"]),
+                    toZonedDateTime(row["created_at"]),
+                    toZonedDateTime(row["modified_at"])
+                )
+            }
 
     /**
      * Called when doing a merge (5.5.12) or partial update patch (5.5.8) operation over an attribute.
@@ -235,7 +242,7 @@ class EntityAttributeService(
             expiresAt = attributeMetadata.expiresAt,
             payload = Json.of(serializeObject(attributePayload))
         )
-        val attributeUuid = upsert(attribute).bind()
+        val attributeUpdateResult = upsert(attribute).bind()
 
         val (timeProperty, operationStatus) =
             if (existedPreviously)
@@ -244,7 +251,7 @@ class EntityAttributeService(
                 AttributeInstance.TemporalProperty.CREATED_AT to OperationStatus.CREATED
 
         val attributeInstance = AttributeInstance(
-            attributeUuid = attributeUuid,
+            attributeUuid = attributeUpdateResult.id,
             timeProperty = timeProperty,
             time = createdAt,
             attributeMetadata = attributeMetadata,
@@ -255,7 +262,7 @@ class EntityAttributeService(
 
         if (attributeMetadata.observedAt != null) {
             val attributeObservedAtInstance = AttributeInstance(
-                attributeUuid = attributeUuid,
+                attributeUuid = attributeUpdateResult.id,
                 time = attributeMetadata.observedAt,
                 attributeMetadata = attributeMetadata,
                 payload = attributePayload
@@ -267,7 +274,7 @@ class EntityAttributeService(
             attributeName,
             attributeMetadata.datasetId,
             operationStatus,
-            attributePayload
+            attributePayload.addSysAttrs(attributeUpdateResult.createdAt, attributeUpdateResult.modifiedAt)
         )
     }
 
@@ -305,7 +312,7 @@ class EntityAttributeService(
                     attribute.attributeName,
                     attributeMetadata.datasetId,
                     OperationStatus.UPDATED,
-                    attributePayload
+                    updatedAttributeInstance.addSysAttrs(attribute.createdAt, mergedAt)
                 )
             }.bind()
     }
@@ -394,7 +401,6 @@ class EntityAttributeService(
                 attribute.datasetId,
                 OperationStatus.DELETED,
                 expandedAttributeInstance.addSysAttrs(
-                    true,
                     teaTimestamps.first,
                     teaTimestamps.second,
                     teaTimestamps.third
@@ -802,7 +808,7 @@ class EntityAttributeService(
             attribute.attributeName,
             attribute.datasetId,
             OperationStatus.UPDATED,
-            updatedAttributeInstance
+            updatedAttributeInstance.addSysAttrs(attribute.createdAt, modifiedAt)
         )
     }
 
@@ -812,7 +818,7 @@ class EntityAttributeService(
         ngsiLdAttribute: NgsiLdAttribute,
         expandedAttributes: ExpandedAttributes,
         createdAt: ZonedDateTime
-    ): Either<APIException, Unit> = either {
+    ): Either<APIException, SucceededAttributeOperationResult?> = either {
         val ngsiLdAttributeInstance = ngsiLdAttribute.getAttributeInstances()[0]
         logger.debug("Upserting temporal attribute {} in entity {}", ngsiLdAttribute.name, entityUri)
         val currentAttribute =
@@ -845,6 +851,7 @@ class EntityAttributeService(
                 attributeMetadata,
                 expandedAttributes[currentAttribute.attributeName]!!.first()
             ).bind()
+            null
         }
     }
 
@@ -880,14 +887,7 @@ class EntityAttributeService(
                     createdAt,
                     attributePayload,
                     false
-                ).map {
-                    SucceededAttributeOperationResult(
-                        ngsiLdAttribute.name,
-                        ngsiLdAttributeInstance.datasetId,
-                        OperationStatus.CREATED,
-                        attributePayload
-                    )
-                }.bind()
+                ).bind()
             else if (isNull)
                 deleteAttribute(
                     entityUri,
@@ -938,13 +938,6 @@ class EntityAttributeService(
                     expandedAttribute.second.first(),
                     true
                 ).bind()
-
-                SucceededAttributeOperationResult(
-                    ngsiLdAttribute.name,
-                    ngsiLdAttributeInstance.datasetId,
-                    OperationStatus.UPDATED,
-                    expandedAttribute.second.first()
-                )
             }
 
         attributeOperationResult

--- a/search-service/src/main/kotlin/com/egm/stellio/search/entity/service/EntityService.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/entity/service/EntityService.kt
@@ -1,20 +1,21 @@
 package com.egm.stellio.search.entity.service
 
 import arrow.core.Either
-import arrow.core.flatMap
 import arrow.core.getOrElse
 import arrow.core.left
 import arrow.core.raise.either
+import arrow.core.raise.ensure
 import arrow.core.right
 import com.egm.stellio.search.authorization.permission.model.Action
 import com.egm.stellio.search.authorization.permission.model.getSpecificAccessPolicy
 import com.egm.stellio.search.authorization.permission.service.AuthorizationService
-import com.egm.stellio.search.common.util.deserializeAsMap
 import com.egm.stellio.search.common.util.deserializeExpandedPayload
 import com.egm.stellio.search.common.util.execute
+import com.egm.stellio.search.common.util.executeExpected
 import com.egm.stellio.search.common.util.oneToResult
+import com.egm.stellio.search.common.util.toJson
+import com.egm.stellio.search.common.util.toList
 import com.egm.stellio.search.common.util.toZonedDateTime
-import com.egm.stellio.search.entity.model.Attribute
 import com.egm.stellio.search.entity.model.AttributeOperationResult
 import com.egm.stellio.search.entity.model.EntitiesQueryFromGet
 import com.egm.stellio.search.entity.model.Entity
@@ -27,7 +28,7 @@ import com.egm.stellio.search.entity.model.OperationType.MERGE_ENTITY
 import com.egm.stellio.search.entity.model.OperationType.UPDATE_ATTRIBUTES
 import com.egm.stellio.search.entity.model.SucceededAttributeOperationResult
 import com.egm.stellio.search.entity.model.UpdateResult
-import com.egm.stellio.search.entity.model.getSucceededAttributesOperations
+import com.egm.stellio.search.entity.model.getSucceededOperations
 import com.egm.stellio.search.entity.model.hasSuccessfulResult
 import com.egm.stellio.search.entity.util.prepareAttributes
 import com.egm.stellio.search.entity.util.rowToEntity
@@ -37,6 +38,8 @@ import com.egm.stellio.search.scope.ScopeService
 import com.egm.stellio.search.temporal.model.AttributeInstance.TemporalProperty
 import com.egm.stellio.shared.model.APIException
 import com.egm.stellio.shared.model.AlreadyExistsException
+import com.egm.stellio.shared.model.BadRequestDataException
+import com.egm.stellio.shared.model.EXPANDED_ENTITY_CORE_MEMBERS
 import com.egm.stellio.shared.model.EXPANDED_ENTITY_SPECIFIC_MEMBERS
 import com.egm.stellio.shared.model.ExpandedAttribute
 import com.egm.stellio.shared.model.ExpandedAttributeInstance
@@ -45,15 +48,21 @@ import com.egm.stellio.shared.model.ExpandedAttributes
 import com.egm.stellio.shared.model.ExpandedEntity
 import com.egm.stellio.shared.model.ExpandedTerm
 import com.egm.stellio.shared.model.JSONLD_ID_KW
+import com.egm.stellio.shared.model.JSONLD_NONE_KW
 import com.egm.stellio.shared.model.JSONLD_TYPE_KW
+import com.egm.stellio.shared.model.NGSILD_DATASET_ID_IRI
+import com.egm.stellio.shared.model.NGSILD_MODIFIED_AT_IRI
 import com.egm.stellio.shared.model.NGSILD_SCOPE_IRI
 import com.egm.stellio.shared.model.NgsiLdEntity
-import com.egm.stellio.shared.model.addSysAttrs
+import com.egm.stellio.shared.model.ResourceNotFoundException
 import com.egm.stellio.shared.model.flattenOnAttributeAndDatasetId
 import com.egm.stellio.shared.model.toAPIException
 import com.egm.stellio.shared.model.toNgsiLdAttributes
 import com.egm.stellio.shared.queryparameter.PaginationQuery
+import com.egm.stellio.shared.util.ErrorMessages.DbQuery.OPERATION_NO_RESULT_MESSAGE
 import com.egm.stellio.shared.util.ErrorMessages.Entity.entityAlreadyExistsMessage
+import com.egm.stellio.shared.util.ErrorMessages.Scope.SCOPE_NOT_A_TARGET_ATTRIBUTE_MESSAGE
+import com.egm.stellio.shared.util.JsonLdUtils.buildNonReifiedTemporalValue
 import com.egm.stellio.shared.util.JsonUtils.serializeObject
 import com.egm.stellio.shared.util.getSubFromSecurityContext
 import com.egm.stellio.shared.util.ngsiLdDateTime
@@ -131,7 +140,7 @@ class EntityService(
                 sub,
                 ExpandedEntity(emptyMap()),
                 expandedEntityWithMetadata,
-                attrsOperationResult.getSucceededAttributesOperations()
+                attrsOperationResult.getSucceededOperations()
             )
         }
     }.fold(
@@ -258,7 +267,7 @@ class EntityService(
         scopeService.replace(ngsiLdEntity, replacedAt).bind()
 
         val operationResult = deleteOperationResults.plus(createOrReplaceOperationResult)
-        operationResult.getSucceededAttributesOperations()
+        operationResult.getSucceededOperations()
             .forEach {
                 val sub = getSubFromSecurityContext()
                 if (it.operationStatus == OperationStatus.DELETED)
@@ -344,41 +353,42 @@ class EntityService(
     suspend fun updateTypes(
         entityId: URI,
         newTypes: List<ExpandedTerm>,
-        modifiedAt: ZonedDateTime,
-        allowEmptyListOfTypes: Boolean = true
+        modifiedAt: ZonedDateTime
     ): Either<APIException, SucceededAttributeOperationResult> = either {
-        val entityPayload = entityQueryService.retrieve(entityId).bind()
-        val currentTypes = entityPayload.types
-        // when dealing with an entity update, list of types can be empty if no change of type is requested
-        if (currentTypes.sorted() == newTypes.sorted() || newTypes.isEmpty() && allowEmptyListOfTypes)
-            return@either SucceededAttributeOperationResult(
-                attributeName = JSONLD_TYPE_KW,
-                operationStatus = OperationStatus.CREATED,
-                newExpandedValue = mapOf(JSONLD_TYPE_KW to currentTypes.toList())
-            )
-
-        val updatedTypes = currentTypes.union(newTypes)
-        val updatedPayload = entityPayload.payload.deserializeAsMap().plus(JSONLD_TYPE_KW to updatedTypes)
-
         databaseClient.sql(
             """
+            WITH new_types AS (
+                SELECT COALESCE(
+                    (
+                        SELECT array_agg(new_type ORDER BY ordinality)
+                        FROM unnest(:new_types::text[]) WITH ORDINALITY AS u(new_type, ordinality)
+                        WHERE new_type <> ALL(ep.types)
+                    ),
+                    '{}'::text[]
+                ) AS to_add
+                FROM entity_payload ep
+                WHERE ep.entity_id = :entity_id
+            )
             UPDATE entity_payload
-            SET types = :types,
+            SET types = entity_payload.types || new_types.to_add,
                 modified_at = :modified_at,
-                payload = :payload
-            WHERE entity_id = :entity_id
+                payload = entity_payload.payload || jsonb_build_object(
+                    '@type',
+                    to_jsonb(entity_payload.types || new_types.to_add)
+                )
+            FROM new_types
+            WHERE entity_payload.entity_id = :entity_id
+            RETURNING types
             """.trimIndent()
         )
             .bind("entity_id", entityId)
             .bind("modified_at", modifiedAt)
-            .bind("types", updatedTypes.toTypedArray())
-            .bind("payload", Json.of(serializeObject(updatedPayload)))
-            .execute()
-            .map {
+            .bind("new_types", newTypes.distinct().toTypedArray())
+            .oneToResult { row ->
                 SucceededAttributeOperationResult(
                     attributeName = JSONLD_TYPE_KW,
                     operationStatus = OperationStatus.CREATED,
-                    newExpandedValue = mapOf(JSONLD_TYPE_KW to updatedTypes.toList())
+                    newExpandedValue = mapOf(JSONLD_TYPE_KW to toList<ExpandedTerm>(row["types"]))
                 )
             }.bind()
     }
@@ -447,6 +457,10 @@ class EntityService(
         entityId: URI,
         expandedAttribute: ExpandedAttribute
     ): Either<APIException, UpdateResult> = either {
+        // 5.6.4.4: scope cannot be the target of a Partial Attribute update
+        ensure(expandedAttribute.first != NGSILD_SCOPE_IRI) {
+            BadRequestDataException(SCOPE_NOT_A_TARGET_ATTRIBUTE_MESSAGE)
+        }
         entityQueryService.checkEntityExistence(entityId).bind()
         authorizationService.userCanUpdateEntity(entityId).bind()
 
@@ -485,7 +499,7 @@ class EntityService(
         ).bind()
 
         if (operationResult.isNotEmpty()) {
-            val updatedEntity = updateState(entityId, mergedAt, entityAttributeService.getAllForEntity(entityId)).bind()
+            val updatedEntity = patchEntityPayload(entityId, mergedAt, operationResult).bind()
             entityEventService.publishAttributeChangeEvents(null, originalEntity, updatedEntity, operationResult)
         }
 
@@ -498,8 +512,9 @@ class EntityService(
         expandedAttributes: ExpandedAttributes
     ): Either<APIException, Unit> = either {
         val createdAt = ngsiLdDateTime()
-        expandedAttributes.forEach { (attributeName, expandedAttributeInstances) ->
-            expandedAttributeInstances.forEach { expandedAttributeInstance ->
+
+        val operationResults = expandedAttributes.flatMap { (attributeName, expandedAttributeInstances) ->
+            expandedAttributeInstances.map { expandedAttributeInstance ->
                 val jsonLdAttribute = mapOf(attributeName to listOf(expandedAttributeInstance))
                 val ngsiLdAttribute = jsonLdAttribute.toNgsiLdAttributes().bind()[0]
 
@@ -510,12 +525,11 @@ class EntityService(
                     createdAt
                 ).bind()
             }
-        }
-        updateState(
-            entityId,
-            createdAt,
-            entityAttributeService.getAllForEntity(entityId)
-        ).bind()
+        }.filterNotNull()
+
+        // if only added history entries, operationResults is empty and nothing more has to be done
+        if (operationResults.isNotEmpty())
+            patchEntityPayload(entityId, createdAt, operationResults).bind()
     }
 
     @Transactional
@@ -523,6 +537,10 @@ class EntityService(
         entityId: URI,
         expandedAttribute: ExpandedAttribute
     ): Either<APIException, UpdateResult> = either {
+        // 5.6.19.4: scope cannot be the target of a Replace Attribute
+        ensure(expandedAttribute.first != NGSILD_SCOPE_IRI) {
+            BadRequestDataException(SCOPE_NOT_A_TARGET_ATTRIBUTE_MESSAGE)
+        }
         entityQueryService.checkEntityExistence(entityId).bind()
         authorizationService.userCanUpdateEntity(entityId).bind()
 
@@ -549,65 +567,21 @@ class EntityService(
         operationResult: List<AttributeOperationResult>,
         createdAt: ZonedDateTime
     ): Either<APIException, Unit> = either {
-        // update modifiedAt in entity if at least one attribute has been added
         if (operationResult.hasSuccessfulResult()) {
             val sub = getSubFromSecurityContext()
-            val attributes = entityAttributeService.getAllForEntity(entityId)
-            val updatedEntity = updateState(entityId, createdAt, attributes).bind()
+            val updatedEntity = patchEntityPayload(
+                entityId,
+                createdAt,
+                operationResult.getSucceededOperations(false)
+            ).bind()
 
             entityEventService.publishAttributeChangeEvents(
                 sub,
                 originalEntity,
                 updatedEntity,
-                operationResult.getSucceededAttributesOperations()
+                operationResult.getSucceededOperations()
             )
         }
-    }
-
-    @Transactional
-    suspend fun updateState(
-        entityUri: URI,
-        modifiedAt: ZonedDateTime,
-        attributes: List<Attribute>
-    ): Either<APIException, ExpandedEntity> =
-        entityQueryService.retrieve(entityUri)
-            .flatMap { entityPayload ->
-                val payload = buildJsonLdEntity(
-                    attributes,
-                    entityPayload.copy(modifiedAt = modifiedAt)
-                )
-                databaseClient.sql(
-                    """
-                    UPDATE entity_payload
-                    SET modified_at = :modified_at,
-                        payload = :payload
-                    WHERE entity_id = :entity_id
-                    """.trimIndent()
-                )
-                    .bind("entity_id", entityUri)
-                    .bind("modified_at", modifiedAt)
-                    .bind("payload", Json.of(serializeObject(payload)))
-                    .execute()
-                    .map { ExpandedEntity(payload) }
-            }
-
-    private fun buildJsonLdEntity(
-        attributes: List<Attribute>,
-        entity: Entity
-    ): Map<String, Any> {
-        val entityCoreAttributes = entity.serializeProperties()
-        val expandedAttributes = attributes
-            .groupBy { attribute ->
-                attribute.attributeName
-            }
-            .mapValues { (_, attributes) ->
-                attributes.map { attribute ->
-                    attribute.payload.deserializeExpandedPayload()
-                        .addSysAttrs(withSysAttrs = true, attribute.createdAt, attribute.modifiedAt)
-                }
-            }
-
-        return entityCoreAttributes.plus(expandedAttributes)
     }
 
     @Transactional
@@ -632,7 +606,7 @@ class EntityService(
                 sub,
                 currentEntity.toExpandedEntity(),
                 deletedEntityPayload,
-                deleteOperationResult.getSucceededAttributesOperations()
+                deleteOperationResult.getSucceededOperations()
             )
             entityEventService.publishEntityDeleteEvent(sub, previousEntity, deletedEntityPayload)
         }
@@ -723,6 +697,7 @@ class EntityService(
 
         val originalEntity = entityQueryService.retrieve(entityId).bind().toExpandedEntity()
 
+        val deletedAt = ngsiLdDateTime()
         val deleteAttributeResults = if (attributeName == NGSILD_SCOPE_IRI) {
             scopeService.delete(entityId).bind()
         } else {
@@ -737,16 +712,16 @@ class EntityService(
                 attributeName,
                 datasetId,
                 deleteAll,
-                ngsiLdDateTime()
+                deletedAt
             ).bind()
         }
-        val updatedEntity = updateState(
+        val updatedEntity = patchEntityPayload(
             entityId,
-            ngsiLdDateTime(),
-            entityAttributeService.getAllForEntity(entityId)
+            deletedAt,
+            deleteAttributeResults.getSucceededOperations(false)
         ).bind()
 
-        deleteAttributeResults.getSucceededAttributesOperations()
+        deleteAttributeResults.getSucceededOperations()
             .forEach {
                 entityEventService.publishAttributeDeleteEvent(sub, originalEntity, updatedEntity, it)
             }
@@ -848,9 +823,10 @@ class EntityService(
         deleteAll: Boolean = false
     ): Either<APIException, Unit> = either {
         authorizationService.userCanUpdateEntity(entityId).bind()
+        val modifiedAt = ngsiLdDateTime()
 
         if (attributeName == NGSILD_SCOPE_IRI) {
-            scopeService.permanentlyDelete(entityId).bind()
+            scopeService.permanentlyDelete(entityId, modifiedAt).bind()
         } else {
             entityAttributeService.checkEntityAndAttributeExistence(
                 entityId,
@@ -859,17 +835,152 @@ class EntityService(
                 anyAttributeInstance = deleteAll,
                 excludeDeleted = false
             ).bind()
-            entityAttributeService.permanentlyDeleteAttribute(
-                entityId,
-                attributeName,
-                datasetId,
-                deleteAll
-            ).bind()
+
+            if (deleteAll) {
+                entityAttributeService.permanentlyDeleteAttribute(entityId, attributeName, datasetId, true).bind()
+                removeAttributeFromPayload(entityId, modifiedAt, attributeName).bind()
+            } else {
+                entityAttributeService.permanentlyDeleteAttribute(entityId, attributeName, datasetId, false).bind()
+                patchEntityPayload(
+                    entityId,
+                    modifiedAt,
+                    listOf(
+                        SucceededAttributeOperationResult(
+                            attributeName = attributeName,
+                            datasetId = datasetId,
+                            operationStatus = OperationStatus.DELETED,
+                            newExpandedValue = emptyMap()
+                        )
+                    )
+                ).bind()
+            }
         }
-        updateState(
-            entityId,
-            ngsiLdDateTime(),
-            entityAttributeService.getAllForEntity(entityId)
-        ).bind()
     }
+
+    private suspend fun patchEntityPayload(
+        entityId: URI,
+        modifiedAt: ZonedDateTime,
+        operationResults: List<SucceededAttributeOperationResult>
+    ): Either<APIException, ExpandedEntity> = either {
+        val modifiedAtPatch = Json.of(
+            serializeObject(mapOf(NGSILD_MODIFIED_AT_IRI to buildNonReifiedTemporalValue(modifiedAt)))
+        )
+        // Any core member (type, scope) change has already been persisted by updateCoreAttributes
+        val attributesByNames = operationResults
+            .filter { it.attributeName !in EXPANDED_ENTITY_CORE_MEMBERS }
+            .groupBy { it.attributeName }
+
+        val updatedPayload = mergeAttributesIntoPayload(entityId, attributesByNames, modifiedAt, modifiedAtPatch).bind()
+        ExpandedEntity(updatedPayload.deserializeExpandedPayload())
+    }
+
+    // For every distinct attribute touched by the operation, keeps that attribute's untouched instances,
+    // drops the touched ones, and appends the new/updated ones, all in a single UPDATE.
+    private suspend fun mergeAttributesIntoPayload(
+        entityId: URI,
+        attributesByNames: Map<ExpandedTerm, List<SucceededAttributeOperationResult>>,
+        modifiedAt: ZonedDateTime,
+        modifiedAtPatch: Json
+    ): Either<APIException, Json> {
+        val batch = attributesByNames.map { (attrName, results) -> buildMergeBatchEntry(attrName, results) }
+        // computes the merged (kept + new) instance array for each attribute
+        // used twice below:
+        //   - once to find attribute names whose merged array is now empty (to remove from payload)
+        //   - once for the others (to set on payload)
+        val mergedInstancesPerAttribute = """
+            SELECT
+                item ->> 'attrName' AS attr_name,
+                COALESCE(
+                    (
+                        SELECT jsonb_agg(elem)
+                        FROM jsonb_array_elements(
+                            COALESCE(payload -> (item ->> 'attrName'), '[]'::jsonb)
+                        ) AS elem
+                        WHERE COALESCE(
+                            elem #>> '{$NGSILD_DATASET_ID_IRI,0,$JSONLD_ID_KW}', '$JSONLD_NONE_KW'
+                        ) <> ALL (ARRAY(SELECT jsonb_array_elements_text(item -> 'excludedDatasetIds')))
+                    ),
+                    '[]'::jsonb
+                ) || COALESCE(item -> 'newInstances', '[]'::jsonb) AS merged_instances
+            FROM jsonb_array_elements(:batch::jsonb) AS item
+        """.trimIndent()
+
+        return databaseClient.sql(
+            """
+            UPDATE entity_payload
+            SET modified_at = :modified_at,
+                payload = (
+                    (
+                        payload - COALESCE(
+                            (
+                                SELECT array_agg(g.attr_name)
+                                FROM ($mergedInstancesPerAttribute) AS g
+                                WHERE g.merged_instances = '[]'::jsonb
+                            ),
+                            '{}'::text[]
+                        )
+                    )
+                    || COALESCE(
+                        (
+                            SELECT jsonb_object_agg(g.attr_name, g.merged_instances)
+                            FROM ($mergedInstancesPerAttribute) AS g
+                            WHERE g.merged_instances <> '[]'::jsonb
+                        ),
+                        '{}'::jsonb
+                    )
+                    || :modified_at_patch::jsonb
+                )
+            WHERE entity_id = :entity_id
+            RETURNING payload
+            """.trimIndent()
+        )
+            .bind("entity_id", entityId)
+            .bind("modified_at", modifiedAt)
+            .bind("batch", Json.of(serializeObject(batch)))
+            .bind("modified_at_patch", modifiedAtPatch)
+            .oneToResult { toJson(it["payload"]) }
+    }
+
+    // One entry for a given attribute name: the datasetIds whose existing instances must not be kept
+    // from the live payload (deleted or replaced by this operation), and the new/updated instances to append.
+    private fun buildMergeBatchEntry(
+        attrName: ExpandedTerm,
+        results: List<SucceededAttributeOperationResult>
+    ): Map<String, Any> {
+        val deletedDatasetIds = results
+            .filter { it.operationStatus == OperationStatus.DELETED }
+            .map { it.datasetId }
+        val upsertedResults = results.filter { it.operationStatus != OperationStatus.DELETED }
+        val excludedDatasetIds = (deletedDatasetIds + upsertedResults.map { it.datasetId })
+            .map { it?.toString() ?: JSONLD_NONE_KW }
+        return mapOf(
+            "attrName" to attrName,
+            "excludedDatasetIds" to excludedDatasetIds,
+            "newInstances" to upsertedResults.map { it.newExpandedValue }
+        )
+    }
+
+    // Only used for permanent deletion of an attribute (just drop the attribute from the entity payload)
+    private suspend fun removeAttributeFromPayload(
+        entityId: URI,
+        modifiedAt: ZonedDateTime,
+        attributeName: ExpandedTerm
+    ): Either<APIException, Unit> = either {
+        databaseClient.sql(
+            """
+            UPDATE entity_payload
+            SET modified_at = :modified_at,
+                payload = payload - :attribute_name::text
+            WHERE entity_id = :entity_id
+            """.trimIndent()
+        )
+            .bind("entity_id", entityId)
+            .bind("modified_at", modifiedAt)
+            .bind("attribute_name", attributeName)
+            .executeExpected { notFoundIfNoRowsUpdated(it) }
+            .bind()
+    }
+
+    private fun notFoundIfNoRowsUpdated(rowsUpdated: Long): Either<APIException, Unit> =
+        if (rowsUpdated == 0L) ResourceNotFoundException(OPERATION_NO_RESULT_MESSAGE).left() else Unit.right()
 }

--- a/search-service/src/main/kotlin/com/egm/stellio/search/scope/ScopeService.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/scope/ScopeService.kt
@@ -7,10 +7,8 @@ import arrow.core.right
 import com.egm.stellio.search.authorization.permission.service.AuthorizationService
 import com.egm.stellio.search.common.config.SearchProperties
 import com.egm.stellio.search.common.util.allToMappedList
-import com.egm.stellio.search.common.util.deserializeExpandedPayload
 import com.egm.stellio.search.common.util.execute
 import com.egm.stellio.search.common.util.oneToResult
-import com.egm.stellio.search.common.util.toJson
 import com.egm.stellio.search.common.util.toList
 import com.egm.stellio.search.common.util.toOptionalList
 import com.egm.stellio.search.common.util.toOptionalZonedDateTime
@@ -94,21 +92,16 @@ class ScopeService(
             .execute()
 
     @Transactional
-    suspend fun retrieve(entityId: URI): Either<APIException, Pair<List<String>?, Json>> =
+    suspend fun retrieve(entityId: URI): Either<APIException, List<String>?> =
         databaseClient.sql(
             """
-            SELECT scopes, payload
+            SELECT scopes
             FROM entity_payload
             WHERE entity_id = :entity_id
             """.trimIndent()
         )
             .bind("entity_id", entityId)
-            .oneToResult {
-                Pair(
-                    toOptionalList(it["scopes"]),
-                    toJson(it["payload"]),
-                )
-            }
+            .oneToResult { toOptionalList(it["scopes"]) }
 
     suspend fun retrieveHistory(
         entitiesIds: List<URI>,
@@ -207,13 +200,6 @@ class ScopeService(
             .oneToResult { toOptionalZonedDateTime(it["first"]) }
             .getOrNull()
 
-    private fun Json.replaceScopeValue(newScopeValue: Any): Map<String, Any> =
-        this.deserializeExpandedPayload()
-            .mapValues {
-                if (it.key == NGSILD_SCOPE_IRI) newScopeValue
-                else it.value
-            }
-
     private fun rowToScopeInstanceResult(
         row: Map<String, Any>,
         temporalEntitiesQuery: TemporalEntitiesQuery
@@ -261,83 +247,121 @@ class ScopeService(
         modifiedAt: ZonedDateTime,
         operationType: OperationType
     ): Either<APIException, AttributeOperationResult> = either {
-        val scopes = mapOf(NGSILD_SCOPE_IRI to expandedAttributeInstances).getScopes()!!
-        val (currentScopes, currentPayload) = retrieve(entityId).bind()
+        val scopes = mapOf(NGSILD_SCOPE_IRI to expandedAttributeInstances).getScopes()!!.distinct()
+        val currentScopes = retrieve(entityId).bind()
 
-        val (updatedScopes, updatedPayload) = when (operationType) {
-            OperationType.UPDATE_ATTRIBUTES -> {
-                if (currentScopes != null) {
-                    val updatedPayload = currentPayload.replaceScopeValue(expandedAttributeInstances)
-                    Pair(scopes, updatedPayload)
-                } else return@either FailedAttributeOperationResult(
-                    attributeName = NGSILD_SCOPE_IRI,
-                    operationStatus = OperationStatus.FAILED,
-                    errorMessage = SCOPE_DOES_NOT_EXIST_MESSAGE
-                )
-            }
-            OperationType.APPEND_ATTRIBUTES, OperationType.MERGE_ENTITY -> {
-                val newScopes = (currentScopes ?: emptyList()).toSet().plus(scopes).toList()
-                val newPayload = newScopes.map { mapOf(JSONLD_VALUE_KW to it) }
-                val updatedPayload = currentPayload.replaceScopeValue(newPayload)
-                Pair(newScopes, updatedPayload)
-            }
+        if (operationType == OperationType.UPDATE_ATTRIBUTES && currentScopes == null)
+            return@either FailedAttributeOperationResult(
+                attributeName = NGSILD_SCOPE_IRI,
+                operationStatus = OperationStatus.FAILED,
+                errorMessage = SCOPE_DOES_NOT_EXIST_MESSAGE
+            )
+
+        val (updatedScopes, operationResult) = when (operationType) {
+            OperationType.UPDATE_ATTRIBUTES,
             OperationType.APPEND_ATTRIBUTES_OVERWRITE_ALLOWED,
-            OperationType.MERGE_ENTITY_OVERWRITE_ALLOWED,
-            OperationType.PARTIAL_ATTRIBUTE_UPDATE,
-            OperationType.REPLACE_ATTRIBUTE -> {
-                val updatedPayload = currentPayload.replaceScopeValue(expandedAttributeInstances)
-                Pair(scopes, updatedPayload)
-            }
-            else -> Pair(null, Json.of("{}"))
+            OperationType.MERGE_ENTITY_OVERWRITE_ALLOWED ->
+                Pair(scopes, performReplace(entityId, scopes, modifiedAt, expandedAttributeInstances).bind())
+            OperationType.APPEND_ATTRIBUTES, OperationType.MERGE_ENTITY ->
+                performAppend(entityId, scopes, modifiedAt).bind()
+            else -> return@either FailedAttributeOperationResult(
+                attributeName = NGSILD_SCOPE_IRI,
+                operationStatus = OperationStatus.FAILED,
+                errorMessage = unrecognizedOperationTypeMessage(operationType.toString())
+            )
         }
 
-        updatedScopes?.let {
-            val operationResult =
-                performUpdate(entityId, updatedScopes, modifiedAt, serializeObject(updatedPayload)).bind()
-            val temporalPropertyToAdd =
-                if (currentScopes == null) TemporalProperty.CREATED_AT
-                else TemporalProperty.MODIFIED_AT
-            addHistoryEntry(entityId, it, temporalPropertyToAdd, modifiedAt).bind()
-            if (temporalPropertyToAdd == TemporalProperty.MODIFIED_AT)
-                // as stated in 4.5.6: In case the Temporal Representation of the Scope is updated as the result of a
-                // change from the Core API, the observedAt sub-Property should be set as a copy of the modifiedAt
-                // sub-Property
-                addHistoryEntry(entityId, it, TemporalProperty.OBSERVED_AT, modifiedAt).bind()
-            authorizationService.createScopesOwnerRights(it).bind()
-            operationResult
-        } ?: FailedAttributeOperationResult(
-            attributeName = NGSILD_SCOPE_IRI,
-            operationStatus = OperationStatus.FAILED,
-            errorMessage = unrecognizedOperationTypeMessage(operationType.toString())
-        )
+        val temporalPropertyToAdd =
+            if (currentScopes == null) TemporalProperty.CREATED_AT
+            else TemporalProperty.MODIFIED_AT
+        addHistoryEntry(entityId, updatedScopes, temporalPropertyToAdd, modifiedAt).bind()
+        if (temporalPropertyToAdd == TemporalProperty.MODIFIED_AT)
+            // as stated in 4.5.6: In case the Temporal Representation of the Scope is updated as the result of a
+            // change from the Core API, the observedAt sub-Property should be set as a copy of the modifiedAt
+            // sub-Property
+            addHistoryEntry(entityId, updatedScopes, TemporalProperty.OBSERVED_AT, modifiedAt).bind()
+        authorizationService.createScopesOwnerRights(updatedScopes).bind()
+        operationResult
     }
 
     @Transactional
-    internal suspend fun performUpdate(
+    internal suspend fun performReplace(
         entityId: URI,
         scopes: List<Scope>,
         modifiedAt: ZonedDateTime,
-        payload: String
+        scopeValue: ExpandedAttributeInstances
     ): Either<APIException, SucceededAttributeOperationResult> = either {
+        val patch = mapOf(NGSILD_SCOPE_IRI to scopeValue)
         databaseClient.sql(
             """
             UPDATE entity_payload
             SET scopes = :scopes,
                 modified_at = :modified_at,
-                payload = :payload
+                payload = (payload || :patch::jsonb)
             WHERE entity_id = :entity_id
             """.trimIndent()
         )
             .bind("entity_id", entityId)
             .bind("scopes", scopes.toTypedArray())
             .bind("modified_at", modifiedAt)
-            .bind("payload", Json.of(payload))
+            .bind("patch", Json.of(serializeObject(patch)))
             .execute()
             .map {
                 SucceededAttributeOperationResult(
                     attributeName = NGSILD_SCOPE_IRI,
                     operationStatus = OperationStatus.CREATED,
-                    newExpandedValue = mapOf(NGSILD_SCOPE_IRI to scopes.toList())
+                    newExpandedValue = mapOf(NGSILD_SCOPE_IRI to scopes.map { mapOf(JSONLD_VALUE_KW to it) })
+                )
+            }.bind()
+    }
+
+    @Transactional
+    internal suspend fun performAppend(
+        entityId: URI,
+        newScopes: List<Scope>,
+        modifiedAt: ZonedDateTime
+    ): Either<APIException, Pair<List<Scope>, SucceededAttributeOperationResult>> = either {
+        val unionExpr = """
+            COALESCE(scopes, '{}') || COALESCE(
+                (
+                    SELECT array_agg(ns ORDER BY ord)
+                    FROM unnest(:new_scopes::text[]) WITH ORDINALITY AS u(ns, ord)
+                    WHERE ns <> ALL (COALESCE(scopes, '{}'))
+                ),
+                '{}'::text[]
+            )
+        """.trimIndent()
+
+        databaseClient.sql(
+            """
+            UPDATE entity_payload
+            SET scopes = $unionExpr,
+                modified_at = :modified_at,
+                payload = payload || jsonb_build_object(
+                    '$NGSILD_SCOPE_IRI',
+                    (
+                        SELECT jsonb_agg(jsonb_build_object('$JSONLD_VALUE_KW', s.value) ORDER BY s.ord)
+                        FROM unnest($unionExpr) WITH ORDINALITY AS s(value, ord)
+                    )
+                )
+            WHERE entity_id = :entity_id
+            RETURNING scopes
+            """.trimIndent()
+        )
+            .bind("entity_id", entityId)
+            .bind("modified_at", modifiedAt)
+            .bind("new_scopes", newScopes.toTypedArray())
+            .oneToResult { row -> toList<Scope>(row["scopes"]) }
+            .map { updatedScopes ->
+                Pair(
+                    updatedScopes,
+                    SucceededAttributeOperationResult(
+                        attributeName = NGSILD_SCOPE_IRI,
+                        operationStatus = OperationStatus.CREATED,
+                        newExpandedValue = mapOf(
+                            NGSILD_SCOPE_IRI to updatedScopes.map { mapOf(JSONLD_VALUE_KW to it) }
+                        )
+                    )
                 )
             }.bind()
     }
@@ -382,7 +406,7 @@ class ScopeService(
     }
 
     @Transactional
-    suspend fun permanentlyDelete(entityId: URI): Either<APIException, Unit> =
+    suspend fun permanentlyDelete(entityId: URI, modifiedAt: ZonedDateTime): Either<APIException, Unit> = either {
         databaseClient.sql(
             """
             DELETE FROM scope_history
@@ -391,4 +415,20 @@ class ScopeService(
         )
             .bind("entity_id", entityId)
             .execute()
+            .bind()
+
+        databaseClient.sql(
+            """
+            UPDATE entity_payload
+            SET scopes = null,
+                modified_at = :modified_at,
+                payload = payload - '$NGSILD_SCOPE_IRI'
+            WHERE entity_id = :entity_id
+            """.trimIndent()
+        )
+            .bind("entity_id", entityId)
+            .bind("modified_at", modifiedAt)
+            .execute()
+            .bind()
+    }
 }

--- a/search-service/src/test/kotlin/com/egm/stellio/search/entity/service/EntityAttributeServiceTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/entity/service/EntityAttributeServiceTests.kt
@@ -9,7 +9,8 @@ import com.egm.stellio.search.entity.model.AttributeMetadata
 import com.egm.stellio.search.entity.model.Entity
 import com.egm.stellio.search.entity.model.FailedAttributeOperationResult
 import com.egm.stellio.search.entity.model.OperationStatus
-import com.egm.stellio.search.entity.model.getSucceededAttributesOperations
+import com.egm.stellio.search.entity.model.SucceededAttributeOperationResult
+import com.egm.stellio.search.entity.model.getSucceededOperations
 import com.egm.stellio.search.support.EMPTY_JSON_PAYLOAD
 import com.egm.stellio.search.support.WithKafkaContainer
 import com.egm.stellio.search.support.WithTimescaleContainer
@@ -17,18 +18,23 @@ import com.egm.stellio.search.temporal.model.AttributeInstance
 import com.egm.stellio.search.temporal.service.AttributeInstanceService
 import com.egm.stellio.shared.WithMockCustomUser
 import com.egm.stellio.shared.model.BadRequestDataException
+import com.egm.stellio.shared.model.ExpandedAttributeInstance
 import com.egm.stellio.shared.model.InternalErrorException
+import com.egm.stellio.shared.model.NGSILD_CREATED_AT_IRI
 import com.egm.stellio.shared.model.NGSILD_DEFAULT_VOCAB
+import com.egm.stellio.shared.model.NGSILD_DELETED_AT_IRI
+import com.egm.stellio.shared.model.NGSILD_MODIFIED_AT_IRI
 import com.egm.stellio.shared.model.NGSILD_NULL
 import com.egm.stellio.shared.model.ResourceNotFoundException
+import com.egm.stellio.shared.model.getMemberValueAsDateTime
 import com.egm.stellio.shared.model.toNgsiLdAttribute
 import com.egm.stellio.shared.model.toNgsiLdAttributes
 import com.egm.stellio.shared.util.APIC_COMPOUND_CONTEXTS
 import com.egm.stellio.shared.util.BEEHIVE_IRI
 import com.egm.stellio.shared.util.ErrorMessages.Entity.NGSI_LD_NULL_NOT_ALLOWED_MESSAGE
 import com.egm.stellio.shared.util.INCOMING_IRI
-import com.egm.stellio.shared.util.JsonLdUtils
 import com.egm.stellio.shared.util.JsonLdUtils.expandAttribute
+import com.egm.stellio.shared.util.JsonLdUtils.expandAttributes
 import com.egm.stellio.shared.util.JsonUtils.serializeObject
 import com.egm.stellio.shared.util.NAME_IRI
 import com.egm.stellio.shared.util.NGSILD_TEST_CORE_CONTEXTS
@@ -387,7 +393,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
         val createdAt = ngsiLdDateTime()
         val newProperty = loadSampleData("fragments/beehive_new_incoming_property.json")
         val expandedAttribute = expandAttribute(newProperty, APIC_COMPOUND_CONTEXTS)
-        entityAttributeService.addOrReplaceAttribute(
+        val result = entityAttributeService.addOrReplaceAttribute(
             beehiveTestCId,
             INCOMING_IRI,
             AttributeMetadata(
@@ -402,7 +408,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
             createdAt,
             expandedAttribute.second[0],
             true
-        ).shouldSucceed()
+        ).shouldSucceedAndResult()
 
         entityAttributeService.getForEntityAndAttribute(
             beehiveTestCId,
@@ -414,8 +420,69 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
             assertJsonPayloadsAreEqual(serializeObject(expandedAttribute.second[0]), it.payload.asString())
             assertTrue(it.createdAt.isBefore(createdAt))
             assertEquals(createdAt, it.modifiedAt)
+            assertSysAttrs(result.newExpandedValue, it.createdAt, it.modifiedAt)
         }
     }
+
+    @Test
+    fun `upsertAttributes should create the attribute when it does not exist yet`() = runTest {
+        coEvery { attributeInstanceService.create(any()) } returns Unit.right()
+
+        val createdAt = ngsiLdDateTime()
+        val expandedAttributes = expandAttributes(
+            loadSampleData("fragments/beehive_mergeAttribute.json"),
+            APIC_COMPOUND_CONTEXTS
+        )
+        val ngsiLdAttribute = expandedAttributes.toMap().toNgsiLdAttributes().shouldSucceedAndResult()[0]
+
+        val result = entityAttributeService.upsertAttributes(
+            beehiveTestCId,
+            ngsiLdAttribute,
+            expandedAttributes.toMap(),
+            createdAt
+        ).shouldSucceedAndResult()
+
+        assertThat(result)
+            .isNotNull
+            .extracting("operationStatus").isEqualTo(OperationStatus.CREATED)
+
+        entityAttributeService.getForEntityAndAttribute(beehiveTestCId, INCOMING_IRI)
+            .shouldSucceedWith { assertEquals(createdAt, it.createdAt) }
+    }
+
+    @Test
+    fun `upsertAttributes should add an observed instance and return no result when the attribute already exists`() =
+        runTest {
+            val rawEntity = loadSampleData()
+            coEvery { attributeInstanceService.create(any()) } returns Unit.right()
+            entityAttributeService.createAttributes(rawEntity, APIC_COMPOUND_CONTEXTS).shouldSucceed()
+
+            val existingAttribute = entityAttributeService.getForEntityAndAttribute(
+                beehiveTestCId,
+                INCOMING_IRI
+            ).shouldSucceedAndResult()
+
+            coEvery {
+                attributeInstanceService.addObservedAttributeInstance(any(), any(), any())
+            } returns Unit.right()
+
+            val expandedAttributes = expandAttributes(
+                loadSampleData("fragments/beehive_mergeAttribute.json"),
+                APIC_COMPOUND_CONTEXTS
+            )
+            val ngsiLdAttribute = expandedAttributes.toMap().toNgsiLdAttributes().shouldSucceedAndResult()[0]
+
+            entityAttributeService.upsertAttributes(
+                beehiveTestCId,
+                ngsiLdAttribute,
+                expandedAttributes.toMap(),
+                ngsiLdDateTime()
+            ).shouldSucceedWith { assertNull(it) }
+
+            coVerify {
+                attributeInstanceService.addObservedAttributeInstance(existingAttribute.id, any(), any())
+            }
+        }
 
     @Test
     fun `mergeAttribute should merge an entity attribute`() = runTest {
@@ -434,7 +501,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
         val mergedAt = ngsiLdDateTime()
         val propertyToMerge = loadSampleData("fragments/beehive_mergeAttribute.json")
         val expandedAttribute = expandAttribute(propertyToMerge, APIC_COMPOUND_CONTEXTS)
-        entityAttributeService.mergeAttribute(
+        val result = entityAttributeService.mergeAttribute(
             attribute,
             AttributeMetadata(
                 null,
@@ -448,7 +515,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
             mergedAt,
             null,
             expandedAttribute.second[0]
-        ).shouldSucceed()
+        ).shouldSucceedAndResult()
 
         val expectedMergedPayload = expandAttribute(
             """
@@ -476,6 +543,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
             assertJsonPayloadsAreEqual(serializeObject(expectedMergedPayload.second[0]), it.payload.asString())
             assertTrue(it.createdAt.isBefore(mergedAt))
             assertEquals(mergedAt, it.modifiedAt)
+            assertSysAttrs(result.newExpandedValue, it.createdAt, it.modifiedAt)
         }
     }
 
@@ -497,7 +565,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
         ).shouldSucceed()
 
         val propertyToMerge = loadSampleData("fragments/beehive_mergeAttribute.json")
-        val expandedAttributes = JsonLdUtils.expandAttributes(propertyToMerge, APIC_COMPOUND_CONTEXTS)
+        val expandedAttributes = expandAttributes(propertyToMerge, APIC_COMPOUND_CONTEXTS)
         entityAttributeService.mergeAttributes(
             beehiveTestCId,
             expandedAttributes.toMap().toNgsiLdAttributes().shouldSucceedAndResult(),
@@ -526,7 +594,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
 
         val createdAt = ngsiLdDateTime()
         val attributesToMerge = loadSampleData("fragments/beehive_mergeAttributes.json")
-        val expandedAttributes = JsonLdUtils.expandAttributes(attributesToMerge, APIC_COMPOUND_CONTEXTS)
+        val expandedAttributes = expandAttributes(attributesToMerge, APIC_COMPOUND_CONTEXTS)
         val ngsiLdAttributes = expandedAttributes.toMap().toNgsiLdAttributes().shouldSucceedAndResult()
         entityAttributeService.mergeAttributes(
             beehiveTestCId,
@@ -535,7 +603,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
             createdAt,
             null
         ).shouldSucceedWith { operationResults ->
-            val successfulOperations = operationResults.getSucceededAttributesOperations()
+            val successfulOperations = operationResults.getSucceededOperations()
             assertEquals(6, successfulOperations.size)
             assertEquals(4, successfulOperations.filter { it.operationStatus == OperationStatus.UPDATED }.size)
             assertEquals(2, successfulOperations.filter { it.operationStatus == OperationStatus.CREATED }.size)
@@ -588,7 +656,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
         val createdAt = ngsiLdDateTime()
         val observedAt = ZonedDateTime.parse("2019-12-04T12:00:00.00Z")
         val propertyToMerge = loadSampleData("fragments/beehive_mergeAttribute_without_observedAt.json")
-        val expandedAttributes = JsonLdUtils.expandAttributes(propertyToMerge, APIC_COMPOUND_CONTEXTS)
+        val expandedAttributes = expandAttributes(propertyToMerge, APIC_COMPOUND_CONTEXTS)
         val ngsiLdAttributes = expandedAttributes.toMap().toNgsiLdAttributes().shouldSucceedAndResult()
         entityAttributeService.mergeAttributes(
             beehiveTestCId,
@@ -597,7 +665,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
             createdAt,
             observedAt
         ).shouldSucceedWith { operationResults ->
-            val successfulOperations = operationResults.getSucceededAttributesOperations()
+            val successfulOperations = operationResults.getSucceededOperations()
             assertEquals(1, successfulOperations.size)
             assertEquals(1, successfulOperations.filter { it.operationStatus == OperationStatus.UPDATED }.size)
         }
@@ -627,7 +695,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
 
         val createdAt = ngsiLdDateTime()
         val propertyToDelete = loadSampleData("fragments/beehive_mergeAttribute_null.json")
-        val expandedAttributes = JsonLdUtils.expandAttributes(propertyToDelete, APIC_COMPOUND_CONTEXTS)
+        val expandedAttributes = expandAttributes(propertyToDelete, APIC_COMPOUND_CONTEXTS)
         val ngsiLdAttributes = expandedAttributes.toMap().toNgsiLdAttributes().shouldSucceedAndResult()
         entityAttributeService.mergeAttributes(
             beehiveTestCId,
@@ -636,7 +704,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
             createdAt,
             null
         ).shouldSucceedWith { operationResults ->
-            val successfulOperations = operationResults.getSucceededAttributesOperations()
+            val successfulOperations = operationResults.getSucceededOperations()
             assertEquals(1, successfulOperations.size)
             assertEquals(1, successfulOperations.filter { it.operationStatus == OperationStatus.DELETED }.size)
         }
@@ -673,7 +741,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
 
         val createdAt = ngsiLdDateTime()
         val propertyToDelete = loadSampleData("fragments/beehive_mergeAttribute_null.json")
-        val expandedAttributes = JsonLdUtils.expandAttributes(propertyToDelete, APIC_COMPOUND_CONTEXTS)
+        val expandedAttributes = expandAttributes(propertyToDelete, APIC_COMPOUND_CONTEXTS)
         val ngsiLdAttributes = expandedAttributes.toMap().toNgsiLdAttributes().shouldSucceedAndResult()
         entityAttributeService.updateAttributes(
             beehiveTestCId,
@@ -681,7 +749,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
             expandedAttributes,
             createdAt
         ).shouldSucceedWith { operationResults ->
-            val successfulOperations = operationResults.getSucceededAttributesOperations()
+            val successfulOperations = operationResults.getSucceededOperations()
             assertEquals(1, successfulOperations.size)
             assertEquals(1, successfulOperations.filter { it.operationStatus == OperationStatus.DELETED }.size)
         }
@@ -723,7 +791,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
         ).shouldSucceed()
 
         val propertyToDelete = loadSampleData("fragments/beehive_new_incoming_property.json")
-        val expandedAttributes = JsonLdUtils.expandAttributes(propertyToDelete, APIC_COMPOUND_CONTEXTS)
+        val expandedAttributes = expandAttributes(propertyToDelete, APIC_COMPOUND_CONTEXTS)
         val ngsiLdAttributes = expandedAttributes.toMap().toNgsiLdAttributes().shouldSucceedAndResult()
         entityAttributeService.updateAttributes(
             beehiveTestCId,
@@ -731,7 +799,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
             expandedAttributes,
             ngsiLdDateTime()
         ).shouldSucceedWith { operationResults ->
-            val successfulOperations = operationResults.getSucceededAttributesOperations()
+            val successfulOperations = operationResults.getSucceededOperations()
             assertEquals(1, successfulOperations.size)
             assertEquals(1, successfulOperations.filter { it.operationStatus == OperationStatus.CREATED }.size)
         }
@@ -805,13 +873,12 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
             APIC_COMPOUND_CONTEXTS
         )
 
-        entityAttributeService.partialUpdateAttribute(
+        val result = entityAttributeService.partialUpdateAttribute(
             beehiveTestCId,
             expandedAttribute,
             updatedAt
-        ).shouldSucceedWith { operationResult ->
-            assertEquals(OperationStatus.UPDATED, operationResult.operationStatus)
-        }
+        ).shouldSucceedAndResult()
+        assertEquals(OperationStatus.UPDATED, result.operationStatus)
 
         val expectedPayload = expandAttribute(
             """
@@ -838,6 +905,11 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
             assertEquals(Attribute.AttributeValueType.NUMBER, it.attributeValueType)
             assertJsonPayloadsAreEqual(serializeObject(expectedPayload.second[0]), it.payload.asString())
             assertEquals(updatedAt, it.modifiedAt)
+            assertSysAttrs(
+                (result as SucceededAttributeOperationResult).newExpandedValue,
+                it.createdAt,
+                it.modifiedAt
+            )
         }
     }
 
@@ -979,7 +1051,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
                 }
             }
         """.trimIndent()
-        val expandedAttributes = JsonLdUtils.expandAttributes(nullAttribute, APIC_COMPOUND_CONTEXTS)
+        val expandedAttributes = expandAttributes(nullAttribute, APIC_COMPOUND_CONTEXTS)
         val ngsiLdAttributes = expandedAttributes.toMap().toNgsiLdAttributes().shouldSucceedAndResult()
 
         entityAttributeService.appendAttributes(
@@ -1052,13 +1124,13 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
         entityAttributeService.createAttributes(rawEntity, APIC_COMPOUND_CONTEXTS)
 
         val deletedAt = ngsiLdDateTime()
-        entityAttributeService.deleteAttribute(
+        val results = entityAttributeService.deleteAttribute(
             beehiveTestDId,
             INCOMING_IRI,
             null,
             false,
             deletedAt
-        ).shouldSucceed()
+        ).shouldSucceedAndResult()
 
         coVerify {
             attributeInstanceService.addDeletedAttributeInstance(
@@ -1081,6 +1153,7 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
         entityAttributeService.getForEntityAndAttribute(beehiveTestDId, INCOMING_IRI)
             .shouldSucceedWith {
                 assertEquals(deletedAt, it.deletedAt)
+                assertSysAttrs(results.first().newExpandedValue, it.createdAt, it.modifiedAt, deletedAt)
             }
     }
 
@@ -1122,17 +1195,22 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
 
         entityAttributeService.createAttributes(rawEntity, APIC_COMPOUND_CONTEXTS)
 
-        entityAttributeService.deleteAttributes(
+        val deletedAt = ngsiLdDateTime()
+        val results = entityAttributeService.deleteAttributes(
             beehiveTestCId,
-            ngsiLdDateTime()
-        ).shouldSucceed()
+            deletedAt
+        ).shouldSucceedAndResult()
 
         coVerify(exactly = 4) {
             attributeInstanceService.addDeletedAttributeInstance(any(), any(), any(), any())
         }
 
         entityAttributeService.getForEntityAndAttribute(beehiveTestCId, INCOMING_IRI)
-            .shouldSucceedWith { assertTrue(it.deletedAt != null) }
+            .shouldSucceedWith { attribute ->
+                assertTrue(attribute.deletedAt != null)
+                val result = results.first { it.attributeName == INCOMING_IRI }
+                assertSysAttrs(result.newExpandedValue, attribute.createdAt, attribute.modifiedAt, deletedAt)
+            }
     }
 
     @Test
@@ -1342,5 +1420,21 @@ class EntityAttributeServiceTests : WithTimescaleContainer, WithKafkaContainer()
         assertThat(attributes)
             .hasSize(3)
             .matches { it.all { tea -> tea.attributeName == INCOMING_IRI || tea.attributeName == NAME_IRI } }
+    }
+
+    private fun assertSysAttrs(
+        expandedInstance: ExpandedAttributeInstance,
+        createdAt: ZonedDateTime,
+        modifiedAt: ZonedDateTime,
+        deletedAt: ZonedDateTime? = null
+    ) {
+        val createdAtMember = expandedInstance.getMemberValueAsDateTime(NGSILD_CREATED_AT_IRI)
+        val modifiedAtMember = expandedInstance.getMemberValueAsDateTime(NGSILD_MODIFIED_AT_IRI)
+        assertEquals(createdAt, createdAtMember)
+        assertEquals(modifiedAt, modifiedAtMember)
+        if (deletedAt != null) {
+            val deletedAtMember = expandedInstance.getMemberValueAsDateTime(NGSILD_DELETED_AT_IRI)
+            assertEquals(deletedAt, deletedAtMember)
+        }
     }
 }

--- a/search-service/src/test/kotlin/com/egm/stellio/search/entity/service/EntityServiceTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/entity/service/EntityServiceTests.kt
@@ -23,12 +23,19 @@ import com.egm.stellio.shared.model.BadRequestDataException
 import com.egm.stellio.shared.model.CompactedAttributeInstances
 import com.egm.stellio.shared.model.JSONLD_ID_KW
 import com.egm.stellio.shared.model.JSONLD_TYPE_KW
+import com.egm.stellio.shared.model.JSONLD_VALUE_KW
+import com.egm.stellio.shared.model.NGSILD_DATASET_ID_IRI
 import com.egm.stellio.shared.model.NGSILD_DEFAULT_VOCAB
 import com.egm.stellio.shared.model.NGSILD_DELETED_AT_IRI
+import com.egm.stellio.shared.model.NGSILD_MODIFIED_AT_IRI
+import com.egm.stellio.shared.model.NGSILD_PROPERTY_TYPE
+import com.egm.stellio.shared.model.NGSILD_PROPERTY_VALUE
 import com.egm.stellio.shared.model.NGSILD_SCOPE_IRI
 import com.egm.stellio.shared.model.NGSILD_TITLE_TERM
 import com.egm.stellio.shared.model.NGSILD_VALUE_TERM
+import com.egm.stellio.shared.model.NgsiLdAttribute
 import com.egm.stellio.shared.model.ResourceNotFoundException
+import com.egm.stellio.shared.model.getDatasetId
 import com.egm.stellio.shared.queryparameter.PaginationQuery
 import com.egm.stellio.shared.util.APIARY_IRI
 import com.egm.stellio.shared.util.APIC_COMPOUND_CONTEXT
@@ -53,6 +60,7 @@ import com.egm.stellio.shared.util.shouldFail
 import com.egm.stellio.shared.util.shouldSucceed
 import com.egm.stellio.shared.util.shouldSucceedAndResult
 import com.egm.stellio.shared.util.shouldSucceedWith
+import com.egm.stellio.shared.util.toNgsiLdFormat
 import com.egm.stellio.shared.util.toUri
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.coEvery
@@ -60,10 +68,15 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
@@ -77,6 +90,7 @@ import org.springframework.r2dbc.core.DatabaseClient
 import org.springframework.test.context.ActiveProfiles
 import java.net.URI
 import java.time.ZonedDateTime
+import kotlin.time.Duration.Companion.milliseconds
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -325,7 +339,6 @@ class EntityServiceTests : WithTimescaleContainer, WithKafkaContainer() {
         } returns listOf(
             SucceededAttributeOperationResult(INCOMING_IRI, null, OperationStatus.CREATED, emptyMap()),
         ).right()
-        coEvery { entityAttributeService.getAllForEntity(any()) } returns emptyList()
         coEvery { authorizationService.createEntityOwnerRight(any()) } returns Unit.right()
 
         val (expandedEntity, ngsiLdEntity) =
@@ -364,9 +377,6 @@ class EntityServiceTests : WithTimescaleContainer, WithKafkaContainer() {
                 any(),
                 any(),
                 any()
-            )
-            entityAttributeService.getAllForEntity(
-                eq(beehiveTestCId)
             )
             authorizationService.createEntityOwnerRight(beehiveTestCId)
         }
@@ -554,6 +564,24 @@ class EntityServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
+    fun `replaceAttribute should raise a BadRequestData error when the target attribute is scope`() = runTest {
+        val expandedAttribute = expandAttribute("""{ "scope": ["/A"] }""", APIC_COMPOUND_CONTEXTS)
+
+        entityService.replaceAttribute(beehiveTestCId, expandedAttribute).shouldFail {
+            assertInstanceOf(BadRequestDataException::class.java, it)
+        }
+    }
+
+    @Test
+    fun `partialUpdateAttribute should raise a BadRequestData error when the target attribute is scope`() = runTest {
+        val expandedAttribute = expandAttribute("""{ "scope": ["/A"] }""", APIC_COMPOUND_CONTEXTS)
+
+        entityService.partialUpdateAttribute(beehiveTestCId, expandedAttribute).shouldFail {
+            assertInstanceOf(BadRequestDataException::class.java, it)
+        }
+    }
+
+    @Test
     fun `updateTypes should add a type to an entity`() = runTest {
         val entityPayload = loadSampleData("beehive.jsonld")
         entityPayload.sampleDataToNgsiLdEntity().map {
@@ -564,7 +592,7 @@ class EntityServiceTests : WithTimescaleContainer, WithKafkaContainer() {
             )
         }
 
-        entityService.updateTypes(beehiveTestCId, listOf(BEEHIVE_IRI, APIARY_IRI), ngsiLdDateTime(), false)
+        entityService.updateTypes(beehiveTestCId, listOf(BEEHIVE_IRI, APIARY_IRI), ngsiLdDateTime())
             .shouldSucceedWith {
                 assertInstanceOf(SucceededAttributeOperationResult::class.java, it)
                 assertEquals(JSONLD_TYPE_KW, it.attributeName)
@@ -592,7 +620,31 @@ class EntityServiceTests : WithTimescaleContainer, WithKafkaContainer() {
                     now
                 )
             }
-        entityService.updateTypes(entity01Uri, listOf(APIARY_IRI), ngsiLdDateTime(), false)
+        entityService.updateTypes(entity01Uri, listOf(APIARY_IRI), ngsiLdDateTime())
+            .shouldSucceed()
+
+        entityQueryService.retrieve(entity01Uri)
+            .shouldSucceedWith {
+                assertEquals(listOf(BEEHIVE_IRI, APIARY_IRI), it.types)
+                assertEquals(
+                    listOf(BEEHIVE_IRI, APIARY_IRI),
+                    it.payload.asString().deserializeExpandedPayload()[JSONLD_TYPE_KW]
+                )
+            }
+    }
+
+    @Test
+    fun `updateTypes should not duplicate a type value repeated within the same list to add`() = runTest {
+        loadMinimalEntity(entity01Uri, setOf(BEEHIVE_IRI))
+            .sampleDataToNgsiLdEntity()
+            .map {
+                entityService.createEntityPayload(
+                    it.second,
+                    it.first,
+                    now
+                )
+            }
+        entityService.updateTypes(entity01Uri, listOf(APIARY_IRI, APIARY_IRI), ngsiLdDateTime())
             .shouldSucceed()
 
         entityQueryService.retrieve(entity01Uri)
@@ -665,7 +717,6 @@ class EntityServiceTests : WithTimescaleContainer, WithKafkaContainer() {
             entityAttributeService.checkEntityAndAttributeExistence(any(), any(), any(), any(), any())
         } returns Unit.right()
         coEvery { entityAttributeService.permanentlyDeleteAttribute(any(), any(), any(), any()) } returns Unit.right()
-        coEvery { entityAttributeService.getAllForEntity(any()) } returns emptyList()
 
         loadAndPrepareSampleData("beehive.jsonld")
             .map {
@@ -687,8 +738,12 @@ class EntityServiceTests : WithTimescaleContainer, WithKafkaContainer() {
                 excludeDeleted = false
             )
             entityAttributeService.permanentlyDeleteAttribute(beehiveTestCId, INCOMING_IRI, null, false)
-            entityAttributeService.getAllForEntity(beehiveTestCId)
         }
+
+        entityQueryService.retrieve(beehiveTestCId)
+            .shouldSucceedWith { entity ->
+                assertFalse(entity.toExpandedEntity().members.containsKey(INCOMING_IRI))
+            }
     }
 
     @Test
@@ -727,6 +782,59 @@ class EntityServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
+    fun `permanentlyDeleteAttribute should return a ResourceNotFound error when the entity no longer exists`() =
+        runTest {
+            coEvery { authorizationService.userCanUpdateEntity(any()) } returns Unit.right()
+            coEvery {
+                entityAttributeService.checkEntityAndAttributeExistence(any(), any(), any(), any(), any())
+            } returns Unit.right()
+            coEvery {
+                entityAttributeService.permanentlyDeleteAttribute(any(), any(), any(), any())
+            } returns Unit.right()
+
+            entityService.permanentlyDeleteAttribute(entity01Uri, INCOMING_IRI, null, deleteAll = true).shouldFail {
+                assertInstanceOf(ResourceNotFoundException::class.java, it)
+            }
+        }
+
+    @Test
+    fun `upsertAttributes should return a ResourceNotFound error when the entity no longer exists`() = runTest {
+        coEvery {
+            entityAttributeService.upsertAttributes(any(), any(), any(), any())
+        } returns SucceededAttributeOperationResult(INCOMING_IRI, null, OperationStatus.CREATED, emptyMap()).right()
+
+        val expandedAttributes = expandAttributes(
+            """{ "$INCOMING_TERM": { "type": "Property", "value": 10 } }""",
+            APIC_COMPOUND_CONTEXTS
+        )
+
+        entityService.upsertAttributes(entity01Uri, expandedAttributes).shouldFail {
+            assertInstanceOf(ResourceNotFoundException::class.java, it)
+        }
+    }
+
+    @Test
+    fun `upsertAttributes should not change modifiedAt when only history entries were added`() = runTest {
+        coEvery {
+            entityAttributeService.upsertAttributes(any(), any(), any(), any())
+        } returns null.right()
+
+        loadMinimalEntity(entity01Uri, setOf(BEEHIVE_IRI))
+            .sampleDataToNgsiLdEntity()
+            .map { entityService.createEntityPayload(it.second, it.first, now) }
+
+        val expandedAttributes = expandAttributes(
+            """{ "$INCOMING_TERM": { "type": "Property", "value": 10, "observedAt": "$now" } }""",
+            APIC_COMPOUND_CONTEXTS
+        )
+
+        entityService.upsertAttributes(entity01Uri, expandedAttributes).shouldSucceed()
+
+        entityQueryService.retrieve(entity01Uri)
+            .shouldSucceedWith { entity -> assertEquals(now, entity.modifiedAt) }
+    }
+
+    @Test
     fun `mergeAttribute should return an error when the entity does not exist`() = runTest {
         entityService.mergeAttribute(
             entity01Uri,
@@ -743,13 +851,12 @@ class EntityServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `mergeAttribute should merge the attribute when entity exists`() = runTest {
+    fun `mergeAttribute should merge the attribute and update the modifiedAt member when entity exists`() = runTest {
         coEvery {
             entityAttributeService.mergeAttributes(any(), any(), any(), any(), any())
         } returns listOf(
             SucceededAttributeOperationResult(INCOMING_IRI, null, OperationStatus.UPDATED, emptyMap())
         ).right()
-        coEvery { entityAttributeService.getAllForEntity(any()) } returns emptyList()
 
         loadMinimalEntity(entity01Uri, setOf(BEEHIVE_IRI))
             .sampleDataToNgsiLdEntity()
@@ -767,6 +874,14 @@ class EntityServiceTests : WithTimescaleContainer, WithKafkaContainer() {
             now
         ).shouldSucceed()
 
+        entityQueryService.retrieve(entity01Uri)
+            .shouldSucceedWith { entity ->
+                assertTrue(entity.modifiedAt > now)
+                val modifiedAtMember =
+                    (entity.toExpandedEntity().members[NGSILD_MODIFIED_AT_IRI] as List<*>).first() as Map<*, *>
+                assertEquals(entity.modifiedAt.toNgsiLdFormat(), modifiedAtMember[JSONLD_VALUE_KW])
+            }
+
         coVerify {
             entityAttributeService.mergeAttributes(
                 eq(entity01Uri),
@@ -775,8 +890,130 @@ class EntityServiceTests : WithTimescaleContainer, WithKafkaContainer() {
                 any(),
                 eq(now)
             )
-            entityAttributeService.getAllForEntity(eq(entity01Uri))
         }
+    }
+
+    // Not using runTest here: this test needs two mergeAttribute() calls to genuinely race against each
+    // other at the DB level, which requires real wall-clock concurrency rather than runTest's virtual-time
+    // coroutine scheduling.
+    @Test
+    fun `mergeAttribute should keep both instances when updated concurrently at two datasetIds`() = runBlocking {
+        val datasetIdX = "urn:ngsi-ld:Dataset:X".toUri()
+        val datasetIdY = "urn:ngsi-ld:Dataset:Y".toUri()
+
+        // force both concurrent mergeAttribute() calls to be in-flight at the same time, so they
+        // genuinely race for the entity_payload row lock in patchEntityPayload
+        listOf(datasetIdX, datasetIdY).forEach { datasetId ->
+            coEvery {
+                entityAttributeService.mergeAttributes(
+                    entity01Uri,
+                    match<List<NgsiLdAttribute>> {
+                        it.first().getAttributeInstances().first().datasetId == datasetId
+                    },
+                    any(),
+                    any(),
+                    any()
+                )
+            } coAnswers {
+                delay(300.milliseconds)
+                listOf(
+                    SucceededAttributeOperationResult(
+                        INCOMING_IRI,
+                        datasetId,
+                        OperationStatus.UPDATED,
+                        mapOf(
+                            JSONLD_TYPE_KW to listOf(NGSILD_PROPERTY_TYPE.uri),
+                            NGSILD_PROPERTY_VALUE to listOf(datasetId.toString()),
+                            NGSILD_DATASET_ID_IRI to listOf(mapOf(JSONLD_ID_KW to datasetId.toString()))
+                        )
+                    )
+                ).right()
+            }
+        }
+
+        loadMinimalEntity(entity01Uri, setOf(BEEHIVE_IRI))
+            .sampleDataToNgsiLdEntity()
+            .map { entityService.createEntityPayload(it.second, it.first, now) }
+
+        val fragmentX = expandAttributes(incomingFragmentWithDatasetId(datasetIdX), APIC_COMPOUND_CONTEXTS)
+            .getValue(INCOMING_IRI)[0]
+        val fragmentY = expandAttributes(incomingFragmentWithDatasetId(datasetIdY), APIC_COMPOUND_CONTEXTS)
+            .getValue(INCOMING_IRI)[0]
+
+        val jobX = async { entityService.mergeAttribute(entity01Uri, INCOMING_IRI, fragmentX, now) }
+        val jobY = async { entityService.mergeAttribute(entity01Uri, INCOMING_IRI, fragmentY, now) }
+        awaitAll(jobX, jobY).forEach { it.shouldSucceed() }
+
+        entityQueryService.retrieve(entity01Uri)
+            .shouldSucceedWith { entity ->
+                val incomingInstances = entity.toExpandedEntity().members.getValue(INCOMING_IRI) as List<*>
+                assertEquals(2, incomingInstances.size)
+                val datasetIds = incomingInstances.map {
+                    (it as Map<String, List<Any>>).getDatasetId()
+                }.toSet()
+                assertEquals(setOf(datasetIdX, datasetIdY), datasetIds)
+            }
+    }
+
+    private fun incomingFragmentWithDatasetId(datasetId: URI): String =
+        """
+        {
+            "incoming": {
+                "type": "Property",
+                "value": "$datasetId",
+                "datasetId": "$datasetId"
+            }
+        }
+        """.trimIndent()
+
+    // Not using runTest here: this test needs updateTypes() and mergeAttribute() to genuinely race
+    // against each other at the DB level, which requires real wall-clock concurrency rather than
+    // runTest's virtual-time scheduling.
+    @Test
+    fun `updateTypes should not lose a concurrent attribute update racing on the same entity`() = runBlocking {
+        val newType = "https://uri.etsi.org/ngsi-ld/default-context/AnotherType"
+
+        coEvery {
+            entityAttributeService.mergeAttributes(any(), any(), any(), any(), any())
+        } coAnswers {
+            // force this call to still be in-flight while updateTypes races against it, so both
+            // compete for the entity_payload row lock
+            delay(300.milliseconds)
+            listOf(
+                SucceededAttributeOperationResult(
+                    INCOMING_IRI,
+                    null,
+                    OperationStatus.UPDATED,
+                    mapOf(
+                        JSONLD_TYPE_KW to listOf(NGSILD_PROPERTY_TYPE.uri),
+                        NGSILD_PROPERTY_VALUE to listOf("some value")
+                    )
+                )
+            ).right()
+        }
+
+        loadMinimalEntity(entity01Uri, setOf(BEEHIVE_IRI))
+            .sampleDataToNgsiLdEntity()
+            .map { entityService.createEntityPayload(it.second, it.first, now) }
+
+        val fragment = expandAttributes(
+            loadSampleData("fragments/beehive_mergeAttribute.json"),
+            APIC_COMPOUND_CONTEXTS
+        ).getValue(INCOMING_IRI)[0]
+
+        val mergeJob = async { entityService.mergeAttribute(entity01Uri, INCOMING_IRI, fragment, now) }
+        val typeJob = async { entityService.updateTypes(entity01Uri, listOf(BEEHIVE_IRI, newType), now) }
+        mergeJob.await().shouldSucceed()
+        typeJob.await().shouldSucceed()
+
+        entityQueryService.retrieve(entity01Uri)
+            .shouldSucceedWith { entity ->
+                assertTrue(entity.types.containsAll(setOf(BEEHIVE_IRI, newType)))
+                val members = entity.toExpandedEntity().members
+                assertTrue(members.containsKey(INCOMING_IRI))
+                @Suppress("UNCHECKED_CAST")
+                assertTrue((members[JSONLD_TYPE_KW] as List<String>).containsAll(setOf(BEEHIVE_IRI, newType)))
+            }
     }
 
     private fun buildTypeQuery(typeIri: String) = EntitiesQueryFromGet(

--- a/search-service/src/test/kotlin/com/egm/stellio/search/scope/ScopeServiceTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/scope/ScopeServiceTests.kt
@@ -1,8 +1,12 @@
 package com.egm.stellio.search.scope
 
+import arrow.core.right
+import com.egm.stellio.search.authorization.permission.service.AuthorizationService
 import com.egm.stellio.search.entity.model.EntitiesQueryFromGet
 import com.egm.stellio.search.entity.model.Entity
+import com.egm.stellio.search.entity.model.FailedAttributeOperationResult
 import com.egm.stellio.search.entity.model.OperationType
+import com.egm.stellio.search.entity.model.SucceededAttributeOperationResult
 import com.egm.stellio.search.entity.service.EntityQueryService
 import com.egm.stellio.search.entity.service.EntityService
 import com.egm.stellio.search.entity.util.toExpandedAttributeInstance
@@ -17,6 +21,7 @@ import com.egm.stellio.shared.model.NGSILD_SCOPE_IRI
 import com.egm.stellio.shared.model.getScopes
 import com.egm.stellio.shared.queryparameter.PaginationQuery
 import com.egm.stellio.shared.util.APIC_COMPOUND_CONTEXTS
+import com.egm.stellio.shared.util.ErrorMessages.Scope.SCOPE_DOES_NOT_EXIST_MESSAGE
 import com.egm.stellio.shared.util.JsonLdUtils
 import com.egm.stellio.shared.util.loadSampleData
 import com.egm.stellio.shared.util.ngsiLdDateTime
@@ -25,14 +30,17 @@ import com.egm.stellio.shared.util.shouldSucceed
 import com.egm.stellio.shared.util.shouldSucceedAndResult
 import com.egm.stellio.shared.util.shouldSucceedWith
 import com.egm.stellio.shared.util.toUri
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.coEvery
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertInstanceOf
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
@@ -60,6 +68,9 @@ class ScopeServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     @Autowired
     private lateinit var r2dbcEntityTemplate: R2dbcEntityTemplate
 
+    @MockkBean
+    private lateinit var authorizationService: AuthorizationService
+
     private val beehiveTestCId = "urn:ngsi-ld:BeeHive:TESTC".toUri()
 
     @AfterEach
@@ -79,7 +90,19 @@ class ScopeServiceTests : WithTimescaleContainer, WithKafkaContainer() {
             Arguments.of(
                 "beehive_with_scope.jsonld",
                 listOf("/B", "/C"),
-                OperationType.REPLACE_ATTRIBUTE,
+                OperationType.MERGE_ENTITY,
+                listOf("/A", "/B", "/C")
+            ),
+            Arguments.of(
+                "beehive_with_scope.jsonld",
+                listOf("/B", "/C"),
+                OperationType.APPEND_ATTRIBUTES_OVERWRITE_ALLOWED,
+                listOf("/B", "/C")
+            ),
+            Arguments.of(
+                "beehive_with_scope.jsonld",
+                listOf("/B", "/C"),
+                OperationType.MERGE_ENTITY_OVERWRITE_ALLOWED,
                 listOf("/B", "/C")
             ),
             Arguments.of(
@@ -104,6 +127,7 @@ class ScopeServiceTests : WithTimescaleContainer, WithKafkaContainer() {
         operationType: OperationType,
         expectedScopes: List<String>?
     ) = runTest {
+        coEvery { authorizationService.createScopesOwnerRights(any()) } returns Unit.right()
         loadSampleData(initialEntity)
             .sampleDataToNgsiLdEntity()
             .map { entityService.createEntityPayload(it.second, it.first, ngsiLdDateTime()) }
@@ -122,13 +146,46 @@ class ScopeServiceTests : WithTimescaleContainer, WithKafkaContainer() {
             expandedAttributes[NGSILD_SCOPE_IRI]!!,
             ngsiLdDateTime(),
             operationType
-        ).shouldSucceed()
+        ).shouldSucceedWith {
+            if (expectedScopes != null) {
+                assertInstanceOf<SucceededAttributeOperationResult>(it)
+                assertEquals(expectedScopes, it.newExpandedValue.getScopes())
+            } else {
+                assertInstanceOf<FailedAttributeOperationResult>(it)
+                assertEquals(SCOPE_DOES_NOT_EXIST_MESSAGE, it.errorMessage)
+            }
+        }
 
         entityQueryService.retrieve(beehiveTestCId)
             .shouldSucceedWith {
                 assertEquals(expectedScopes, it.scopes)
                 val scopesInEntity = it.payload.toExpandedAttributeInstance().getScopes()
                 assertEquals(expectedScopes, scopesInEntity)
+            }
+    }
+
+    @Test
+    fun `update should not duplicate a scope value repeated within the same append fragment`() = runTest {
+        coEvery { authorizationService.createScopesOwnerRights(any()) } returns Unit.right()
+        loadSampleData("beehive_with_scope.jsonld")
+            .sampleDataToNgsiLdEntity()
+            .map { entityService.createEntityPayload(it.second, it.first, ngsiLdDateTime()) }
+
+        val expandedAttributes = JsonLdUtils.expandAttributes(
+            """{ "scope": ["/B", "/B"] }""",
+            APIC_COMPOUND_CONTEXTS
+        )
+
+        scopeService.update(
+            beehiveTestCId,
+            expandedAttributes[NGSILD_SCOPE_IRI]!!,
+            ngsiLdDateTime(),
+            OperationType.APPEND_ATTRIBUTES
+        ).shouldSucceedWith { assertNotNull(it) }
+
+        entityQueryService.retrieve(beehiveTestCId)
+            .shouldSucceedWith {
+                assertEquals(listOf("/A", "/B"), it.scopes)
             }
     }
 
@@ -421,18 +478,21 @@ class ScopeServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
-    fun `delete should remove the scope and its history`() = runTest {
+    fun `delete should remove the scope and keep the scope history`() = runTest {
+        coEvery { authorizationService.userCanCreateEntities() } returns Unit.right()
+        coEvery { authorizationService.createEntityOwnerRight(any()) } returns Unit.right()
+        coEvery { authorizationService.createScopesOwnerRights(any()) } returns Unit.right()
+
         loadSampleData("beehive_with_scope.jsonld")
             .sampleDataToNgsiLdEntity()
-            .map { entityService.createEntityPayload(it.second, it.first, ngsiLdDateTime()) }
+            .map { entityService.createEntity(it.second, it.first).shouldSucceed() }
 
         scopeService.delete(beehiveTestCId).shouldSucceed()
 
-        scopeService.retrieve(beehiveTestCId)
-            .shouldSucceedWith {
-                assertNull(it.first)
-                assertNull(it.second.toExpandedAttributeInstance().getScopes())
-            }
+        entityQueryService.retrieve(beehiveTestCId).shouldSucceedWith {
+            assertNull(it.payload.toExpandedAttributeInstance().getScopes())
+            assertNull(it.scopes)
+        }
         val scopeHistoryEntries = scopeService.retrieveHistory(
             listOf(beehiveTestCId),
             TemporalEntitiesQueryFromGet(
@@ -440,11 +500,46 @@ class ScopeServiceTests : WithTimescaleContainer, WithKafkaContainer() {
                     paginationQuery = PaginationQuery(limit = 100, offset = 0),
                     contexts = APIC_COMPOUND_CONTEXTS
                 ),
-                temporalQuery = buildDefaultTestTemporalQuery(),
+                temporalQuery = buildDefaultTestTemporalQuery(
+                    timeproperty = TemporalProperty.CREATED_AT,
+                ),
                 temporalRepresentation = TemporalRepresentation.NORMALIZED,
                 withAudit = false
             )
         ).shouldSucceedAndResult()
-        assertTrue(scopeHistoryEntries.isEmpty())
+        assertThat(scopeHistoryEntries).hasSize(1)
+    }
+
+    @Test
+    fun `permanentlyDelete should remove the scope, and clear its history`() = runTest {
+        coEvery { authorizationService.userCanCreateEntities() } returns Unit.right()
+        coEvery { authorizationService.createEntityOwnerRight(any()) } returns Unit.right()
+        coEvery { authorizationService.createScopesOwnerRights(any()) } returns Unit.right()
+
+        loadSampleData("beehive_with_scope.jsonld")
+            .sampleDataToNgsiLdEntity()
+            .map { entityService.createEntity(it.second, it.first).shouldSucceed() }
+
+        scopeService.permanentlyDelete(beehiveTestCId, ngsiLdDateTime()).shouldSucceed()
+
+        entityQueryService.retrieve(beehiveTestCId).shouldSucceedWith {
+            assertNull(it.payload.toExpandedAttributeInstance().getScopes())
+            assertNull(it.scopes)
+        }
+        val scopeHistoryEntries = scopeService.retrieveHistory(
+            listOf(beehiveTestCId),
+            TemporalEntitiesQueryFromGet(
+                EntitiesQueryFromGet(
+                    paginationQuery = PaginationQuery(limit = 100, offset = 0),
+                    contexts = APIC_COMPOUND_CONTEXTS
+                ),
+                temporalQuery = buildDefaultTestTemporalQuery(
+                    timeproperty = TemporalProperty.CREATED_AT,
+                ),
+                temporalRepresentation = TemporalRepresentation.NORMALIZED,
+                withAudit = false
+            )
+        ).shouldSucceedAndResult()
+        assertThat(scopeHistoryEntries).isEmpty()
     }
 }

--- a/shared/src/main/kotlin/com/egm/stellio/shared/model/ExpandedMembers.kt
+++ b/shared/src/main/kotlin/com/egm/stellio/shared/model/ExpandedMembers.kt
@@ -76,24 +76,21 @@ fun ExpandedAttributeInstances.getSingleEntry(): ExpandedAttributeInstance {
 }
 
 fun ExpandedAttributeInstance.addSysAttrs(
-    withSysAttrs: Boolean,
     createdAt: ZonedDateTime,
     modifiedAt: ZonedDateTime? = null,
     deletedAt: ZonedDateTime? = null
 ): ExpandedAttributeInstance =
-    if (withSysAttrs)
-        this.plus(NGSILD_CREATED_AT_IRI to buildNonReifiedTemporalValue(createdAt))
-            .let {
-                if (modifiedAt != null)
-                    it.plus(NGSILD_MODIFIED_AT_IRI to buildNonReifiedTemporalValue(modifiedAt))
-                else it
-            }
-            .let {
-                if (deletedAt != null)
-                    it.plus(NGSILD_DELETED_AT_IRI to buildNonReifiedTemporalValue(deletedAt))
-                else it
-            }
-    else this
+    this.plus(NGSILD_CREATED_AT_IRI to buildNonReifiedTemporalValue(createdAt))
+        .let {
+            if (modifiedAt != null)
+                it.plus(NGSILD_MODIFIED_AT_IRI to buildNonReifiedTemporalValue(modifiedAt))
+            else it
+        }
+        .let {
+            if (deletedAt != null)
+                it.plus(NGSILD_DELETED_AT_IRI to buildNonReifiedTemporalValue(deletedAt))
+            else it
+        }
 
 /**
  * Extract the actual value (@value) of a member from an expanded property.

--- a/shared/src/main/kotlin/com/egm/stellio/shared/util/ErrorMessages.kt
+++ b/shared/src/main/kotlin/com/egm/stellio/shared/util/ErrorMessages.kt
@@ -344,6 +344,7 @@ object ErrorMessages {
 
     object Scope {
         const val SCOPE_DOES_NOT_EXIST_MESSAGE = "Scope does not exist and operation does not allow creating it"
+        const val SCOPE_NOT_A_TARGET_ATTRIBUTE_MESSAGE = "scope cannot be the target attribute of this operation"
         fun unrecognizedOperationTypeMessage(operationType: String) = "Unrecognized operation type: $operationType"
     }
 

--- a/shared/src/test/kotlin/com/egm/stellio/shared/model/ExpandedMembersTests.kt
+++ b/shared/src/test/kotlin/com/egm/stellio/shared/model/ExpandedMembersTests.kt
@@ -22,7 +22,7 @@ class ExpandedMembersTests {
     fun `addSysAttrs should add createdAt information into an attribute`() {
         val attrPayload = mapOf("attribute" to buildExpandedPropertyValue(12.0))
 
-        val attrPayloadWithSysAttrs = attrPayload.addSysAttrs(true, ngsiLdDateTime(), null)
+        val attrPayloadWithSysAttrs = attrPayload.addSysAttrs(ngsiLdDateTime())
 
         assertThat(attrPayloadWithSysAttrs)
             .containsKey(NGSILD_CREATED_AT_IRI)
@@ -34,7 +34,7 @@ class ExpandedMembersTests {
     fun `addSysAttrs should add createdAt and modifiedAt information into an attribute`() {
         val attrPayload = mapOf("attribute" to buildExpandedPropertyValue(12.0))
 
-        val attrPayloadWithSysAttrs = attrPayload.addSysAttrs(true, ngsiLdDateTime(), ngsiLdDateTime())
+        val attrPayloadWithSysAttrs = attrPayload.addSysAttrs(ngsiLdDateTime(), ngsiLdDateTime())
 
         assertThat(attrPayloadWithSysAttrs)
             .containsKey(NGSILD_CREATED_AT_IRI)
@@ -47,7 +47,7 @@ class ExpandedMembersTests {
         val attrPayload = mapOf("attribute" to buildExpandedPropertyValue(12.0))
 
         val attrPayloadWithSysAttrs =
-            attrPayload.addSysAttrs(true, ngsiLdDateTime(), ngsiLdDateTime(), ngsiLdDateTime())
+            attrPayload.addSysAttrs(ngsiLdDateTime(), ngsiLdDateTime(), ngsiLdDateTime())
 
         assertThat(attrPayloadWithSysAttrs)
             .containsKey(NGSILD_CREATED_AT_IRI)


### PR DESCRIPTION
Replace the O(N) per-write pattern — getAllForEntity() SELECT + full entity
deserialization + full payload replace — with a single, self-referential
returns the resulting entity via RETURNING.

This removes the N-attribute read on every write and eliminates a
concurrent lost-update bug where two simultaneous attribute modifications
would race to overwrite the full payload.

Specific changes:
  - upsert() now returns created_at and modified_at via RETURNING, avoiding
    a second SELECT to obtain the actual DB timestamps
  - patchEntityPayload() batches every distinct attribute name touched by
    an operation into one UPDATE, and reads the resulting entity straight
    from that statement's RETURNING clause instead of re-deriving it with
    a separate in-memory merge
  - each EntityAttributeService function pre-embeds sysAttrs into
    newExpandedValue before building the result
  - updateState() and buildJsonLdEntity() removed

Also fixes several issues found in review:
  - missing NGSI-LD spec conformance points for scope handling (5.6.2.4,
    5.6.4.4, 5.6.19.4)