### PR TITLE
fix: handle uncaught exceptions in async entity event publishing

### DIFF
--- a/search-service/src/main/kotlin/com/egm/stellio/search/entity/service/EntityEventService.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/entity/service/EntityEventService.kt
@@ -15,6 +15,7 @@ import com.egm.stellio.shared.model.ExpandedTerm
 import com.egm.stellio.shared.util.JsonUtils.deserializeAsMap
 import com.egm.stellio.shared.util.JsonUtils.serializeObject
 import com.egm.stellio.shared.util.getTenantFromContext
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -34,7 +35,11 @@ class EntityEventService(
 
     private val logger = LoggerFactory.getLogger(javaClass)
 
-    private val coroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+    private val coroutineExceptionHandler = CoroutineExceptionHandler { _, exception ->
+        logger.error("Error while asynchronously publishing an entity event", exception)
+    }
+
+    private val coroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob() + coroutineExceptionHandler)
 
     internal fun publishEntityEvent(event: EntityEvent): Boolean {
         kafkaTemplate.send(catchAllTopic, event.entityId.toString(), serializeObject(event))


### PR DESCRIPTION
Fire-and-forget Kafka publishes in EntityEventService ran on a scope with no CoroutineExceptionHandler, so failures (e.g. producer closed during Spring test-context teardown) became truly uncaught. kotlinx-coroutines-test's leak detector then reported them against whatever test ran next, causing unrelated tests to fail intermittently.

See https://github.com/stellio-hub/stellio-context-broker/runs/86648591700 for an example
