### PR TITLE
fix: deduplicate attribute types in entity type info response

### DIFF
--- a/search-service/src/main/kotlin/com/egm/stellio/search/discovery/service/EntityTypeService.kt
+++ b/search-service/src/main/kotlin/com/egm/stellio/search/discovery/service/EntityTypeService.kt
@@ -75,7 +75,7 @@ class EntityTypeService(
                 WHERE :type_name = any (types)
                 AND deleted_at IS NULL
             )    
-            SELECT attribute_name, ARRAY_AGG(attribute_type) as attribute_types, (select count(entity_id) from entities) as entity_count
+            SELECT attribute_name, ARRAY_AGG(DISTINCT attribute_type) as attribute_types, (select count(entity_id) from entities) as entity_count
             FROM temporal_entity_attribute
             WHERE entity_id IN (SELECT entity_id FROM entities)
             AND deleted_at IS NULL

--- a/search-service/src/test/kotlin/com/egm/stellio/search/discovery/service/EntityTypeServiceTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/discovery/service/EntityTypeServiceTests.kt
@@ -281,6 +281,37 @@ class EntityTypeServiceTests : WithTimescaleContainer, WithKafkaContainer() {
     }
 
     @Test
+    fun `getEntityTypeInfoByType should not duplicate an attribute type shared by many entities of the same type`() =
+        runTest {
+            val sharedType = "https://ontology.eglobalmark.com/egm#SharedType"
+            val sharedAttribute = "https://ontology.eglobalmark.com/egm#sharedAttr"
+            val entityCount = 5
+
+            (1..entityCount).forEach { index ->
+                val entityId = "urn:ngsi-ld:SharedType:E$index"
+                createEntityPayload(gimmeEntityPayload(entityId, listOf(sharedType)))
+                createAttribute(
+                    newAttribute(
+                        entityId,
+                        sharedAttribute,
+                        Attribute.AttributeType.Property,
+                        Attribute.AttributeValueType.NUMBER
+                    )
+                )
+            }
+
+            val entityTypeInfo = entityTypeService.getEntityTypeInfoByType(sharedType, APIC_COMPOUND_CONTEXTS)
+
+            entityTypeInfo.shouldSucceedWith {
+                assertEquals(entityCount, it.entityCount)
+                val attributeInfo = it.attributeDetails.first { attribute ->
+                    attribute.attributeName == sharedAttribute
+                }
+                assertEquals(listOf(AttributeType.Property), attributeInfo.attributeTypes)
+            }
+        }
+
+    @Test
     fun `getEntityTypeInfoByType should return an error when the entity type does not exist`() = runTest {
         entityTypeService.getEntityTypeInfoByType(TEMPERATURE_IRI, APIC_COMPOUND_CONTEXTS)
             .shouldFail {


### PR DESCRIPTION
GET /ngsi-ld/v1/types/{type} lists, for each attribute of the given entity type, the set of attribute types (Property, Relationship, GeoProperty, ...) it takes across matching entities. ARRAY_AGG(attribute_type) collected one value per entity carrying the attribute instead of one per distinct attribute type, so an attribute present on N entities of that entity type showed its attribute type repeated N times. Use ARRAY_AGG(DISTINCT ...) to deduplicate at the database level.