### PR TITLE
fix: avoid verbose database transaction

### DIFF
--- a/search-service/src/main/resources/logback-spring.xml
+++ b/search-service/src/main/resources/logback-spring.xml
@@ -9,6 +9,7 @@
     </appender>
 
     <logger name="com.egm.stellio" level="DEBUG"/>
+    <logger name="com.egm.stellio.shared.config.DefaultTimeoutR2dbcTransactionManager" level="INFO"/>
     <logger name="org.flywaydb" level="DEBUG"/>
     <logger name="org.apache.kafka" level="WARN"/>
     <logger name="db.migration" level="DEBUG" />

--- a/shared/src/main/kotlin/com/egm/stellio/shared/config/TransactionalEitherConfiguration.kt
+++ b/shared/src/main/kotlin/com/egm/stellio/shared/config/TransactionalEitherConfiguration.kt
@@ -32,6 +32,7 @@ import kotlin.coroutines.Continuation
 import kotlin.reflect.jvm.kotlinFunction
 
 @Configuration(proxyBeanMethods = false)
+@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
 class TransactionalEitherConfiguration {
 
     @Bean


### PR DESCRIPTION
Also avoid build warning 
```
stellio-search-service  |  2026-08-09 15:20:44,843 [  restartedMain] WARN  trationDelegate$BeanPostProcessorChecker - postProcessAfterInitialization - Bean 'transactionalEitherConfiguration' of type [com.egm.stellio.shared.config.TransactionalEitherConfiguration] is not eligible for getting processed by all BeanPostProcessors (for example: not eligible for auto-proxying). Is this bean getting eagerly injected/applied to a currently created BeanPostProcessor [meterRegistryPostProcessor]? Check the corresponding BeanPostProcessor declaration and its dependencies/advisors. If this bean does not have to be post-processed, declare it with ROLE_INFRASTRUCTURE.
```