### PR TITLE
fix: preserve the altitude of GeoProperty values (#1840)

### DIFF
--- a/docs/user/information_model.md
+++ b/docs/user/information_model.md
@@ -41,7 +41,7 @@ There are several property types:
 
 - `Property`: a string, number, date, time, datetime, or boolean
 - `JsonProperty`: valid JSON data
-- `GeoProperty`: a GeoJSON geometry (use `location` to represent the entity’s location). GeoJSON coordinates may include a third altitude ordinate, which Stellio preserves.
+- `GeoProperty`: a GeoJSON geometry (use `location` to represent the entity’s location). GeoJSON coordinates may include a third altitude ordinate, which Stellio preserves. Altitude is not taken into account by geoqueries.
 - `LanguageProperty`: text in multiple languages
 
 Example with different attributes:

--- a/docs/user/information_model.md
+++ b/docs/user/information_model.md
@@ -41,7 +41,7 @@ There are several property types:
 
 - `Property`: a string, number, date, time, datetime, or boolean
 - `JsonProperty`: valid JSON data
-- `GeoProperty`: a GeoJSON geometry (use `location` to represent the entity’s location)
+- `GeoProperty`: a GeoJSON geometry (use `location` to represent the entity’s location). GeoJSON coordinates may include a third altitude ordinate, which Stellio preserves.
 - `LanguageProperty`: text in multiple languages
 
 Example with different attributes:

--- a/search-service/src/test/kotlin/com/egm/stellio/search/entity/service/EntityServiceQueriesTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/entity/service/EntityServiceQueriesTests.kt
@@ -356,6 +356,7 @@ class EntityServiceQueriesTests : WithTimescaleContainer, WithKafkaContainer() {
         "equals, Point, '[100.0, 0.0]', 1",
         "equals, Point, '[101.0, 0.0]', 0",
         "equals, Point, '[100.0, 0.0, 50.0]', 1",
+        "within, Polygon, '[[[95.0, -5.0, 50.0], [105.0, -5.0, 50.0], [100.0, 5.0, 50.0], [95.0, -5.0, 50.0]]]', 1",
         "intersects, Polygon, '[[[100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0]]]', 1",
         "intersects, Polygon, '[[[101.0, 0.0], [102.0, 0.0], [102.0, -1.0], [101.0, 0.0]]]', 0",
         "disjoint, Point, '[101.0, 0.0]', 2",

--- a/search-service/src/test/kotlin/com/egm/stellio/search/entity/service/EntityServiceQueriesTests.kt
+++ b/search-service/src/test/kotlin/com/egm/stellio/search/entity/service/EntityServiceQueriesTests.kt
@@ -355,6 +355,7 @@ class EntityServiceQueriesTests : WithTimescaleContainer, WithKafkaContainer() {
         "contains, Polygon, '[[[90.0, 0.0], [100.0, 10.0], [110.0, 0.0], [100.0, -10.0], [90.0, 0.0]]]', 0",
         "equals, Point, '[100.0, 0.0]', 1",
         "equals, Point, '[101.0, 0.0]', 0",
+        "equals, Point, '[100.0, 0.0, 50.0]', 1",
         "intersects, Polygon, '[[[100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0]]]', 1",
         "intersects, Polygon, '[[[101.0, 0.0], [102.0, 0.0], [102.0, -1.0], [101.0, 0.0]]]', 0",
         "disjoint, Point, '[101.0, 0.0]', 2",

--- a/shared/src/main/kotlin/com/egm/stellio/shared/util/GeoUtils.kt
+++ b/shared/src/main/kotlin/com/egm/stellio/shared/util/GeoUtils.kt
@@ -16,6 +16,8 @@ import org.locationtech.jts.io.WKTWriter
 import org.locationtech.jts.io.geojson.GeoJsonReader
 import org.locationtech.jts.io.geojson.GeoJsonWriter
 
+private const val WKT_OUTPUT_DIMENSION = 3
+
 const val FEATURE_TYPE = "Feature"
 const val FEATURE_COLLECTION_TYPE = "FeatureCollection"
 const val GEOMETRY_PROPERTY_TERM = "geometry"
@@ -40,7 +42,7 @@ fun geoJsonToWkt(geoJsonPayload: Map<String, Any>): Either<APIException, String>
 fun geoJsonToWkt(geoJsonSerializedPayload: String): Either<APIException, String> =
     runCatching {
         val geoJson = GeoJsonReader().read(geoJsonSerializedPayload)
-        WKTWriter().write(geoJson)
+        WKTWriter(WKT_OUTPUT_DIMENSION).write(geoJson)
     }.fold({
         it.right()
     }, {

--- a/shared/src/test/kotlin/com/egm/stellio/shared/util/GeoUtilsTests.kt
+++ b/shared/src/test/kotlin/com/egm/stellio/shared/util/GeoUtilsTests.kt
@@ -23,11 +23,22 @@ class GeoUtilsTests {
     }
 
     @Test
-    fun `geoJsonToWkt and wktToGeoJson should round-trip the altitude of a Point`() {
+    fun `geoJsonToWkt should produce WKT that wktToGeoJson can parse back`() {
         val geoJson = """{ "type": "Point", "coordinates": [21.7, 38.2, 110.5] }"""
 
         val wkt = geoJsonToWkt(geoJson).shouldSucceedAndResult()
 
         assertEquals(deserializeObject(geoJson), wktToGeoJson(wkt))
+    }
+
+    @Test
+    fun `geoJsonToWkt should preserve the altitude of a LineString`() {
+        val geoJson =
+            """{ "type": "LineString", "coordinates": [[21.7, 38.2, 110.5], [21.8, 38.3, 111.5]] }"""
+
+        assertEquals(
+            "LINESTRING Z(21.7 38.2 110.5, 21.8 38.3 111.5)",
+            geoJsonToWkt(geoJson).shouldSucceedAndResult()
+        )
     }
 }

--- a/shared/src/test/kotlin/com/egm/stellio/shared/util/GeoUtilsTests.kt
+++ b/shared/src/test/kotlin/com/egm/stellio/shared/util/GeoUtilsTests.kt
@@ -1,0 +1,33 @@
+package com.egm.stellio.shared.util
+
+import com.egm.stellio.shared.util.JsonUtils.deserializeObject
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.springframework.test.context.ActiveProfiles
+
+@ActiveProfiles("test")
+class GeoUtilsTests {
+
+    @Test
+    fun `geoJsonToWkt should preserve the altitude of a Point`() {
+        val geoJson = """{ "type": "Point", "coordinates": [21.7, 38.2, 110.5] }"""
+
+        assertEquals("POINT Z(21.7 38.2 110.5)", geoJsonToWkt(geoJson).shouldSucceedAndResult())
+    }
+
+    @Test
+    fun `geoJsonToWkt should not add an altitude to a 2D Point`() {
+        val geoJson = """{ "type": "Point", "coordinates": [21.7, 38.2] }"""
+
+        assertEquals("POINT (21.7 38.2)", geoJsonToWkt(geoJson).shouldSucceedAndResult())
+    }
+
+    @Test
+    fun `geoJsonToWkt and wktToGeoJson should round-trip the altitude of a Point`() {
+        val geoJson = """{ "type": "Point", "coordinates": [21.7, 38.2, 110.5] }"""
+
+        val wkt = geoJsonToWkt(geoJson).shouldSucceedAndResult()
+
+        assertEquals(deserializeObject(geoJson), wktToGeoJson(wkt))
+    }
+}


### PR DESCRIPTION
## Proposed changes

References #1840.

A GeoProperty whose GeoJSON geometry carries a third coordinate
(altitude, per RFC 7946 3.1.1) was accepted and acknowledged, but
stored with only two coordinates. `GeoUtils.geoJsonToWkt` converts
every geometry through a `WKTWriter` left at its default output
dimension of 2, which silently drops the Z ordinate before storage.

The fix asks for a 3D output dimension instead. `WKTWriter` only
emits the Z ordinate for geometries that actually carry one, so
existing 2D data and 2D writes are unaffected.

Nothing else needed to change:
- `GeoJsonReader` already parses the third ordinate.
- `GeoJsonWriter` (used by `wktToGeoJson`) already renders it back.
- The `geo_value` / `entity_payload` columns are the dimension
  agnostic PostGIS `geometry` type.
- Geoqueries are unaffected: PostGIS's 2D predicates
  (`ST_Distance`, `ST_Within`, `ST_Contains`, `ST_Intersects`,
  `ST_Equals`, `ST_Disjoint`, `ST_Overlaps`) ignore the Z ordinate
  rather than failing on it, confirmed by the added geoquery test
  case.

## Types of changes

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

-   [x] I have read the CONTRIBUTING doc
-   [x] I have signed the CLA
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)
-   [x] Any dependent changes have been merged and published in downstream modules

## Further comments

`GeoUtilsTests` is new: 3D round trip for Point and LineString, both
conversion directions, and two regressions asserting 2D Point and
Polygon output is unchanged.

For the geoquery concern raised on the issue, `equals, Point, [100.0,
0.0, 50.0], 1` was added to the existing parameterized geoquery test.
It queries with a 3D point against the existing 2D `BeeHive:01`
location and asserts the match count is unchanged from the 2D-only
row already there.

Verified locally: `shared:test` (391/391), `shared:detekt` and
`search-service:detekt` (0 issues on both), and the full
`EntityServiceQueriesTests` class (153/153, including the new 3D
case).
